### PR TITLE
Author page: show work metadata on the flat list's snippet cards (beads_by-dsm)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1482,6 +1482,15 @@ p.by-genre-name-v02.headline-2-v02 {
 .toc-snippet {
 	margin-top: 6px;
 	margin-left: 0;
+
+	/* The work's metadata, above the excerpt: kept to as few lines as possible, so the items flow
+	 * along one line and wrap only when the card runs out of width. */
+	.toc-snippet-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 2px 12px;
+		margin-bottom: 4px;
+	}
 }
 
 /* Sticky navbar for lexicon entries.

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -37,6 +37,17 @@ class ManifestationController < ApplicationController
   # Lines of text per snippet: the card clamps to 3 rendered lines, so this is
   # merely enough to fill it for any reasonable line length.
   SNIPPET_LINES = 10
+  # Everything the snippet card touches, so that a batch of them costs a fixed number of queries
+  # rather than a handful per work: the work (genre, original language), the authorities it names
+  # along with their gender (which lives on the Person behind the Authority), and the collections
+  # containing it. The containment goes one level up, which covers a work sitting in a series
+  # inside a volume; deeper nestings still cost Collection#parent_volume_or_isssue a query per
+  # level, its walk up the tree being of no fixed depth.
+  SNIPPET_INCLUDES = [
+    { collection_items: { collection: { parent_collection_items: :collection } } },
+    { expression: [{ involved_authorities: { authority: :person } },
+                   { work: { involved_authorities: { authority: :person } } }] }
+  ].freeze
 
   #############################################
   # public actions
@@ -162,7 +173,7 @@ class ManifestationController < ApplicationController
   def snippets
     ids = params[:ids].to_s.split(',').map(&:to_i).reject(&:zero?).first(SNIPPET_BATCH_LIMIT)
     authority_id = params[:authority_id].to_i
-    scope = Manifestation.where(id: ids).includes(expression: :work)
+    scope = Manifestation.where(id: ids).includes(SNIPPET_INCLUDES)
     scope = scope.all_published unless current_user&.editor?
     result = scope.each_with_object({}) do |m, acc|
       key = "m_snippet_card_#{m.id}_#{authority_id}_#{m.updated_at.to_i}"

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -150,17 +150,25 @@ class ManifestationController < ApplicationController
     @pagetype = :periods
   end
 
-  # Text snippets for a batch of works, as JSON keyed by manifestation id.
-  # The author page's flat-list summaries view fetches these lazily as the
-  # reader scrolls, because an author can have hundreds of works and rendering
-  # every snippet with the page would be prohibitively slow.
+  # Summary cards (work metadata plus a text excerpt) for a batch of works, as JSON keyed by
+  # manifestation id. The author page's flat-list summaries view fetches these lazily as the reader
+  # scrolls, because an author can have hundreds of works and rendering every card with the page
+  # would be prohibitively slow.
+  #
+  # authority_id is the authority whose page the cards are shown on: it decides which involved
+  # authorities the card can leave unsaid, so it is part of the cache key. The key does not cover
+  # the work's collections or authorities, which change far more rarely than the text; the 24-hour
+  # expiry is what bounds staleness there.
   def snippets
     ids = params[:ids].to_s.split(',').map(&:to_i).reject(&:zero?).first(SNIPPET_BATCH_LIMIT)
-    scope = Manifestation.where(id: ids)
+    authority_id = params[:authority_id].to_i
+    scope = Manifestation.where(id: ids).includes(expression: :work)
     scope = scope.all_published unless current_user&.editor?
     result = scope.each_with_object({}) do |m, acc|
-      acc[m.id] = Rails.cache.fetch("m_snippet_#{m.id}_#{m.updated_at.to_i}", expires_in: 24.hours) do
-        m.snippet_html(SNIPPET_LINES)
+      key = "m_snippet_card_#{m.id}_#{authority_id}_#{m.updated_at.to_i}"
+      acc[m.id] = Rails.cache.fetch(key, expires_in: 24.hours) do
+        render_to_string(partial: 'manifestation/snippet_card', formats: [:html],
+                         locals: { m: m, authority_id: authority_id })
       end
     end
     render json: result

--- a/app/helpers/authors_helper.rb
+++ b/app/helpers/authors_helper.rb
@@ -77,6 +77,26 @@ module AuthorsHelper
                  .join(', ')
   end
 
+  # Single-line list of the authorities involved in a work, for the works list's summary cards:
+  # "name (role), name (role)", roles in the usual presentation order.
+  #
+  # A role whose only holder is the authority whose page this is contributes nothing the page
+  # doesn't already say, so it is dropped. That is the same omission #manifestation_label makes in
+  # each of its branches: the sole author on their own page, the sole translator on theirs, and so
+  # on.
+  # @param manifestation
+  # @param authority_id - the authority whose page the list is shown on
+  def compact_authorities_line(manifestation, authority_id)
+    by_role = manifestation.involved_authorities.group_by(&:role)
+    by_named_role = InvolvedAuthority::ROLES_PRESENTATION_ORDER.filter_map do |role|
+      authorities = by_role[role].to_a.map(&:authority).uniq.sort_by(&:name)
+      next if authorities.empty? || authorities.map(&:id) == [authority_id]
+
+      authorities.map { |au| "#{au.name} (#{textify_role(role, au.gender)})" }.join(', ')
+    end
+    by_named_role.join(', ')
+  end
+
   def preloaded_author_aboutnesses(author)
     author.aboutnesses.preload(
       work: {

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -32,6 +32,7 @@ class Manifestation < ApplicationRecord
   before_save :update_alternate_titles, if: :title_changed?
   before_save :recalc_cached_people, if: :expression_id_changed?
   before_save :recalc_responsibility_statement, if: :expression_id_changed?
+  before_save :recalc_word_count, if: :markdown_changed?
 
   enum :status, { published: 0, nonpd: 1, unpublished: 2, deprecated: 3 }
 
@@ -360,9 +361,10 @@ class Manifestation < ApplicationRecord
     return metadata + markdown
   end
 
-  def word_count
-    # roughly okay, despite the markdown artifacts
-    return markdown.split.length
+  # The count is cached in the word_count column, because works lists show it for a whole
+  # screenful of works at a time. Roughly okay, despite the markdown artifacts.
+  def recalc_word_count
+    self.word_count = markdown.to_s.split.length
   end
 
   def recalc_cached_people

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -578,23 +578,24 @@
       function $rows() { return $('#sorted_card .manifestation-node'); }
       function midOf(node) { return $(node).find('.sorting-metadata').attr('data-mid'); }
 
+      // The card's contents (metadata line, excerpt, read-more) come rendered from the server;
+      // all that is left to do here is wrap them and hide the read-more when it is pointless.
       function render(mid, html) {
         var $row = $rows().filter(function() { return midOf(this) === mid; }).first();
         if ($row.length === 0 || $row.children('.toc-snippet').length > 0) { return; }
-        var textId = 'toc_snippet_text_' + mid;
-        var $text = $('<div class="summary-text"></div>').attr('id', textId).html(html);
-        var $more = $('<div class="summary-read-more" style="display:none"></div>')
-                      .append($('<span class="linkcolor pointer"></span>').text(#{I18n.t(:read_more).to_json}));
-        $('<div class="value-summary-card-v02 toc-snippet"></div>').append($text).append($more).appendTo($row);
+        var $card = $('<div class="value-summary-card-v02 toc-snippet"></div>').html(html).appendTo($row);
         // Only offer "read more" when the excerpt is actually cut off.
-        try { if (is_clamped(textId)) { $more.show(); } } catch (e) {}
+        try {
+          if (is_clamped('toc_snippet_text_' + mid)) { $card.children('.summary-read-more').show(); }
+        } catch (e) {}
       }
 
       function flush() {
         timer = null;
         while (pending.length > 0) {
           var chunk = pending.splice(0, BATCH_SIZE);
-          $.getJSON("#{manifestation_snippets_path}", { ids: chunk.join(',') }, function(data) {
+          var params = { ids: chunk.join(','), authority_id: #{@author.id} };
+          $.getJSON("#{manifestation_snippets_path}", params, function(data) {
             if (!enabled) { return; } // reader switched back to the plain list meanwhile
             $.each(data, function(mid, html) { render(mid, html); });
           });

--- a/app/views/manifestation/_snippet_card.html.haml
+++ b/app/views/manifestation/_snippet_card.html.haml
@@ -1,0 +1,22 @@
+-# Inner HTML of one card of the works list's summaries view (ManifestationController#snippets).
+  Rendered whole on the server so that the metadata line and the excerpt are fetched, and cached,
+  together. The wrapping .value-summary-card-v02 is added by the JS that inserts this.
+:ruby
+  w = m.expression.work
+  volume = m.volumes.first
+  authorities = compact_authorities_line(m, authority_id)
+.toc-snippet-meta.small-text.grey-text
+  %span= textify_genre(w.genre)
+  - if m.expression.translation && w.orig_lang.present?
+    %span #{t(:orig_lang)}: #{textify_lang(w.orig_lang)}
+  %span #{t(:word_count)}: #{number_with_delimiter(m.word_count.to_i)}
+  - if volume.present?
+    %span
+      = t(:out_of)
+      = link_to volume.title, collection_path(volume)
+  - if authorities.present?
+    %span= authorities
+.summary-text{ id: "toc_snippet_text_#{m.id}" }
+  != m.snippet_html(ManifestationController::SNIPPET_LINES)
+.summary-read-more{ style: 'display: none' }
+  %span.linkcolor.pointer= t(:read_more)

--- a/db/migrate/20260815090000_add_word_count_to_manifestations.rb
+++ b/db/migrate/20260815090000_add_word_count_to_manifestations.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Caches each Manifestation's word count in a column. It used to be counted from the markdown on
+# every call, which is fine for one work but not for the works lists that now show it for a whole
+# screenful at a time.
+class AddWordCountToManifestations < ActiveRecord::Migration[8.0]
+  BATCH_SIZE = 500
+
+  def up
+    add_column :manifestations, :word_count, :integer unless column_exists?(:manifestations, :word_count)
+
+    Manifestation.reset_column_information
+    # Backfilled without callbacks: the value is purely derived, so filling it in should disturb
+    # neither updated_at (caches downstream are keyed on it) nor the Elasticsearch index. Counting
+    # has to happen in Ruby (no SQL equivalent of String#split), but the writes go one statement
+    # per batch: the corpus is tens of thousands of works, and a statement each would take hours.
+    # suppress_messages: each statement names every id in the batch, which is unreadable in a log.
+    suppress_messages do
+      Manifestation.where(word_count: nil).select(:id, :markdown).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+        counts = batch.to_h { |m| [m.id, m.markdown.to_s.split.length] }
+        whens = counts.map { |id, count| "WHEN #{id} THEN #{count}" }.join(' ')
+        execute("UPDATE manifestations SET word_count = CASE id #{whens} END WHERE id IN (#{counts.keys.join(',')})")
+      end
+    end
+  end
+
+  def down
+    remove_column :manifestations, :word_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_08_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_090000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -862,6 +862,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_120000) do
     t.integer "status"
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "word_count"
     t.index ["conv_counter"], name: "index_manifestations_on_conv_counter"
     t.index ["created_at"], name: "index_manifestations_on_created_at"
     t.index ["expression_id"], name: "index_manifestations_on_expression_id"

--- a/spec/helpers/authors_helpers_spec.rb
+++ b/spec/helpers/authors_helpers_spec.rb
@@ -158,4 +158,51 @@ describe AuthorsHelper do
       end
     end
   end
+
+  describe '.compact_authorities_line' do
+    subject(:result) { helper.compact_authorities_line(manifestation, authority.id) }
+
+    let(:authority) { create(:authority) }
+
+    context 'when the authority is the work\'s only author' do
+      let(:manifestation) { create(:manifestation, author: authority, orig_lang: 'he') }
+
+      it 'says nothing, the page itself being the attribution' do
+        expect(result).to eq('')
+      end
+    end
+
+    context 'when the work has another author besides the authority' do
+      let(:manifestation) { create(:manifestation, author: authority, orig_lang: 'he') }
+      let(:other_authority) { create(:authority) }
+
+      before do
+        manifestation.expression.work.involved_authorities.create!(role: :author, authority: other_authority)
+      end
+
+      it 'names both, with their role' do
+        expected = [authority, other_authority].sort_by(&:name)
+                                               .map { |au| "#{au.name} (#{helper.textify_role('author', au.gender)})" }
+        expect(result).to eq(expected.join(', '))
+      end
+    end
+
+    context 'when the work has other roles besides the authority\'s' do
+      let(:translator) { create(:authority) }
+      let(:manifestation) { create(:manifestation, author: authority, translator: translator, orig_lang: 'ru') }
+
+      it 'names them on one line, in the roles presentation order' do
+        expect(result).to eq("#{translator.name} (#{helper.textify_role('translator', translator.gender)})")
+      end
+
+      context 'when the authority is the sole translator of someone else\'s work' do
+        let(:author) { create(:authority) }
+        let(:manifestation) { create(:manifestation, author: author, translator: authority, orig_lang: 'ru') }
+
+        it 'names the author but omits the authority' do
+          expect(result).to eq("#{author.name} (#{helper.textify_role('author', author.gender)})")
+        end
+      end
+    end
+  end
 end

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -157,6 +157,25 @@ describe Manifestation do
     end
   end
 
+  describe '#word_count' do
+    let(:manifestation) { create(:manifestation, markdown: "One two three\nfour\n") }
+
+    it 'is cached on save' do
+      expect(manifestation.word_count).to eq 4
+    end
+
+    it 'is recalculated when the markdown changes' do
+      expect { manifestation.update!(markdown: 'Only two') }
+        .to change { manifestation.reload.word_count }.from(4).to(2)
+    end
+
+    it 'is not recalculated when the markdown is untouched' do
+      # a value the markdown could never yield, so any recalculation would show
+      manifestation.update_columns(word_count: 999)
+      expect { manifestation.update!(title: 'A new title') }.not_to(change { manifestation.reload.word_count })
+    end
+  end
+
   describe '.manual_delete' do
     subject(:manual_delete) { manifestation.manual_delete }
 

--- a/spec/requests/manifestation_snippets_spec.rb
+++ b/spec/requests/manifestation_snippets_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Manifestation snippets', type: :request do
   let!(:poem) { create(:manifestation, title: 'Alpha Poem', markdown: 'The opening line of the Alpha poem.') }
   let!(:story) { create(:manifestation, title: 'Beta Story', markdown: 'The opening line of the Beta story.') }
 
-  it 'returns the rendered snippet of every requested work, keyed by id' do
+  it 'returns the rendered card of every requested work, keyed by id' do
     get manifestation_snippets_path, params: { ids: [poem.id, story.id].join(',') }
 
     expect(response).to have_http_status(:ok)
@@ -54,5 +54,64 @@ RSpec.describe 'Manifestation snippets', type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to eq({})
+  end
+
+  describe 'the card metadata line' do
+    subject(:card) do
+      get manifestation_snippets_path, params: { ids: work.id.to_s, authority_id: author.id }
+      response.parsed_body[work.id.to_s]
+    end
+
+    let(:author) { create(:authority) }
+
+    context 'with an original Hebrew work by the authority whose page it is' do
+      let(:work) do
+        create(:manifestation, author: author, genre: 'poetry', orig_lang: 'he',
+                               markdown: "One two three four five\n")
+      end
+
+      it 'states the genre and the word count' do
+        expect(card).to include(I18n.t('genre_values.poetry'))
+        expect(card).to include("#{I18n.t(:word_count)}: 5")
+      end
+
+      it 'names no authorities, the page itself being the attribution' do
+        expect(card).not_to include(author.name)
+      end
+
+      it 'says nothing of the original language, the work not being a translation' do
+        expect(card).not_to include(I18n.t(:orig_lang))
+      end
+    end
+
+    context 'with a translation' do
+      let(:translator) { create(:authority) }
+      let(:work) do
+        create(:manifestation, author: author, translator: translator, orig_lang: 'ru', markdown: 'Some text.')
+      end
+
+      it 'states the language it was translated from' do
+        expect(card).to include("#{I18n.t(:orig_lang)}: #{I18n.t(:russian)}")
+      end
+
+      it 'names the translator, whose role the page does not imply' do
+        expect(card).to include(translator.name)
+      end
+    end
+
+    context 'when the work sits in a volume, below an intervening series' do
+      let(:volume) { create(:collection, collection_type: :volume, title: 'The Collected Poems') }
+      let(:series) { create(:collection, collection_type: :series, title: 'Part One') }
+      let(:work) { create(:manifestation, author: author, collections: [series], markdown: 'Some text.') }
+
+      before do
+        volume.collection_items.create!(item: series, seqno: 1)
+      end
+
+      it 'names the volume, ignoring the series in between' do
+        expect(card).to include('The Collected Poems')
+        expect(card).not_to include('Part One')
+      end
+    end
   end
 end

--- a/spec/requests/manifestation_snippets_spec.rb
+++ b/spec/requests/manifestation_snippets_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe 'Manifestation snippets', type: :request do
   let!(:poem) { create(:manifestation, title: 'Alpha Poem', markdown: 'The opening line of the Alpha poem.') }
   let!(:story) { create(:manifestation, title: 'Beta Story', markdown: 'The opening line of the Beta story.') }
 
+  def count_queries(&)
+    count = 0
+    counter = ->(*, payload) { count += 1 unless payload[:cached] || payload[:name] == 'SCHEMA' }
+    ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &)
+    count
+  end
+
   it 'returns the rendered card of every requested work, keyed by id' do
     get manifestation_snippets_path, params: { ids: [poem.id, story.id].join(',') }
 
@@ -54,6 +61,33 @@ RSpec.describe 'Manifestation snippets', type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to eq({})
+  end
+
+  # A batch is up to SNIPPET_BATCH_LIMIT works, and the cards name things -- authorities, their
+  # gender, the containing volume -- that each live an association or two away, so anything the
+  # card reads but the endpoint does not eager-load costs a query per work in the batch.
+  it 'costs the same number of queries however many works the batch holds' do
+    author = create(:authority)
+    volume = create(:collection, collection_type: :volume, title: 'A Volume')
+
+    build_batch = lambda do |size|
+      (1..size).map do |i|
+        series = create(:collection, collection_type: :series, title: "Series #{i}")
+        volume.collection_items.create!(item: series, seqno: volume.collection_items.count + 1)
+        create(:manifestation, author: author, translator: create(:authority), orig_lang: 'ru',
+                               collections: [series], markdown: 'Some text.').id
+      end
+    end
+    small = build_batch.call(2)
+    large = build_batch.call(8)
+
+    fetch = lambda do |ids|
+      Rails.cache.clear # the point is the cost of rendering a card, not of serving a cached one
+      count_queries { get manifestation_snippets_path, params: { ids: ids.join(','), authority_id: author.id } }
+    end
+    fetch.call(small) # warm up whatever loads lazily on the first request of the process
+
+    expect(fetch.call(large)).to eq(fetch.call(small))
   end
 
   describe 'the card metadata line' do

--- a/spec/system/author_toc_action_bar_spec.rb
+++ b/spec/system/author_toc_action_bar_spec.rb
@@ -14,13 +14,13 @@ describe 'Author TOC action bar', :js do
 
   let(:poem) do
     Chewy.strategy(:atomic) do
-      create(:manifestation, title: 'Alpha Poem', status: :published, author: author,
+      create(:manifestation, title: 'Alpha Poem', status: :published, author: author, orig_lang: 'he',
                              markdown: 'The opening line of the Alpha poem.')
     end
   end
   let(:story) do
     Chewy.strategy(:atomic) do
-      create(:manifestation, title: 'Beta Story', status: :published, author: author,
+      create(:manifestation, title: 'Beta Story', status: :published, author: author, orig_lang: 'he',
                              markdown: 'The opening line of the Beta story.')
     end
   end
@@ -83,6 +83,20 @@ describe 'Author TOC action bar', :js do
     expect(page).to have_no_css('.toc-snippet', visible: :all)
     expect(page).to have_no_content('The opening line of the Alpha poem.')
     expect(page).to have_css('#tocmode_list.active')
+  end
+
+  it 'heads each excerpt with the work\'s metadata' do
+    visit authority_path(author)
+    choose_sort('title')
+    find('#tocmode_snippets').click
+    expect(page).to have_css('.toc-snippet', count: 2)
+
+    within(first('.toc-snippet .toc-snippet-meta')) do
+      expect(page).to have_content("#{I18n.t(:word_count)}: 7")
+      expect(page).to have_link('A Volume')
+      # the work is this authority's own, so naming them here would add nothing
+      expect(page).to have_no_content(author.name)
+    end
   end
 
   it 'keeps the summaries view across a re-sort within the flat list' do


### PR DESCRIPTION
Follow-up to #1560. The summaries view of the author page's flat texts list showed only a text excerpt; each card now heads that excerpt with a single line of metadata.

## What's on the line

In order: **genre**, **original language** (translations only), **word count**, **parent volume / periodical issue** (linked), and a **compact list of involved authorities** — all on one flex line that wraps only when the card runs out of width, in the existing `.small-text.grey-text` styles.

## Authority omission

The flat list merges works from *every* role section, so there is no single "section role" per card. The rule used is: **drop a role group whose only holder is the authority whose page this is.** That one rule reproduces each branch of `manifestation_label` — the sole author on their own page, the sole translator on theirs, the sole editor/illustrator likewise — i.e. it says nothing the page doesn't already say. Verified against real data:

| context | line |
|---|---|
| the German author's own page | `שירה · שפת מקור: גרמנית · מספר מילים: 57 · מתוך כתבי יהודה ליב גורדון · יהודה ליב גורדון (מתרגם)` |
| no authority context | `... · לאופולד שפר (יוצר), יהודה ליב גורדון (מתרגם)` |

Since the omission depends on the authority, the page's authority id is now a parameter of `ManifestationController#snippets` and part of its cache key.

## Other changes

- **Card rendered server-side in one piece** (`manifestation/_snippet_card`), so the metadata and the excerpt are fetched and cached together. The JS that inserts it now only wraps it and decides whether "read more" is worth offering. The JSON value goes from a bare excerpt string to the card's full inner HTML (new cache key prefix, so no collision with the old entries).
- **`manifestations.word_count` column** replaces the on-the-fly `Manifestation#word_count`, with a `before_save` recalculating it when the markdown changes. A screenful of cards asks for dozens of counts at a time, so counting each from the markdown per request is wasteful.
- **Parent volume** comes from the existing `Manifestation#volumes`, which already skips over any intervening series collections (covered by a spec).

### On the migration

It backfills all 61,458 works, one `UPDATE ... CASE id` statement per 500 rows, without callbacks — the value is derived, so filling it in should disturb neither `updated_at` (the snippet cache is keyed on it) nor the Elasticsearch index. It is also idempotent (`column_exists?` guard, `where(word_count: nil)`), so a killed run can simply be re-run. It took well under a minute on the dev DB.

## Test plan

- `spec/requests/manifestation_snippets_spec.rb` — 11 examples: genre + word count, `שפת מקור` only for translations, translator named / page authority omitted, and a volume named *through* an intervening series.
- `spec/helpers/authors_helpers_spec.rb` — `compact_authorities_line`: sole author on own page → empty; co-author → both named with roles; sole translator on own page → only the author named.
- `spec/models/manifestation_spec.rb` — `word_count` cached on save, recalculated when the markdown changes, left alone otherwise.
- `spec/system/author_toc_action_bar_spec.rb` — new example asserting the metadata line, the volume link, and the omitted author, plus the 4 pre-existing ones.

All green: **122 examples, 0 failures** across those four files plus `author_toc_collapse_buttons_state_spec`; `anthology_text_spec`/`anthology_spec` (the other `word_count` consumer) also green. Layout verified with a throwaway screenshot spec (since deleted) and against the dev server's real corpus.

**The full suite was not run** — it takes 40+ minutes and needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)