### PR TITLE
Exclude non-primary works from the periodicals landing page lists (beads_by-5x3)

### DIFF
--- a/app/controllers/periodicals_controller.rb
+++ b/app/controllers/periodicals_controller.rb
@@ -13,11 +13,14 @@ class PeriodicalsController < ApplicationController
     with_public_works = Collection.ids_with_published_manifestations(periodicals.map(&:id)).to_set
     @periodicals = periodicals.select { |p| with_public_works.include?(p.id) }
     @periodicals_count = @periodicals.size
+    # non-primary works (e.g. an issue's editorial column) are parts of a larger text, not standalone works
     @popular_works = ManifestationsIndex.query(match: { in_periodical: true })
+                                        .filter(term: { primary: true })
                                         .filter(range: { impressions_count: { gte: 1 } })
                                         .order(impressions_count: :desc)
                                         .limit(10)
     @newest_works = ManifestationsIndex.query(match: { in_periodical: true })
+                                       .filter(term: { primary: true })
                                        .order(pby_publication_date: :desc)
                                        .limit(10)
     @periodicals_text_count = Rails.cache.fetch('periodicals_text_count', expires_in: 15.minutes) do

--- a/app/services/periodicals_whats_new_since.rb
+++ b/app/services/periodicals_whats_new_since.rb
@@ -6,7 +6,9 @@ class PeriodicalsWhatsNewSince < ApplicationService
     authors = {}
     # Get all published manifestations that are new since the timestamp
     # and are contained in periodicals (have periodical_issue in parent chain)
+    # non-primary works (e.g. an issue's editorial column) are parts of a larger text, not standalone works
     Manifestation.all_published.new_since(timestamp)
+                 .joins(expression: :work).where(works: { primary: true })
                  .includes({ expression: { work: { involved_authorities: :authority } } }, collection_items: :collection)
                  .find_each do |m|
       # Skip if not in a periodical

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe 'Periodicals', type: :request do
     end
   end
 
+  # Regression: works flagged non-primary (e.g. an issue's editorial column) are parts of a larger
+  # text, not standalone works, and must not surface in the periodicals landing page's work lists.
+  describe 'suppression of non-primary works in the newest/popular lists' do
+    let!(:periodical_issue) { create(:collection, collection_type: 'periodical_issue') }
+    let!(:primary_work) do
+      create(:manifestation, title: 'Primary Periodical Work', impressions_count: 5, collections: [periodical_issue])
+    end
+    let!(:non_primary_work) do
+      create(:manifestation, title: 'Editorial Column', primary: false, impressions_count: 99,
+                             collections: [periodical_issue])
+    end
+
+    before do
+      import_and_await(ManifestationsIndex, [primary_work, non_primary_work])
+      get '/periodicals'
+    end
+
+    after do
+      Chewy.massacre
+    end
+
+    it 'excludes non-primary works from @newest_works' do
+      expect(assigns(:newest_works).map { |w| w.id.to_i }).to contain_exactly(primary_work.id)
+    end
+
+    it 'excludes non-primary works from @popular_works' do
+      expect(assigns(:popular_works).map { |w| w.id.to_i }).to contain_exactly(primary_work.id)
+    end
+  end
+
   describe 'GET /show' do
     it 'returns http success' do
       get '/periodicals/show'

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe 'Periodicals', type: :request do
     end
 
     before do
+      Chewy.massacre
       import_and_await(ManifestationsIndex, [primary_work, non_primary_work])
       get '/periodicals'
     end

--- a/spec/services/periodicals_whats_new_since_spec.rb
+++ b/spec/services/periodicals_whats_new_since_spec.rb
@@ -43,6 +43,13 @@ describe PeriodicalsWhatsNewSince do
       works
     end
 
+    let!(:non_primary_periodical_work) do
+      # e.g. an issue's editorial column: part of a larger text, not a standalone work
+      create(:manifestation, author: author, orig_lang: 'he', primary: false, created_at: 2.weeks.ago).tap do |work|
+        create(:collection_item, collection: periodical_issue, item: work)
+      end
+    end
+
     let!(:non_periodical_works) do
       # Create works not in periodicals (should not be included)
       create_list(
@@ -73,6 +80,13 @@ describe PeriodicalsWhatsNewSince do
           author_works.except(:latest).values.flatten
         end
         expect(all_returned_manifestations).not_to include(*non_periodical_works)
+      end
+
+      it 'does not include works flagged non-primary' do
+        all_returned_manifestations = result.values.flat_map do |author_works|
+          author_works.except(:latest).values.flatten
+        end
+        expect(all_returned_manifestations).not_to include(non_primary_periodical_work)
       end
     end
 


### PR DESCRIPTION
## Problem

Works whose metadata flags them non-primary (parts of a larger text, e.g. an issue's
editorial column) appeared in the newest-works list on `/periodicals`. Reported case:
issue 23 of פנטסיה 2000 went up on 2026-06-04 and דבר העורך (/read/68678) showed up in
that list. Fixes gh-1304 / beads_by-5x3.

## Changes

The same defect affected all three work lists on the page, so all three now filter on
`primary` (confirmed with the user before widening scope beyond the bead's wording):

- `app/controllers/periodicals_controller.rb`: added `.filter(term: { primary: true })`
  to both the `@newest_works` and `@popular_works` Elasticsearch queries. The `primary`
  field has been in `ManifestationsIndex` since 2022 (7fbc8e04d), so no reindex is needed.
- `app/services/periodicals_whats_new_since.rb`: the "מה חדש בכתבי עת" author cards now
  join works and filter `works.primary = true`.

## Not touched

- `@periodicals_text_count` still counts every text in periodicals, primary or not — it is
  a corpus-size figure, not a list of works. Say the word if it should match.
- The homepage `Manifestation.newest_works` / `popular_works` are site-wide, outside this bug.

## Test plan

New regression coverage, verified to fail before the fix and pass after:

- `spec/requests/periodicals_spec.rb`: a periodical issue holding one primary and one
  non-primary work; asserts `@newest_works` and `@popular_works` contain only the primary
  one (the non-primary work is given a higher `impressions_count` so it would rank first).
- `spec/services/periodicals_whats_new_since_spec.rb`: a non-primary periodical work is
  excluded from the grouped results.

```
bundle exec rspec spec/services/periodicals_whats_new_since_spec.rb spec/requests/periodicals_spec.rb
28 examples, 0 failures
```

RuboCop on all four changed files reports only pre-existing offenses (no new ones).
The full suite was **not** run (40+ min, needs approval) — CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)