### PR TITLE
Author TOC: per-collection collapse toggles + stateful Collapse all/Expand all (beads_by-565, beads_by-7yp)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,7 +15,17 @@
  *= require_self
  *= require slick
 */
-// Per-volume collapse toggle in the Authority TOC: uses the ben-yehuda chevron
+// Collapse all / Expand all in the Authority TOC: the button whose action is
+// currently a no-op is disabled, and greys out like .by-button-v02.disabled.
+#max_collapse:disabled,
+#expand-all:disabled {
+  background-color: #bfbfbf;
+  border-color: #bfbfbf;
+  color: #ffffff;
+  cursor: default;
+}
+
+// Per-collection collapse toggle in the Authority TOC: uses the ben-yehuda chevron
 // glyph ")" (same as the navbar .dropdown-arrow). Expanded points up, collapsed points down.
 .volume-collapse-toggle {
   font-family: ben-yehuda;

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -225,6 +225,9 @@
       // The list was just rebuilt (and entering flat mode shrinks it a lot), so
       // return the reader to the top of the page as the filters do.
       if(window.TocFilters) { window.TocFilters.scrollToTop(); }
+      // The rebuilt list is fully expanded again (and the flat sorts have no
+      // collapsible cards at all), so re-evaluate the collapse/expand buttons.
+      if(window.syncCollapseButtons) { window.syncCollapseButtons(); }
     });
     prune_collections();
     var orig_mainlist = $('#browse_mainlist').html();

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -83,8 +83,10 @@
                     = " (#{type_prefix})"
                   != '&nbsp;&nbsp;&nbsp;'
                   = link_to t(:edit), collection_manage_path(collection.id), style: 'font-size: 70%;'
-                - if collection.volume? && renders_toclist
-                  - toggle_label = t(:toggle_collapse_volume)
+                -# Every collapsible collection card (any type, not just volumes) gets its own toggle,
+                   except in the editable (collections-migration) view, which has no collapse JS.
+                - if renders_toclist && !editable
+                  - toggle_label = t(:toggle_collapse_collection, title: collection.title)
                   -# aria-expanded on the toggle itself: focus lands here, not on the treeitem li
                   %span.volume-collapse-toggle{ role: 'button', tabindex: 0, title: toggle_label,
                                                 aria: { label: toggle_label, expanded: 'true' } } )

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -100,7 +100,7 @@
               %button.btn-small-outline-v02#multiselect_btn{title: t(:worklist_multi_tt)}
                 .by-icon-v02.purple-v02 \
           .by-card-v02.sticky-fold
-            -# TODO: implement these buttons
+            -# state (primary/disabled) is kept in sync by syncCollapseButtons() below
             %button.by-button-v02#max_collapse{href: "#"}= t(:collapse_all_sections)
             %button.by-button-v02.by-button-secondary-v02#expand-all{href: "#"}= t(:expand_all_sections)
             %p
@@ -352,6 +352,21 @@
         }
       });
 
+      // The Collapse all / Expand all buttons reflect the list's current state:
+      // whichever action would still change something is the primary (filled)
+      // button, and the one that would be a no-op is greyed out and disabled.
+      // In a mixed state both apply, and Collapse all stays the primary one.
+      window.syncCollapseButtons = function() {
+        var $toggles = $('#browse_mainlist .volume-collapse-toggle');
+        var collapsed = $toggles.filter('.collapsed').length;
+        var canCollapse = $toggles.length > collapsed; // something is still open
+        var canExpand = collapsed > 0;                 // something is still closed
+        $('#max_collapse').prop('disabled', !canCollapse)
+                          .toggleClass('by-button-secondary-v02', !canCollapse);
+        $('#expand-all').prop('disabled', !canExpand)
+                        .toggleClass('by-button-secondary-v02', canCollapse || !canExpand);
+      };
+
       // Collapse all sections
       $('#max_collapse').click(function(e) {
         e.preventDefault();
@@ -360,6 +375,7 @@
         $('#browse_mainlist .by-card-v02[role="treeitem"]:has(.toclist)').attr('aria-expanded', 'false');
         // keep the focusable toggles' own aria-expanded in sync with their state
         $('#browse_mainlist .volume-collapse-toggle').addClass('collapsed').attr('aria-expanded', 'false');
+        window.syncCollapseButtons();
       });
 
       // Expand all sections
@@ -370,14 +386,14 @@
         $('#browse_mainlist .by-card-v02[role="treeitem"]:has(.toclist)').attr('aria-expanded', 'true');
         // keep the focusable toggles' own aria-expanded in sync with their state
         $('#browse_mainlist .volume-collapse-toggle').removeClass('collapsed').attr('aria-expanded', 'true');
+        window.syncCollapseButtons();
       });
 
-      // Expand a treeitem card's own children list, then cascade into any
-      // nested sub-collections that have NO toggle of their own (series /
-      // sub-volumes). Those have no independent control, so their collapsed
-      // state (e.g. after collapse-all) would otherwise be unreachable — they
-      // must follow their parent volume. Nested volumes that DO have their own
-      // toggle are left untouched so they keep their own collapsed/expanded state.
+      // Expand a treeitem card's own children list, then cascade all the way
+      // down into its nested sub-collections: expanding a volume reveals its
+      // whole subtree, so a collapsed descendant is never left stranded out of
+      // reach (e.g. after collapse-all). Each descendant's own toggle is put
+      // back into the expanded state to match.
       function cascadeExpand($card) {
         var $wrapper = $card.children('.by-card-content-v02').children('.cwrapper');
         var $list = $wrapper.children('ul.toclist');
@@ -386,16 +402,14 @@
         if ($list.length === 0) { return; }
         $list.slideDown();
         $card.attr('aria-expanded', 'true');
+        // This card's own toggle lives in the title div, a sibling of the list.
+        $wrapper.children('div').find('.volume-collapse-toggle')
+                .removeClass('collapsed').attr('aria-expanded', 'true');
         // Direct sub-collection cards inside this card's own list. The card
         // li is a direct child of ul.toclist (the browser auto-closes the
         // empty wrapper li that HTML forbids nesting an li inside).
         $list.children('.by-card-v02[role="treeitem"]').each(function() {
-            var $sub = $(this);
-            var $subwrapper = $sub.children('.by-card-content-v02').children('.cwrapper');
-            var hasOwnToggle = $subwrapper.children('div').children('.volume-collapse-toggle').length > 0;
-            if (!hasOwnToggle) {
-              cascadeExpand($sub);
-            }
+            cascadeExpand($(this));
           });
       }
 
@@ -417,6 +431,7 @@
           cascadeExpand($card);
           $toggle.removeClass('collapsed').attr('aria-expanded', 'true');
         }
+        window.syncCollapseButtons();
       }
       $('#browse_mainlist').on('click', '.volume-collapse-toggle', function(e) {
         e.preventDefault();
@@ -428,4 +443,9 @@
           toggleVolume($(this));
         }
       });
+
+      // Initial button state. This ready() handler runs after the one in
+      // _generated_toc, so prune_collections has already dropped the toggles of
+      // volumes rendered as a single link.
+      window.syncCollapseButtons();
   });

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -390,7 +390,7 @@
       });
 
       // Expand a treeitem card's own children list, then cascade all the way
-      // down into its nested sub-collections: expanding a volume reveals its
+      // down into its nested sub-collections: expanding a collection reveals its
       // whole subtree, so a collapsed descendant is never left stranded out of
       // reach (e.g. after collapse-all). Each descendant's own toggle is put
       // back into the expanded state to match.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3218,7 +3218,7 @@ en:
   total_collections_including_author: Total collections involving author
   collapse_all_sections: Collapse all sections
   expand_all_sections: Expand all sections
-  toggle_collapse_volume: Collapse or expand this volume
+  toggle_collapse_collection: "Collapse or expand: %{title}"
   toggle_collapse_uncollected: Collapse or expand the uncollected works
   legacy_urls:
     index:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2475,7 +2475,7 @@ he:
   total_collections_including_author: כותרים במאגר
   collapse_all_sections: צמצם הכל
   expand_all_sections: הרחב הכל
-  toggle_collapse_volume: צמצם או הרחב כרך זה
+  toggle_collapse_collection: "צמצם או הרחב: %{title}"
   toggle_collapse_uncollected: צמצם או הרחב את היצירות שלא כונסו
   by_involved_authorities: לפי אישים מעורבים
   works_and_volumes: כותרים ויצירות

--- a/spec/system/author_toc_collapse_buttons_state_spec.rb
+++ b/spec/system/author_toc_collapse_buttons_state_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Collapse all / Expand all buttons in the Authority TOC action bar must
+# reflect the list's current state: whichever action would still change
+# something is the primary (filled) button, and the one that would be a no-op is
+# disabled. In a mixed state both apply and Collapse all stays primary.
+describe 'Author TOC collapse/expand buttons state', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let!(:author) { create(:authority, name: 'Test Author') }
+
+  # The non-primary (outline) style is the .by-button-secondary-v02 class.
+  let(:collapse_btn) { '#max_collapse' }
+  let(:expand_btn) { '#expand-all' }
+
+  let!(:volumes) do
+    Chewy.strategy(:atomic) do
+      %w(First Second).map do |name|
+        volume = create(:collection, title: "#{name} Volume", collection_type: :volume)
+        work = create(:manifestation, title: "Work in #{name} Volume", status: :published, author: author)
+        create(:collection_item, collection: volume, item: work)
+        create(:involved_authority, authority: author, item: volume, role: 'editor')
+        volume
+      end
+    end
+  end
+
+  after { Chewy.massacre }
+
+  it 'starts with Expand all disabled, everything being expanded' do
+    visit authority_path(author)
+
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
+    expect(page).to have_css("#{collapse_btn}:not(:disabled):not(.by-button-secondary-v02)")
+    expect(page).to have_css("#{expand_btn}:disabled.by-button-secondary-v02")
+  end
+
+  it 'swaps the primary button once everything is collapsed, and back again' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
+
+    find(collapse_btn).click
+
+    # Nothing left to collapse: Collapse all goes disabled/secondary and Expand
+    # all becomes the primary action.
+    expect(page).to have_css("#{collapse_btn}:disabled.by-button-secondary-v02")
+    expect(page).to have_css("#{expand_btn}:not(:disabled):not(.by-button-secondary-v02)")
+
+    find(expand_btn).click
+
+    expect(page).to have_css("#{collapse_btn}:not(:disabled):not(.by-button-secondary-v02)")
+    expect(page).to have_css("#{expand_btn}:disabled.by-button-secondary-v02")
+  end
+
+  it 'enables both buttons while the list is in a mixed state' do
+    visit authority_path(author)
+
+    # At least two toggles, so collapsing one always leaves another expanded.
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle', minimum: 2)
+    find('#browse_mainlist .volume-collapse-toggle', match: :first).click
+
+    # Both actions still do something; Collapse all remains the primary one.
+    expect(page).to have_css("#{collapse_btn}:not(:disabled):not(.by-button-secondary-v02)")
+    expect(page).to have_css("#{expand_btn}:not(:disabled).by-button-secondary-v02")
+  end
+
+  it 'tracks state driven by the individual toggles alone' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
+
+    # Collapsing every card one by one must leave the buttons in the same state
+    # as pressing Collapse all.
+    all('#browse_mainlist .volume-collapse-toggle').each(&:click)
+
+    expect(page).to have_css("#{collapse_btn}:disabled.by-button-secondary-v02")
+    expect(page).to have_css("#{expand_btn}:not(:disabled):not(.by-button-secondary-v02)")
+  end
+
+  it 'disables both buttons in the flat list, which has no collapsible cards' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
+
+    # Switching to a flat sort rebuilds the list as a single card of works.
+    find("#sort_by option[value='title']").select_option
+
+    expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle')
+    expect(page).to have_css("#{collapse_btn}:disabled")
+    expect(page).to have_css("#{expand_btn}:disabled")
+  end
+end

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -2,9 +2,10 @@
 
 require 'rails_helper'
 
-# Covers the per-volume collapse toggle added to the Authority TOC: each
-# volume-type collection with children gets a chevron toggle at the end of its
-# title line that collapses/expands only that volume's children list.
+# Covers the per-collection collapse toggle in the Authority TOC: every
+# collection card with children — whatever its collection_type — gets a chevron
+# toggle at the end of its title line that collapses/expands only that
+# collection's own children list.
 describe 'Author TOC per-volume collapse toggle', :js do
   before do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
@@ -95,9 +96,34 @@ describe 'Author TOC per-volume collapse toggle', :js do
     end
   end
 
-  it 'expands nested toggle-less sub-collections when re-expanding a volume after collapse-all' do
-    # A series sub-collection has NO toggle of its own, so after collapse-all it
-    # can only be re-opened by cascading through its parent volume's toggle.
+  it 'gives non-volume collection types their own toggle' do
+    # Toggles are not limited to volumes: any collection card rendering a
+    # children list gets one (here a periodical).
+    periodical_work = Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Work in Periodical', status: :published, author: author)
+    end
+    periodical = create(:collection, title: 'Test Periodical', collection_type: :periodical)
+    create(:collection_item, collection: periodical, item: periodical_work)
+    create(:involved_authority, authority: author, item: periodical, role: 'editor')
+
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist')
+
+    toggle = find("#cwrapper_#{periodical.id} .volume-collapse-toggle", match: :first)
+    cwrapper = toggle.find(:xpath, "./ancestor::div[contains(@class, 'cwrapper')][1]")
+
+    toggle.click
+    expect(cwrapper).to have_css('ul.toclist', visible: :hidden)
+    expect(toggle[:class]).to include('collapsed')
+
+    toggle.click
+    expect(cwrapper).to have_css('ul.toclist', visible: :visible)
+    expect(toggle[:class]).not_to include('collapsed')
+  end
+
+  it 'cascades expansion into nested sub-collections when re-expanding a volume after collapse-all' do
+    # Expanding a volume reveals its whole subtree, so a nested collection left
+    # collapsed by collapse-all is never stranded out of reach.
     # Give the nested work a different author so it renders only inside the
     # series (avoids a duplicate copy in this author's work-level section).
     other_author = create(:authority, name: 'Other Author')
@@ -114,8 +140,8 @@ describe 'Author TOC per-volume collapse toggle', :js do
     visit authority_path(author)
     expect(page).to have_css('#browse_mainlist')
 
-    # The nested series has no toggle of its own; the outer volume does.
-    expect(page).to have_no_css("#cwrapper_#{series.id} .volume-collapse-toggle")
+    # Both the nested series and its parent volume carry their own toggle.
+    expect(page).to have_css("#cwrapper_#{series.id} .volume-collapse-toggle")
     expect(page).to have_css("#cwrapper_#{outer_volume.id} .volume-collapse-toggle")
 
     # Initially the deeply nested work is visible.
@@ -128,9 +154,11 @@ describe 'Author TOC per-volume collapse toggle', :js do
     outer_toggle = find("#cwrapper_#{outer_volume.id} .volume-collapse-toggle", match: :first)
     outer_toggle.click
 
-    # The fix cascades expansion into the toggle-less series, so its work must
-    # become visible again — not just the series header.
+    # The cascade reaches down through the series, so its work must become
+    # visible again — not just the series header — and the series' own toggle
+    # must be back in the expanded state to match.
     expect(page).to have_link('Nested Series Work', visible: :visible)
+    expect(page).to have_no_css("#cwrapper_#{series.id} .volume-collapse-toggle.collapsed")
   end
 
   it 'keeps individual toggles in sync with the collapse-all / expand-all buttons' do

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 # collection card with children — whatever its collection_type — gets a chevron
 # toggle at the end of its title line that collapses/expands only that
 # collection's own children list.
-describe 'Author TOC per-volume collapse toggle', :js do
+describe 'Author TOC per-collection collapse toggle', :js do
   before do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
   end


### PR DESCRIPTION
Closes #1353, closes #1340.

## by-565 — per-collection expand/collapse (gh-1353)

The chevron toggle was rendered only for `volume`-type collections (plus the uncollected card), so a periodical, series, `volume_series` or `other` collection could not be expanded/collapsed on its own. Now **every collection card that renders a children list gets its own toggle**, whatever its `collection_type`.

Expanding a card still **cascades** down its whole subtree (per PR #1426's intent), so a descendant left collapsed by Collapse all is never stranded out of reach — and each descendant's own toggle is put back into the expanded state to match.

The toggle is suppressed in the editable (collections-migration) view, which has no collapse JS and would otherwise show inert chevrons.

## by-7yp — buttons reflect current state (gh-1340)

`Collapse all` / `Expand all` were styled statically. Now:

| State | Collapse all | Expand all |
|---|---|---|
| everything expanded | primary, enabled | secondary, **disabled** |
| everything collapsed | secondary, **disabled** | primary, enabled |
| mixed | primary, enabled | secondary, enabled |
| nothing collapsible (flat sorts, legacy TOC) | disabled | disabled |

State is recomputed on load (after `prune_collections` drops the toggles of volumes rendered as a single link), on either button, on any individual toggle, and after a sort rebuilds the list.

## i18n

`toggle_collapse_volume` ("Collapse or expand this volume") no longer fits non-volume types and Hebrew has no gender-neutral demonstrative that covers כרך / סדרה / כתב עת, so it is replaced by `toggle_collapse_collection` — "צמצם או הרחב: %{title}" / "Collapse or expand: %{title}" — in both locales. The old key had no other callers.

## Test plan

- `spec/system/author_toc_collapse_buttons_state_spec.rb` (new, 5 examples): initial state, the primary/disabled swap in both directions, mixed state, state driven by individual toggles alone, and both-disabled in the flat list.
- `spec/system/author_toc_volume_collapse_toggle_spec.rb`: added an example covering a non-volume (periodical) toggle; the nested-sub-collection example now asserts the series has its own toggle *and* that cascading still re-expands it.

Ran green: the three collapse specs (12 examples), plus `author_toc_filters`, `author_toc_colls_abc`, `author_navbar_collapse_arrows`, `authors_filter_panel`, `author_toc_mobile_filter` (27), plus `authors_controller`, `author_toc_filters` (request), `navbar_works_about_author_i18n`, `author_lex_citations` (81). RuboCop and haml-lint clean on the changed lines. **The full suite was not run** (40+ min) — it needs your go-ahead.

## Notes for the reviewer

- The CSS class name `.volume-collapse-toggle` is now a misnomer (it covers all collection types), but renaming it would churn the stylesheet, `prune_collections`, and three spec files, so it is left alone.
- The disabled-button grey is scoped to `#max_collapse` / `#expand-all` in `application.scss` rather than applied to `.by-button-v02:disabled` globally, to avoid restyling disabled buttons elsewhere in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)