### PR TITLE
Export more fields in export_catalog rake task

### DIFF
--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -27,8 +27,13 @@ module ExportCatalogHelpers
     raw.split(';').map(&:strip).compact_blank
   end
 
-  def serialize_manifestation(manifestation, url_helpers, edition_details: false)
-    lang = manifestation.expression.work.orig_lang
+  def textify_genre(genre)
+    I18n.t("genre_values.#{genre}")
+  end
+
+  def serialize_manifestation(manifestation, url_helpers)
+    expr = manifestation.expression
+    work = expr.work
     entry = {
       type: 'manifestation',
       id: manifestation.id,
@@ -39,12 +44,11 @@ module ExportCatalogHelpers
     }
     alts = split_alternate_titles(manifestation.alternate_titles)
     entry[:alternate_titles] = alts unless alts.empty?
-    entry[:original_language] = textify_lang(lang) unless lang.blank? || lang == 'he'
-    if edition_details
-      expr = manifestation.expression
-      entry[:source_edition] = expr.source_edition if expr.source_edition.present?
-      entry[:date] = expr.date if expr.date.present?
-    end
+    entry[:genre] = textify_genre(work.genre) if work.genre.present?
+    entry[:language] = textify_lang(expr.language) if expr.language.present?
+    entry[:original_language] = textify_lang(work.orig_lang) if work.orig_lang.present?
+    entry[:source_edition] = expr.source_edition if expr.source_edition.present?
+    entry[:date] = expr.date if expr.date.present?
     entry
   end
 
@@ -62,6 +66,8 @@ module ExportCatalogHelpers
     alts = split_alternate_titles(collection.alternate_titles)
     entry[:alternate_titles] = alts unless alts.empty?
     entry[:publisher_line] = collection.publisher_line if collection.publisher_line.present?
+    entry[:inception] = collection.inception if collection.inception.present?
+    entry[:pub_year] = collection.pub_year if collection.pub_year.present?
     entry
   end
 
@@ -142,7 +148,7 @@ task export_catalog: :environment do
       .preload(expression: [{ involved_authorities: :authority }, { work: { involved_authorities: :authority } }],
                taggings: :tag)
       .find_each do |manifestation|
-        serialized = serialize_manifestation(manifestation, url_helpers, edition_details: true)
+        serialized = serialize_manifestation(manifestation, url_helpers)
         f.write(",\n") unless ufirst
         ufirst = false
         f.write(JSON.pretty_generate(serialized).split("\n").map { |l| "    #{l}" }.join("\n"))

--- a/spec/lib/tasks/export_catalog_rake_spec.rb
+++ b/spec/lib/tasks/export_catalog_rake_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
   context 'with a qualifying volume collection' do
     let!(:author) { create(:authority) }
     let!(:manifestation) do
-      create(:manifestation, author: author, status: :published, orig_lang: 'en')
+      create(:manifestation, author: author, status: :published, orig_lang: 'en', language: 'he', genre: 'poetry')
     end
     let!(:collection) do
       create(:collection,
@@ -43,6 +43,8 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
              title: 'Test Volume',
              subtitle: 'A subtitle',
              publisher_line: 'Publisher Co.',
+             inception: '1935',
+             pub_year: '1937',
              alternate_titles: 'Alt Title One; Alt Title Two',
              manifestations: [manifestation])
     end
@@ -67,6 +69,21 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       expect(c['publisher_line']).to eq('Publisher Co.')
     end
 
+    it 'includes inception and pub_year when present' do
+      task.invoke
+      c = parsed_output['collections'].first
+      expect(c['inception']).to eq('1935')
+      expect(c['pub_year']).to eq('1937')
+    end
+
+    it 'omits inception and pub_year when blank' do
+      collection.update!(inception: nil, pub_year: nil)
+      task.invoke
+      c = parsed_output['collections'].first
+      expect(c).not_to have_key('inception')
+      expect(c).not_to have_key('pub_year')
+    end
+
     it 'splits alternate_titles on semicolon regardless of spacing' do
       collection.update!(alternate_titles: 'One;Two ; Three')
       task.invoke
@@ -87,11 +104,28 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       expect(m['original_language']).to eq('אנגלית')
     end
 
-    it 'omits original_language for Hebrew works' do
+    it 'includes original_language for Hebrew works too' do
       manifestation.expression.work.update!(orig_lang: 'he')
       task.invoke
       m = parsed_output['collections'].first['contents'].first
-      expect(m).not_to have_key('original_language')
+      expect(m['original_language']).to eq('עברית')
+    end
+
+    it 'includes genre and language as Hebrew text' do
+      task.invoke
+      m = parsed_output['collections'].first['contents'].first
+      expect(m['genre']).to eq('שירה')
+      expect(m['language']).to eq('עברית')
+    end
+
+    it 'omits genre and language when blank' do
+      # genre has an inclusion validation, so bypass it to simulate legacy records with no genre
+      manifestation.expression.work.update_column(:genre, nil)
+      manifestation.expression.update!(language: nil)
+      task.invoke
+      m = parsed_output['collections'].first['contents'].first
+      expect(m).not_to have_key('genre')
+      expect(m).not_to have_key('language')
     end
   end
 
@@ -274,15 +308,23 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       expect(m['date']).to eq('1920')
     end
 
-    it 'does not include source_edition and date for collected manifestations' do
+    it 'includes source_edition and date for collected manifestations as well' do
       m_in_vol = create(:manifestation, status: :published)
       m_in_vol.expression.update!(source_edition: 'First Ed.', date: '1920')
       create(:collection, collection_type: :volume, manifestations: [m_in_vol])
       task.invoke
       collected = parsed_output['collections'].flat_map { |c| c['contents'] }
                                               .find { |x| x['id'] == m_in_vol.id }
-      expect(collected).not_to have_key('source_edition')
-      expect(collected).not_to have_key('date')
+      expect(collected['source_edition']).to eq('First Ed.')
+      expect(collected['date']).to eq('1920')
+    end
+
+    it 'omits source_edition and date when blank' do
+      published_m.expression.update!(source_edition: nil, date: nil)
+      task.invoke
+      m = parsed_output['uncollected_texts'].find { |x| x['id'] == published_m.id }
+      expect(m).not_to have_key('source_edition')
+      expect(m).not_to have_key('date')
     end
 
     it 'does not include the uncollected collection itself in collections' do


### PR DESCRIPTION
## Summary

Enriches the JSON produced by `rake export_catalog`.

**Manifestations** now include:
- `genre` — from the associated `Work` (note: genre lives on Work, not Expression; `Manifestation#genre` delegates there)
- `language` — `Expression#language`
- `original_language` — `Work#orig_lang`
- `source_edition` and `date` — from the `Expression`

`genre`, `language` and `original_language` are emitted as Hebrew display text (`I18n.t('genre_values.…')` / `textify_lang`), consistent with how `original_language` was already rendered. Any field that is blank is omitted.

**Collections** now include `inception` and `pub_year` alongside the existing `publisher_line`.

## Behaviour changes to note

Two previous restrictions were lifted, per product decision, so that all five manifestation fields appear on every manifestation:

- `source_edition` / `date` were previously emitted only for uncollected texts (via the `edition_details:` keyword argument); they now appear for collected manifestations too. The now-redundant `edition_details:` argument was removed — it had no other callers.
- `original_language` was previously suppressed when the original language was Hebrew; it is now always emitted.

## Test plan

- `spec/lib/tasks/export_catalog_rake_spec.rb` updated: the two specs asserting the old omissions were rewritten to assert the new behaviour, and new specs cover genre/language values and text, inception/pub_year, and blank-value omission for all of them. 33 examples, 0 failures.
- Full suite: 2232 examples, 0 failures, 14 pending (pre-existing skips).
- RuboCop clean on both changed files.

Closes by-9ud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)