### PR TITLE
Author page: swap the action bar for the flat texts list (beads_by-r81)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1458,6 +1458,30 @@ p.by-genre-name-v02.headline-2-v02 {
 	select {
 		max-width: 100%;
 	}
+
+	/* Grouped (volumes) view vs. flat texts list: each mode's actions are shown
+	 * only in that mode. .flat-mode is set by setTocBarMode() (authors/toc). */
+	.toc-flat-action {
+		display: none;
+	}
+
+	&.flat-mode {
+		.toc-grouped-action {
+			display: none;
+		}
+
+		.toc-flat-action {
+			display: flex;
+		}
+	}
+}
+
+/* Summaries view of the flat texts list: an excerpt card under each work,
+ * matching the dictionary list's entry summaries. The card is a block inside
+ * the work's <li>, which otherwise lays its title out inline. */
+.toc-snippet {
+	margin-top: 6px;
+	margin-left: 0;
 }
 
 /* Sticky navbar for lexicon entries.

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -31,6 +31,13 @@ class ManifestationController < ApplicationController
   DATE_FIELD = { 'uploaded' => 'manifestations.created_at', 'created' => 'works.normalized_creation_date',
                  'published' => 'expressions.normalized_pub_date' }.freeze
 
+  # #snippets serves one screenful of the flat list at a time; the cap keeps a
+  # hand-crafted request from asking for an author's entire corpus at once.
+  SNIPPET_BATCH_LIMIT = 30
+  # Lines of text per snippet: the card clamps to 3 rendered lines, so this is
+  # merely enough to fill it for any reasonable line length.
+  SNIPPET_LINES = 10
+
   #############################################
   # public actions
   #############################################
@@ -141,6 +148,22 @@ class ManifestationController < ApplicationController
     @tabclass = set_tab('periods')
     @page_title = t(:periods) + ' - ' + t(:project_ben_yehuda)
     @pagetype = :periods
+  end
+
+  # Text snippets for a batch of works, as JSON keyed by manifestation id.
+  # The author page's flat-list summaries view fetches these lazily as the
+  # reader scrolls, because an author can have hundreds of works and rendering
+  # every snippet with the page would be prohibitively slow.
+  def snippets
+    ids = params[:ids].to_s.split(',').map(&:to_i).reject(&:zero?).first(SNIPPET_BATCH_LIMIT)
+    scope = Manifestation.where(id: ids)
+    scope = scope.all_published unless current_user&.editor?
+    result = scope.each_with_object({}) do |m, acc|
+      acc[m.id] = Rails.cache.fetch("m_snippet_#{m.id}_#{m.updated_at.to_i}", expires_in: 24.hours) do
+        m.snippet_html(SNIPPET_LINES)
+      end
+    end
+    render json: result
   end
 
   # This code was used for 'secondary portal', but not used anymore. We may need to reimplement it at some point

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -268,6 +268,19 @@ class Manifestation < ApplicationRecord
     # stripping tags -- return ActionController::Base.helpers.strip_tags(MultiMarkdown.new(markdown.lines[0..p_count].join("\n")).to_html.force_encoding('UTF-8').gsub(/<h1.*?<\/h1>/,'').gsub(/<figcaption>.*?<\/figcaption>/,'')) # remove MMD's automatic figcaptions, and the initial title
   end
 
+  # Excerpt of the text for a works list's summaries view: the first `line_count`
+  # lines of actual prose/verse. Headings are dropped rather than merely skipped
+  # over, because a work commonly opens with its title and/or first chapter
+  # heading ("## א"), which on its own makes for a useless snippet.
+  def snippet_html(line_count)
+    lines = markdown.to_s.lines.grep_v(/\A\s*#/).drop_while(&:blank?)
+    MultiMarkdown.new(lines.first(line_count).join)
+                 .to_html
+                 .force_encoding('UTF-8')
+                 .gsub(%r{<h\d[^>]*>.*?</h\d>}m, '') # any heading MMD still inferred (e.g. underlined)
+                 .gsub(%r{<figcaption>.*?</figcaption>}, '') # MMD's automatic figcaptions
+  end
+
   def authors_string
     return I18n.t(:nil) if expression.work.authors.empty?
 

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -225,6 +225,18 @@
       // The list was just rebuilt (and entering flat mode shrinks it a lot), so
       // return the reader to the top of the page as the filters do.
       if(window.TocFilters) { window.TocFilters.scrollToTop(); }
+      // Swap the action bar: collapse/expand belong to the grouped views, the
+      // list/summaries switch to the flat list.
+      if(window.setTocBarMode) { window.setTocBarMode(flat); }
+      if(flat) {
+        // A flat->flat re-sort keeps the summaries view; the nodes (and the
+        // snippets already inside them) were only reordered.
+        TocSnippets.refresh();
+      } else {
+        // Leaving flat mode rebuilds the list from scratch, so the summaries
+        // view has nothing left to show: fall back to the plain list.
+        setTocDisplayMode(false);
+      }
       // The rebuilt list is fully expanded again (and the flat sorts have no
       // collapsible cards at all), so re-evaluate the collapse/expand buttons.
       if(window.syncCollapseButtons) { window.syncCollapseButtons(); }
@@ -549,6 +561,126 @@
       };
     })();
     window.TocFilters.init();
+
+    // ---- Summaries view of the flat list (bead r81) ----
+    // In the flat list each work can also show an excerpt of its text, in the
+    // same card the dictionary list uses for entry summaries. An author can
+    // have hundreds of works, so the excerpts are fetched from the server in
+    // batches, and only for the rows that actually scroll into view.
+    var TocSnippets = (function() {
+      var BATCH_SIZE = 25;      // must not exceed the server's per-request cap
+      var BATCH_DEBOUNCE = 60;  // ms to collect ids scrolled into view
+      var enabled = false;
+      var observer = null;
+      var pending = [];
+      var timer = null;
+
+      function $rows() { return $('#sorted_card .manifestation-node'); }
+      function midOf(node) { return $(node).find('.sorting-metadata').attr('data-mid'); }
+
+      function render(mid, html) {
+        var $row = $rows().filter(function() { return midOf(this) === mid; }).first();
+        if ($row.length === 0 || $row.children('.toc-snippet').length > 0) { return; }
+        var textId = 'toc_snippet_text_' + mid;
+        var $text = $('<div class="summary-text"></div>').attr('id', textId).html(html);
+        var $more = $('<div class="summary-read-more" style="display:none"></div>')
+                      .append($('<span class="linkcolor pointer"></span>').text(#{I18n.t(:read_more).to_json}));
+        $('<div class="value-summary-card-v02 toc-snippet"></div>').append($text).append($more).appendTo($row);
+        // Only offer "read more" when the excerpt is actually cut off.
+        try { if (is_clamped(textId)) { $more.show(); } } catch (e) {}
+      }
+
+      function flush() {
+        timer = null;
+        while (pending.length > 0) {
+          var chunk = pending.splice(0, BATCH_SIZE);
+          $.getJSON("#{manifestation_snippets_path}", { ids: chunk.join(',') }, function(data) {
+            if (!enabled) { return; } // reader switched back to the plain list meanwhile
+            $.each(data, function(mid, html) { render(mid, html); });
+          });
+        }
+      }
+
+      function request(mid) {
+        pending.push(mid);
+        if (timer === null) { timer = window.setTimeout(flush, BATCH_DEBOUNCE); }
+      }
+
+      // Rows already carrying (or awaiting) a snippet are skipped, so this is
+      // safe to re-run after a re-sort or a filter change.
+      function observe() {
+        $rows().each(function() {
+          var mid = midOf(this);
+          if (!mid || $(this).attr('data-snippet-requested') === '1') { return; }
+          if (observer) {
+            observer.observe(this);
+          } else {
+            // No IntersectionObserver: fall back to fetching the visible rows.
+            $(this).attr('data-snippet-requested', '1');
+            request(mid);
+          }
+        });
+      }
+
+      function onIntersect(entries) {
+        for (var i = 0; i < entries.length; i++) {
+          if (!entries[i].isIntersecting) { continue; }
+          var row = entries[i].target;
+          observer.unobserve(row);
+          if ($(row).attr('data-snippet-requested') === '1') { continue; }
+          $(row).attr('data-snippet-requested', '1');
+          request(midOf(row));
+        }
+      }
+
+      return {
+        enable: function() {
+          enabled = true;
+          if (observer === null && window.IntersectionObserver) {
+            // A screenful of margin so the next rows are ready before they show.
+            observer = new IntersectionObserver(onIntersect, { rootMargin: '400px 0px' });
+          }
+          observe();
+        },
+        disable: function() {
+          enabled = false;
+          pending = [];
+          if (observer) { observer.disconnect(); }
+          $('#browse_mainlist .toc-snippet').remove();
+          $('#browse_mainlist .manifestation-node').removeAttr('data-snippet-requested');
+        },
+        refresh: function() { if (enabled) { observe(); } }
+      };
+    })();
+
+    function setTocDisplayMode(snippets) {
+      $('#tocmode_snippets').toggleClass('active', snippets);
+      $('#tocmode_list').toggleClass('active', !snippets);
+      if (snippets) { TocSnippets.enable(); } else { TocSnippets.disable(); }
+    }
+
+    $('#tocmode_list').click(function(e) { e.preventDefault(); setTocDisplayMode(false); });
+    $('#tocmode_snippets').click(function(e) { e.preventDefault(); setTocDisplayMode(true); });
+
+    // Expand a clamped excerpt; once it is expanded as far as the card goes,
+    // the link takes the reader to the work itself.
+    $('#browse_mainlist').on('click', '.toc-snippet .summary-read-more', function() {
+      var $card = $(this).closest('.toc-snippet');
+      var $text = $card.children('.summary-text').first();
+      if ($text.length > 0) {
+        $text.removeClass('summary-text').addClass('summary-text-more-lines');
+        try {
+          if (is_clamped($text.attr('id'))) {
+            $(this).find('span').text(#{I18n.t(:to_the_full_work).to_json});
+            return;
+          }
+        } catch (e) {}
+        $(this).hide();
+      } else {
+        var href = $(this).closest('.manifestation-node').find('a[href]').first().attr('href');
+        if (href) { window.location.href = href; }
+      }
+    });
 
     $(document).on('show.bs.collapse', '[id^="paratext_collapse_"]', function() {
       $('[aria-controls="' + this.id + '"]').text(#{I18n.t(:show_less).to_json});

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -105,8 +105,8 @@
              .flat-mode on the bar.
           .by-card-v02.sticky-fold
             -# state (primary/disabled) is kept in sync by syncCollapseButtons() below
-            %button.by-button-v02.toc-grouped-action#max_collapse{href: "#"}= t(:collapse_all_sections)
-            %button.by-button-v02.by-button-secondary-v02.toc-grouped-action#expand-all{href: "#"}
+            %button.by-button-v02.toc-grouped-action#max_collapse{ href: '#' }= t(:collapse_all_sections)
+            %button.by-button-v02.by-button-secondary-v02.toc-grouped-action#expand-all{ href: '#' }
               = t(:expand_all_sections)
             .BYD-switch.toc-flat-action
               %button.search-mobile-option.active#tocmode_list= t(:toc_display_list)

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -99,10 +99,18 @@
                   %input#select-all{type: 'checkbox', style:'display:none'}
               %button.btn-small-outline-v02#multiselect_btn{title: t(:worklist_multi_tt)}
                 .by-icon-v02.purple-v02 \
+          -# The grouped (volumes) view and the flat texts list call for different
+             actions: collapse/expand apply only to volume cards, the list/summaries
+             switch only to the flat list. setTocBarMode() swaps them by toggling
+             .flat-mode on the bar.
           .by-card-v02.sticky-fold
             -# state (primary/disabled) is kept in sync by syncCollapseButtons() below
-            %button.by-button-v02#max_collapse{href: "#"}= t(:collapse_all_sections)
-            %button.by-button-v02.by-button-secondary-v02#expand-all{href: "#"}= t(:expand_all_sections)
+            %button.by-button-v02.toc-grouped-action#max_collapse{href: "#"}= t(:collapse_all_sections)
+            %button.by-button-v02.by-button-secondary-v02.toc-grouped-action#expand-all{href: "#"}
+              = t(:expand_all_sections)
+            .BYD-switch.toc-flat-action
+              %button.search-mobile-option.active#tocmode_list= t(:toc_display_list)
+              %button.search-mobile-option#tocmode_snippets= t(:toc_display_snippets)
             %p
               = t(:sort_by)
               = select_tag :sort_by, options_for_select([[t(:collections_and_pubdates_asc), 'colls'], [t(:collections_abc),'colls_abc'], [t(:alefbet_asc), 'title'], [t(:popularity_desc), 'popularity_desc'], [t(:popularity_asc), 'popularity_asc'], [t(:pubdate_asc), 'pubdate_asc'], [t(:pubdate_desc), 'pubdate_desc'], [t(:creation_date_asc), 'creation_date_asc'], [t(:creation_date_desc), 'creation_date_desc'], [t(:uploaddate_asc), 'upload_date_asc'], [t(:uploaddate_desc), 'upload_date_desc']  ], params[:sort_by])
@@ -351,6 +359,13 @@
           });
         }
       });
+
+      // Swap the action bar between the grouped (volumes) view and the flat
+      // texts list. Called by the sort handler in _generated_toc, which is what
+      // knows whether the chosen sort produces a flat list.
+      window.setTocBarMode = function(flat) {
+        $('.sticky-fold').toggleClass('flat-mode', flat);
+      };
 
       // The Collapse all / Expand all buttons reflect the list's current state:
       // whichever action would still change something is the primary (filled)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3220,6 +3220,9 @@ en:
   expand_all_sections: Expand all sections
   toggle_collapse_collection: "Collapse or expand: %{title}"
   toggle_collapse_uncollected: Collapse or expand the uncollected works
+  toc_display_list: List
+  toc_display_snippets: Summaries
+  to_the_full_work: To the full work
   legacy_urls:
     index:
       title: Legacy URL Mappings

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2477,6 +2477,9 @@ he:
   expand_all_sections: הרחב הכל
   toggle_collapse_collection: "צמצם או הרחב: %{title}"
   toggle_collapse_uncollected: צמצם או הרחב את היצירות שלא כונסו
+  toc_display_list: רשימה
+  toc_display_snippets: תקצירים
+  to_the_full_work: ליצירה המלאה
   by_involved_authorities: לפי אישים מעורבים
   works_and_volumes: כותרים ויצירות
   list_all_collections: רשימת כל הכותרים

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -416,6 +416,7 @@ Bybeconv::Application.routes.draw do
   get 'kwic/:id/download' => 'manifestation#kwic_download', as: 'manifestation_kwic_download'
   get 'kwic/:id/context/:paragraph' => 'manifestation#kwic_context', as: 'manifestation_kwic_context'
   get 'manifestation/show/:id' => 'manifestation#show', as: 'manifestation_show'
+  get 'manifestation/snippets' => 'manifestation#snippets', as: 'manifestation_snippets'
   get 'manifestation/render_html'
   get 'manifestation/chomp_period/:id' => 'manifestation#chomp_period', as: 'manifestation_chomp_period'
   post 'manifestation/set_bookmark'

--- a/spec/controllers/concerns/tracking_spec.rb
+++ b/spec/controllers/concerns/tracking_spec.rb
@@ -83,6 +83,24 @@ describe Tracking do
           expect(manifestation_index.impressions_count).to eq(impression_count)
         end
       end
+
+      # A view is not a change to the record, and caches downstream are keyed on
+      # updated_at (e.g. the works-list snippets), so counting one must not
+      # invalidate them.
+      context 'with any of the record types it is called for' do
+        let(:impression_count) { 1 }
+
+        it 'leaves updated_at alone' do
+          records = Chewy.strategy(:atomic) do
+            [manifestation, create(:authority, impressions_count: 1), create(:collection, impressions_count: 1)]
+          end
+
+          records.each do |record|
+            record.update_columns(updated_at: 3.days.ago)
+            expect { controller.track_view(record) }.not_to(change { record.reload.updated_at })
+          end
+        end
+      end
     end
 
     context 'when user agent is known spider' do

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -131,6 +131,32 @@ describe Manifestation do
     end
   end
 
+  describe '.snippet_html' do
+    subject(:snippet) { manifestation.snippet_html(10) }
+
+    let(:manifestation) { create(:manifestation, markdown: markdown) }
+
+    context 'when the text opens with a title and a chapter heading' do
+      let(:markdown) { "\n\n## The Title\n\n### א\n\nThe first real line.\n\nThe second one.\n" }
+
+      it 'skips the headings and starts at the text itself' do
+        expect(snippet).to include('The first real line.')
+        expect(snippet).to include('The second one.')
+        expect(snippet).not_to include('The Title')
+        expect(snippet).not_to include('<h')
+      end
+    end
+
+    context 'when the text runs longer than the requested number of lines' do
+      let(:markdown) { (1..40).map { |i| "Line #{i}." }.join("\n\n") }
+
+      it 'stops after them' do
+        expect(snippet).to include('Line 1.')
+        expect(snippet).not_to include('Line 40.')
+      end
+    end
+  end
+
   describe '.manual_delete' do
     subject(:manual_delete) { manifestation.manual_delete }
 

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -131,7 +131,7 @@ describe Manifestation do
     end
   end
 
-  describe '.snippet_html' do
+  describe '#snippet_html' do
     subject(:snippet) { manifestation.snippet_html(10) }
 
     let(:manifestation) { create(:manifestation, markdown: markdown) }

--- a/spec/requests/manifestation_snippets_spec.rb
+++ b/spec/requests/manifestation_snippets_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The batch snippets endpoint feeding the Authority TOC's summaries view
+# (bead r81). The JS that calls it is covered by the system spec.
+RSpec.describe 'Manifestation snippets', type: :request do
+  let!(:poem) { create(:manifestation, title: 'Alpha Poem', markdown: 'The opening line of the Alpha poem.') }
+  let!(:story) { create(:manifestation, title: 'Beta Story', markdown: 'The opening line of the Beta story.') }
+
+  it 'returns the rendered snippet of every requested work, keyed by id' do
+    get manifestation_snippets_path, params: { ids: [poem.id, story.id].join(',') }
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+    expect(body.keys).to contain_exactly(poem.id.to_s, story.id.to_s)
+    expect(body[poem.id.to_s]).to include('The opening line of the Alpha poem.')
+    expect(body[story.id.to_s]).to include('The opening line of the Beta story.')
+  end
+
+  it 'skips over headings, which would otherwise be the whole snippet' do
+    chaptered = create(:manifestation, title: 'Chaptered',
+                                       markdown: "## Chaptered\n\n### א\n\nThe text under the first chapter.\n")
+
+    get manifestation_snippets_path, params: { ids: chaptered.id.to_s }
+
+    snippet = response.parsed_body[chaptered.id.to_s]
+    expect(snippet).to include('The text under the first chapter.')
+    expect(snippet).not_to include('<h')
+  end
+
+  it 'ignores ids that are not published works' do
+    unpublished = create(:manifestation, title: 'Hidden', status: :unpublished, markdown: 'Secret text.')
+
+    get manifestation_snippets_path, params: { ids: [poem.id, unpublished.id, 0, 'junk'].join(',') }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.keys).to eq([poem.id.to_s])
+  end
+
+  it 'serves nothing when no usable ids are given' do
+    get manifestation_snippets_path, params: { ids: '' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to eq({})
+  end
+
+  it 'caps how many works one request may ask for' do
+    # Ids of no existing work, enough of them to fill the cap on their own; the
+    # two real works sit past it, so neither may come back.
+    base = Manifestation.maximum(:id) + 1
+    filler = (base...(base + ManifestationController::SNIPPET_BATCH_LIMIT)).to_a
+    get manifestation_snippets_path, params: { ids: (filler + [poem.id, story.id]).join(',') }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to eq({})
+  end
+end

--- a/spec/system/author_toc_action_bar_spec.rb
+++ b/spec/system/author_toc_action_bar_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Authority TOC action bar carries different actions per view (bead r81):
+# the grouped (volumes) view gets Collapse all / Expand all, while the flat texts
+# list gets the list/summaries display switch. The summaries view fetches each
+# work's excerpt lazily from ManifestationController#snippets.
+describe 'Author TOC action bar', :js do
+  # Lazy `let` (not `let!`) so the WebDriver skip in the before hook can
+  # short-circuit without running the DB + Chewy setup when Chrome is unavailable.
+  let(:author) { create(:authority, name: 'Bar Author') }
+  let(:volume) { create(:collection, title: 'A Volume', collection_type: :volume) }
+
+  let(:poem) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Alpha Poem', status: :published, author: author,
+                             markdown: 'The opening line of the Alpha poem.')
+    end
+  end
+  let(:story) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Beta Story', status: :published, author: author,
+                             markdown: 'The opening line of the Beta story.')
+    end
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    create(:collection_item, collection: volume, item: poem)
+    create(:collection_item, collection: volume, item: story)
+    create(:involved_authority, authority: author, item: volume, role: 'editor')
+  end
+
+  after { Chewy.massacre }
+
+  def choose_sort(value)
+    find("#sort_by option[value='#{value}']").select_option
+  end
+
+  it 'swaps the collapse/expand buttons for the display switch in the flat list, and back' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
+
+    # Grouped view: volume actions only.
+    expect(page).to have_css('#max_collapse', visible: :visible)
+    expect(page).to have_css('#expand-all', visible: :visible)
+    expect(page).to have_css('#tocmode_list', visible: :hidden)
+    expect(page).to have_css('#tocmode_snippets', visible: :hidden)
+
+    choose_sort('title')
+
+    # Flat list: display switch only, starting on the plain list.
+    expect(page).to have_css('#tocmode_list.active', visible: :visible)
+    expect(page).to have_css('#tocmode_snippets', visible: :visible)
+    expect(page).to have_no_css('#tocmode_snippets.active', visible: :visible)
+    expect(page).to have_no_css('#max_collapse')
+    expect(page).to have_no_css('#expand-all')
+
+    choose_sort('colls')
+
+    expect(page).to have_css('#max_collapse', visible: :visible)
+    expect(page).to have_css('#expand-all', visible: :visible)
+    expect(page).to have_css('#tocmode_list', visible: :hidden)
+  end
+
+  it 'shows each work\'s excerpt in the summaries view and drops it again in the list view' do
+    visit authority_path(author)
+    choose_sort('title')
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
+    expect(page).to have_no_css('.toc-snippet')
+
+    find('#tocmode_snippets').click
+
+    expect(page).to have_css('.toc-snippet', count: 2)
+    expect(page).to have_content('The opening line of the Alpha poem.')
+    expect(page).to have_content('The opening line of the Beta story.')
+    expect(page).to have_css('#tocmode_snippets.active')
+
+    find('#tocmode_list').click
+
+    expect(page).to have_no_css('.toc-snippet', visible: :all)
+    expect(page).to have_no_content('The opening line of the Alpha poem.')
+    expect(page).to have_css('#tocmode_list.active')
+  end
+
+  it 'keeps the summaries view across a re-sort within the flat list' do
+    visit authority_path(author)
+    choose_sort('title')
+    find('#tocmode_snippets').click
+    expect(page).to have_css('.toc-snippet', count: 2)
+
+    choose_sort('popularity_desc')
+
+    # The nodes are only reordered, so their excerpts travel with them.
+    expect(page).to have_css('#tocmode_snippets.active')
+    expect(page).to have_css('.toc-snippet', count: 2)
+  end
+
+  it 'falls back to the list view when leaving the flat list' do
+    visit authority_path(author)
+    choose_sort('title')
+    find('#tocmode_snippets').click
+    expect(page).to have_css('.toc-snippet', count: 2)
+
+    choose_sort('colls')
+    expect(page).to have_no_css('.toc-snippet', visible: :all)
+
+    choose_sort('title')
+
+    expect(page).to have_css('#tocmode_list.active', visible: :visible)
+    expect(page).to have_no_css('.toc-snippet', visible: :all)
+  end
+end

--- a/spec/system/author_toc_collapse_buttons_state_spec.rb
+++ b/spec/system/author_toc_collapse_buttons_state_spec.rb
@@ -80,7 +80,7 @@ describe 'Author TOC collapse/expand buttons state', :js do
     expect(page).to have_css("#{expand_btn}:not(:disabled):not(.by-button-secondary-v02)")
   end
 
-  it 'disables both buttons in the flat list, which has no collapsible cards' do
+  it 'takes both buttons out of the flat list, which has no collapsible cards' do
     visit authority_path(author)
     expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
 
@@ -88,7 +88,11 @@ describe 'Author TOC collapse/expand buttons state', :js do
     find("#sort_by option[value='title']").select_option
 
     expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle')
-    expect(page).to have_css("#{collapse_btn}:disabled")
-    expect(page).to have_css("#{expand_btn}:disabled")
+    # The action bar swaps them out for the list/summaries switch entirely, and
+    # they are left disabled underneath.
+    expect(page).to have_no_css(collapse_btn)
+    expect(page).to have_no_css(expand_btn)
+    expect(page).to have_css("#{collapse_btn}:disabled", visible: :hidden)
+    expect(page).to have_css("#{expand_btn}:disabled", visible: :hidden)
   end
 end


### PR DESCRIPTION
Closes #1347 (bead `beads_by-r81`).

## Problem

The Authority TOC action bar carried the volume actions (צמצם הכל / הרחב הכל) in every view, including the flat texts list — where there are no volume cards for them to act on, so they sat there disabled.

## What changed

The bar now swaps its actions with the view, per the wireframes on the issue:

- **Grouped views** (`colls` / `colls_abc`): Collapse all / Expand all, as before.
- **Flat texts list** (any other sort): a **רשימה / תקצירים** display switch instead.

The swap is a single `.flat-mode` class on the bar (`setTocBarMode()` in `authors/toc`), driven by the sort handler that already knows whether the chosen sort produces a flat list.

### The summaries (תקצירים) view

Each work in the flat list gets an excerpt of its text, in the same `.value-summary-card-v02` card the dictionary list uses for entry summaries, with the same clamp + "קראו עוד" behaviour (once expanded as far as the card goes, the link takes the reader to the work).

An author can have hundreds of works, so excerpts are **not** rendered with the page:

- new batch endpoint `GET /manifestation/snippets?ids=…` returns `{id => html}`, capped at 30 ids per request and cached per work;
- the client requests them via an `IntersectionObserver`, only for rows that scroll into view, batched with a short debounce.

`Manifestation#snippet_html` builds the excerpt by dropping heading lines first: works commonly open with their title and/or a chapter heading (`## א`), so the pre-existing `snippet_paragraphs` (which strips only an initial `<h1>`) yielded snippets consisting of nothing but the chapter number. Verified against real texts in the dev DB. `snippet_paragraphs` is left alone — the surprise-work card still uses it.

## Test plan

New:
- `spec/system/author_toc_action_bar_spec.rb` (js) — the bar swaps both ways; summaries appear and are dropped again; the mode survives a flat→flat re-sort and falls back to the list view when leaving flat mode.
- `spec/requests/manifestation_snippets_spec.rb` — batch JSON, heading skipping, unpublished works excluded, id cap.
- `spec/models/manifestation_spec.rb` — `snippet_html` heading skipping and line limit.

Updated:
- `spec/system/author_toc_collapse_buttons_state_spec.rb` — the flat-list example now expects the collapse/expand buttons to be swapped out rather than merely disabled.

Run and passing: the four specs above plus the related TOC suites (`author_toc_filters`, `author_toc_volume_collapse_toggle`, `author_toc_uncollected_collapse_toggle`, `author_toc_colls_abc`, `requests/author_toc_filters`) — 40 examples, 0 failures. The full suite (40+ min) was **not** run; it needs the maintainer's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)