### PR TITLE
Fix spec failures from the lexicon-onto-master rebase

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1289,36 +1289,44 @@ p.by-genre-name-v02.headline-2-v02 {
 }
 
 /* Tag-proposal popup: the mode toggle (suggest / pick from full list) and the
-   tag-suggestion heuristic strip. Both are jQuery UI tab navs; the layout that
-   used to be set inline on the <ul> lives here so mobile can override it. */
-.tag-mode-tabs {
+   tag-suggestion heuristic strip. Both are Bootstrap tab navs, and Bootstrap's
+   .nav / .nav-link class names collide with the side-menu rules in
+   BY_styles_General.css (.nav { width: 100px }, .nav-link { width: 100px }),
+   which squeezes both strips into a 100px column. The strips therefore restore
+   their own widths here, where mobile can also override them. */
+.tag-mode-tabs,
+.tag-heuristic-tabs {
   display: flex;
+  width: 100%;
 }
 
 .tag-heuristic-tabs {
-  display: flex;
   flex-wrap: wrap;
   font-size: 80%;
 }
 
-/* .by-card-content-v02 ul sets list-style: disc, which leaks into the strips
-   wherever the jQuery UI tab stylesheet loses the cascade */
+/* .by-card-content-v02 ul sets list-style: disc, which leaks into the strips */
 .tag-mode-tabs > li,
 .tag-heuristic-tabs > li {
   list-style: none;
 }
 
+/* on desktop each tab is only as wide as its own label (see .nav-link above) */
+.tag-mode-tabs > li > a,
+.tag-heuristic-tabs > li > a {
+  width: auto;
+}
+
 @media screen and (max-width: 767px) {
   /* mode toggle becomes a full-width, two-up segmented control */
-  .ui-tabs .tag-mode-tabs {
-    width: 100%;
+  .tag-mode-tabs {
     margin: 0 0 12px;
     padding: 0;
     border: 0;
     background: none;
   }
 
-  .ui-tabs .tag-mode-tabs > li {
+  .tag-mode-tabs > li {
     float: none;
     flex: 1 1 50%;
     min-width: 0;
@@ -1327,25 +1335,24 @@ p.by-genre-name-v02.headline-2-v02 {
     white-space: normal;
   }
 
-  .ui-tabs .tag-mode-tabs > li .ui-tabs-anchor {
+  .tag-mode-tabs > li > a {
     float: none;
     display: block;
+    width: auto;
     padding: 10px 6px;
     white-space: normal;
   }
 
   /* heuristics become wrapping chips, so all of them stay visible */
-  .ui-tabs .tag-heuristic-tabs {
-    flex-wrap: wrap;
+  .tag-heuristic-tabs {
     gap: 6px;
-    width: 100%;
     margin: 0 0 12px;
     padding: 0;
     border: 0;
     background: none;
   }
 
-  .ui-tabs .tag-heuristic-tabs > li {
+  .tag-heuristic-tabs > li {
     float: none;
     flex: 0 0 auto;
     margin: 0;
@@ -1353,14 +1360,11 @@ p.by-genre-name-v02.headline-2-v02 {
     white-space: normal;
   }
 
-  .ui-tabs .tag-heuristic-tabs > li .ui-tabs-anchor {
+  .tag-heuristic-tabs > li > a {
     float: none;
     display: block;
+    width: auto;
     padding: 6px 12px;
-  }
-
-  #add_tagging_tabs .ui-tabs-panel {
-    padding: 0;
   }
 }
 

--- a/app/views/taggings/add_tagging_popup.html.haml
+++ b/app/views/taggings/add_tagging_popup.html.haml
@@ -17,7 +17,7 @@
             %span.headline-1-v02.desktop-only= t(:add_tag)
             %a.popup-x-v02{'data-dismiss'=>'modal'} -
           #add_tagging_tabs
-            %ul.nav.nav-tabs{ role: 'tablist', style: 'display: flex;' }
+            %ul.nav.nav-tabs.tag-mode-tabs{ role: 'tablist' }
               %li.nav-item
                 %a.nav-link.active{ href: '#add-tag-form', 'data-toggle': 'tab', role: 'tab' }
                   = t(:i_want_to_suggest_a_tag)

--- a/app/views/taggings/suggest.html.haml
+++ b/app/views/taggings/suggest.html.haml
@@ -1,5 +1,5 @@
 #suggestion_heuristics
-  %ul.nav.nav-tabs{ role: 'tablist', style: 'flex-wrap: wrap;font-size:80%' }
+  %ul.nav.nav-tabs.tag-heuristic-tabs{ role: 'tablist' }
     - @tag_suggestions.keys.each_with_index do |key, index|
       %li.nav-item
         %a.nav-link{ class: (index == 0 ? 'active' : ''), 'data-toggle': 'tab', href: '#' + key.to_s, role: 'tab' }

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -36,7 +36,7 @@ describe '/files' do
 
         it 'fails with Not Found status' do
           expect(call).to eq(404)
-          expect(response.body).to eq("Record not found: #{record_id}")
+          expect(response.body).to eq("File not found: #{filename}")
         end
       end
 
@@ -53,8 +53,8 @@ describe '/files' do
         let(:filename) { 'file_1.txt' }
 
         it 'redirects to the file URL' do
-          attachment = record.attachments.detect { |att| att.filename.to_s == 'file_1.txt' }
-          expect(call).to redirect_to(rails_blob_url(attachment.blob, disposition: 'attachment'))
+          expect(call).to eq(302)
+          expect(response.location).to include('file_1.txt')
         end
       end
 
@@ -62,8 +62,8 @@ describe '/files' do
         let(:filename) { 'file_2' }
 
         it 'redirects to the file URL' do
-          attachment = record.attachments.detect { |att| att.filename.to_s == 'file_2' }
-          expect(call).to redirect_to(rails_blob_url(attachment.blob, disposition: 'attachment'))
+          expect(call).to eq(302)
+          expect(response.location).to include('file_2')
         end
       end
     end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,8 +8,10 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
 
-  config.before(:each, :js, type: :system) do
-    driven_by :selenium_firefox_headless
+  config.before(:each, :js, type: :system) do |example|
+    # Headless Firefox refuses to size its window below 500px wide, so specs that assert
+    # layout at real phone widths (320/360/390px) have to run under Chrome.
+    driven_by example.metadata[:narrow_viewport] ? :selenium_chrome_headless : :selenium_firefox_headless
     page.driver.browser.manage.window.resize_to(1400, 900)
   end
 end
@@ -21,6 +23,18 @@ Capybara.register_driver :selenium_firefox_headless do |app|
   options.add_argument('--width=1400')
   options.add_argument('--height=900')
   Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+end
+
+# Chrome driver, used only by specs tagged :narrow_viewport (see above)
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless=new')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--window-size=1400,900')
+  options.add_argument('--disable-search-engine-choice-screen')
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara.server = :puma, { Silent: true }

--- a/spec/support/paperclip.rb
+++ b/spec/support/paperclip.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Paperclip attachments (e.g. Authority#profile_image) are configured to use S3 storage.
+# Factories such as `create(:authority, :with_image)` only set the *_file_name column, so no
+# file is ever uploaded, but destroying such a record still makes Paperclip reach out to S3 to
+# delete the (non-existent) object. Under WebMock/VCR that raises UnhandledHTTPRequestError,
+# which aborts `clean_tables` and leaves records behind, poisoning every subsequent spec that
+# cleans the database.
+#
+# Preserving files on destroy keeps URL generation unchanged while making destroys purely local.
+Paperclip::Attachment.default_options[:preserve_files] = true

--- a/spec/system/tag_proposal_mobile_spec.rb
+++ b/spec/system/tag_proposal_mobile_spec.rb
@@ -6,7 +6,9 @@ require 'rails_helper'
 # the mode toggle (propose a tag / pick from the full list) used to overflow the
 # popup, and the suggestion-heuristic tabs used to render as a plain list rather
 # than a usable tab strip.
-RSpec.describe 'Tag proposal popup on mobile', :js, type: :system do
+# :narrow_viewport runs this spec under headless Chrome: headless Firefox, the default
+# driver for system specs here, will not size its window below 500px wide.
+RSpec.describe 'Tag proposal popup on mobile', :js, :narrow_viewport, type: :system do
   let(:user) { create(:user) }
   let!(:base_user) { BaseUser.create!(user: user) }
   let(:author) { create(:authority, toc: create(:toc)) }


### PR DESCRIPTION
Fixes the five spec files that broke when `lexicon` was rebased onto `master`:
`files_spec`, `manifestation_collection_type_filtering_spec`, `tag_proposal_mobile_spec`,
`whatsnew_page_spec`, `works_mobile_sorting_spec`.

There were **four independent causes**, all from master code meeting lexicon code.

### 1. `files_spec` — stale expectations (3 failures)

Master's 9798db180 changed `FilesController` to cache direct service URLs and dropped the
"Record not found" branch, updating its own contexts. The lexicon-only `LexEntry` contexts
still asserted `rails_blob_url` and `"Record not found: <id>"`. The controller here is
byte-identical to master, so the spec was the stale side — the LexEntry contexts now match
what master did to its own.

### 2. Paperclip reaching S3 during DB cleanup (12 failures across 3 files)

Master's 483ce958c added `homepage_authors_card_height_spec`, which creates
`create_list(:authority, 3, :with_image)` in `before(:all)`. That trait only sets
`profile_image_file_name`, but **destroying** such a record makes Paperclip issue a real
`HEAD https://bybeprod.s3.amazonaws.com/…`. VCR raises `UnhandledHTTPRequestError`,
`clean_tables` aborts mid-way, and the records **survive in the test DB** — poisoning
`clean_tables` for every spec that runs afterwards. The local test DB was still carrying
three such rows.

New `spec/support/paperclip.rb` sets `preserve_files = true` for specs, so destroys stay
local. URL generation is unchanged and no spec asserts Paperclip deletion.

### 3. A real CSS bug this branch shipped (`tag_proposal_mobile`, 9 failures)

`BY_styles_General.css` (~line 2013) defines the site's *own* side-menu rules:

```css
.nav      { display: flex; width: 100px; }
.nav-link { background-color: #eeeced; width: 100px; display: flex; flex-direction: column; }
```

This branch rewrote the tag-proposal popup from jQuery-UI tabs to Bootstrap tabs
(`ul.nav.nav-tabs > li.nav-item > a.nav-link`) and hit that class collision head-on: both
tab strips were squeezed into a 100px column — stacked and bulleted — **at every width, in
real browsers, not just in tests** (confirmed by screenshot at 1400px). Master's #1490
mobile CSS could not help: it is scoped to the `.ui-tabs` / `.tag-*-tabs` hooks that the
new markup dropped.

The `.tag-mode-tabs` / `.tag-heuristic-tabs` hooks are restored on the two `<ul>`s
(replacing inline styles) and the `application.scss` block is rewired to the Bootstrap
markup: widths restored on the `ul` and `> li > a`, `.ui-tabs` scoping dropped, dead
`.ui-tabs-panel` rule removed.

> Worth flagging: this collision is a live landmine anywhere else the branch uses Bootstrap
> nav/tab classes.

### 4. Headless Firefox cannot do phone widths (3 failures)

This branch drives system specs with Firefox (#944/#954/#960). **Headless Firefox floors its
viewport at 500px** — `resize_to(320, …)` yields `window.innerWidth == 500` — so the
320/360/390px assertions were unreachable. Chrome honours any width (measured down to 200px).

Firefox stays the default; specs tagged `:narrow_viewport` now run under a registered Chrome
driver. Media-query-only specs like `works_mobile_sorting_spec` don't need the tag, since the
`max-width: 767px` rules still apply at 500px.

## Test plan

- The five originally-failing files together: **68 examples, 0 failures, 1 pending**
  (pre-existing pending in whatsnew).
- `tag_proposal_mobile_spec` run 3×: two clean runs plus a clean isolated run; one run showed
  a single flake in `proposes a tag selected from the full list`, where the jQuery autocomplete
  menu can overlay the submit button at a genuinely narrow viewport. That is a pre-existing
  latent issue now merely *visible*, and master's spec was left alone.
- Collateral checks: `homepage_authors_card_height_spec` + `welcome_controller_spec`
  (18 examples, 0 failures) and three unrelated js system specs (6 examples, 0 failures)
  confirm the two global spec-support changes are inert.
- RuboCop clean; haml-lint 40 → 39 lints (none new).
- **The full suite was not run** (40+ minutes, needs maintainer approval).

Closes beads_by-81c

🤖 Generated with [Claude Code](https://claude.com/claude-code)