### PR TITLE
Collections list: drop the type label; top-align the publisher_site metadata row

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -63,7 +63,7 @@ module CollectionsHelper
     when /popular/
       method(:browse_collection_popularity)
     else
-      method(:browse_collection_type)
+      ->(_collection) { '' }
     end
   end
 
@@ -74,10 +74,6 @@ module CollectionsHelper
 
   def browse_collection_popularity(collection)
     return " (#{collection.impressions_count} #{t(:num_views)})"
-  end
-
-  def browse_collection_type(collection)
-    return " • #{textify_collection_type(collection.collection_type)}"
   end
 
   # Returns icon/badge for collection type

--- a/app/views/manifestation/_metadata.html.haml
+++ b/app/views/manifestation/_metadata.html.haml
@@ -88,7 +88,7 @@
   - if tags_etc
     - publisher_link = @m.publisher_link
     - if publisher_link.present?
-      .metadata
+      .metadata.metadata-top-aligned
         -# simple case: default title, link to url with description as link text
         - if publisher_link.description.index('&&&').nil?
           %span{style: 'font-weight: bold'}= t(:made_available_by)

--- a/spec/requests/collections_browse_spec.rb
+++ b/spec/requests/collections_browse_spec.rb
@@ -81,6 +81,27 @@ RSpec.describe 'Collections Browse', type: :request do
       end
     end
 
+    context 'when rendering list items' do
+      let!(:author) { create(:authority, name: 'Test Author') }
+
+      before do
+        volume.involved_authorities.create!(authority: author, role: :author)
+        CollectionsIndex.import([volume])
+      end
+
+      it 'shows the authors but not the collection type under each item' do
+        get collections_browse_path
+
+        item = Nokogiri::HTML(response.body).css('#browse_mainlist li').find do |li|
+          li.at_css('a')&.text == 'Test Volume'
+        end
+
+        expect(item).to be_present
+        expect(item.text).to include('Test Author')
+        expect(item.text).not_to include(ApplicationController.helpers.textify_collection_type('volume'))
+      end
+    end
+
     context 'JS/AJAX request' do
       it 'renders successfully' do
         get collections_browse_path, xhr: true, as: :js

--- a/spec/requests/manifestation_publisher_link_alignment_spec.rb
+++ b/spec/requests/manifestation_publisher_link_alignment_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The "made available by" publisher_site line in Manifestation#read's metadata sits in a
+# flex row (.metadata is display:flex; align-items:center). When the link text wraps past
+# one line, centering drags the bold label out of line with the first line of the value.
+# .metadata-top-aligned (align-items: flex-start) keeps the label flush with the first
+# line, the same way the source-edition line above it already does.
+describe 'Manifestation#read publisher link alignment', type: :request do
+  let!(:text) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, orig_lang: 'he', status: :published)
+    end
+  end
+
+  after { Chewy.massacre }
+
+  it 'top-aligns the publisher_site metadata row' do
+    create(:external_link, linkable: text, linktype: :publisher_site, url: 'https://example.com',
+                           description: 'Some Very Long Publisher Name')
+
+    get manifestation_path(text)
+
+    row = Nokogiri::HTML(response.body).css('.metadata').find do |d|
+      d.text.include?('Some Very Long Publisher Name')
+    end
+    expect(row).to be_present
+    expect(row['class'].split).to include('metadata-top-aligned')
+  end
+end


### PR DESCRIPTION
## What changed

### 1. `/collections` — stop printing the collection type under each item
The browse list printed ` • <collection type>` beneath every item, duplicating
what the type icon on the title line already says. The default browse decorator
now emits nothing, and the now-unreachable `browse_collection_type` helper is
removed (it had no other caller). The publication-date and popularity decorators
— used when sorting by those — are untouched.

### 2. `Manifestation#read` — top-align the publisher_site metadata row
`.metadata` is `display: flex; align-items: center`, so when the "made available
by" link text wrapped past one line, the bold label floated to the vertical
middle of the whole block instead of sitting level with the first line of the
value. The row now carries `.metadata-top-aligned` (`align-items: flex-start`),
the same override the source-edition row directly above it already uses. No CSS
changes were needed — the class already exists in `manifestation.css.scss`.

## Test plan

- `spec/requests/collections_browse_spec.rb` — new example parses the rendered
  `#browse_mainlist` item and asserts the author string is present while the
  collection-type label is not.
- `spec/requests/manifestation_publisher_link_alignment_spec.rb` (new) — asserts
  the `.metadata` row holding the publisher link carries `metadata-top-aligned`.

Both new examples were verified to fail against the pre-fix code and pass after.

Ran: `spec/requests/collections_browse_spec.rb`,
`spec/requests/manifestation_publisher_link_alignment_spec.rb`,
`spec/helpers/collections_helper_spec.rb`,
`spec/system/collections_browse_authorities_filter_spec.rb` — 57 examples, 0 failures.

The full suite was **not** run (it takes 40+ minutes and needs explicit approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)