### PR TITLE
Fix blank space above heading when the 'welcome back' donation banner shows (beads_by-mt7)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -250,6 +250,17 @@ body {
   margin-top: 93px;
 }
 
+/* Only the outermost .top-element (the layout's #content) needs a top margin to clear the
+   fixed header; several views wrap their body in another .top-element nested inside it.
+   That inner margin is normally invisible because it collapses into the outer one, but any
+   element rendered before it (e.g. the returning-visitor donation banner) breaks the
+   collapse and the duplicate margin turns into a band of blank space above the page's
+   heading. !important is needed because the layout's JS sets margin-top inline on every
+   .top-element. */
+.top-element .top-element {
+  margin-top: 0 !important;
+}
+
 header {overflow-x: hidden;} /* prevent horizontal scrollbar (caused by Slick's carousel track having a virtual width of 50000) */
 .share {cursor: pointer;}
 .pointer {cursor: pointer;}

--- a/spec/system/donation_banner_spacing_spec.rb
+++ b/spec/system/donation_banner_spacing_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The layout's JS sets margin-top (header height + 25px) on *every* .top-element, and several
+# views (collections/show among them) wrap their body in a second .top-element nested inside
+# the layout's #content.top-element. That inner margin used to be invisible only because it
+# collapsed into the outer one; the returning-visitor donation banner, rendered just before
+# the yielded view, broke the collapse and left a ~250px band of blank space above the page's
+# heading, which only went away when the banner was dismissed. See issue #1019.
+RSpec.describe 'Returning-visitor donation banner spacing', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let(:collection) do
+    Chewy.strategy(:atomic) do
+      coll = create(:collection, collection_type: :volume, title: 'אוסף לבדיקה')
+      2.times { |i| coll.collection_items.create!(item: create(:manifestation, status: :published), seqno: i + 1) }
+      coll
+    end
+  end
+
+  let(:base_user) { create(:base_user) }
+
+  # The banner shows every 4th visit; stub the count rather than creating Ahoy visits, since
+  # the browser session itself gets tracked and would shift the count.
+  def stub_base_user(visits_count)
+    allow(base_user).to receive(:visits).and_return(instance_double(ActiveRecord::Relation, count: visits_count))
+    # rubocop:disable RSpec/AnyInstance -- the controller instance is the server's, not ours
+    allow_any_instance_of(ApplicationController).to receive(:base_user).and_return(base_user)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  # Distance in px between the bottom of the donation banner (or the top of the layout's
+  # content container when there is no banner) and the top of the page's first card.
+  def gap_above_content
+    page.evaluate_script(<<~JS)
+      (function() {
+        var banner = document.getElementById('donban');
+        var top = banner ? banner.getBoundingClientRect().bottom
+                         : document.getElementById('content').getBoundingClientRect().top;
+        return Math.round(document.querySelector('.work-info-card').getBoundingClientRect().top - top);
+      })()
+    JS
+  end
+
+  after { Chewy.massacre }
+
+  it 'does not add a band of blank space above the heading when the banner is shown' do
+    stub_base_user(3)
+    visit collection_path(collection)
+
+    expect(page).to have_css('#donban')
+    # Only the .by-card-v02 top margin (15px) separates the banner from the content below it.
+    expect(gap_above_content).to be < 40
+  end
+
+  it 'zeroes the duplicate top margin of a nested .top-element' do
+    stub_base_user(3)
+    visit collection_path(collection)
+
+    expect(page).to have_css('#donban')
+    nested_margin = page.evaluate_script(
+      "getComputedStyle(document.querySelector('#content.top-element .top-element')).marginTop"
+    )
+    expect(nested_margin).to eq('0px')
+  end
+
+  it 'leaves the spacing above the heading unchanged when no banner is shown' do
+    stub_base_user(1)
+    visit collection_path(collection)
+
+    expect(page).to have_no_css('#donban')
+    expect(gap_above_content).to be < 40
+  end
+end


### PR DESCRIPTION
Fixes #1019 (bead `beads_by-mt7`).

## The bug

The returning-visitor donation banner ("אנו שמחים שחזרתם לפרויקט בן־יהודה!") left a
tall band of blank space above the heading of the collection/work it was shown over.
The space only went away once the user dismissed the message.

## Root cause

`app/views/layouts/application.html.erb:254` sets an inline `margin-top` of
`header height + 25px` on **every** `.top-element`:

```js
$('.top-element').css('margin-top', h + 25);
```

The layout's own content container is `#content.container-fluid.top-element`, but
several views wrap their body in a *second* `.top-element` nested inside it
(`collections/show`, `taggings/tag_portal`, `lexicon/entries/list`,
`html_dirs/index`). That inner margin was invisible only because it collapsed into
the outer container's margin.

The donation banner is rendered just before `yield`, i.e. *between* the two — which
breaks the parent/first-child margin collapse, so the duplicate margin (~250px on a
1400px-wide desktop) became real blank space. Dismissing the banner sets
`display: none`, the banner stops generating a box, the collapse resumes, and the
gap vanishes — exactly the behaviour reported.

Measured on a collection page (banner shown, 1400x900): page content started at
`top=645` instead of `top=396`, i.e. 249px of blank space.

## The fix

Zero the top margin of nested `.top-element` containers in `application.scss`.
`!important` is required because the layout's JS sets the margin inline.

Only the outermost `.top-element` needs to clear the fixed header, so this is a
no-op when the banner is absent (verified: content top stays at 249px).

## Tests

New `spec/system/donation_banner_spacing_spec.rb` (js system spec) forces the
banner on and asserts:
- the gap between the banner's bottom and the first content card is < 40px,
- a nested `.top-element` computes to `margin-top: 0px`,
- spacing is unchanged when no banner is shown.

Verified the first two examples fail on `lexicon` without the CSS change (the
nested margin reads `248.95px`) and pass with it.

Ran:
```
bundle exec rspec spec/system/donation_banner_spacing_spec.rb \
  spec/system/collection_toc_navbar_width_spec.rb spec/system/collection_show_authorities_spec.rb \
  spec/system/collection_image_alignment_spec.rb spec/system/author_sidebar_overlap_spec.rb \
  spec/system/manifestation_scrollspy_spec.rb spec/system/donation_popup_stacking_spec.rb \
  spec/system/collection_selective_download_print_spec.rb spec/system/collection_volume_series_nav_spec.rb \
  spec/system/collection_show_orig_lang_spec.rb spec/system/collection_involved_authority_ui_update_spec.rb
# 30 examples, 0 failures
```
The full suite (40+ min) was **not** run.

## Known related issue, not fixed here

The chapters/TOC side nav (`#chapternav`) is rendered from the header partial inside
a zero-height row that overflows into the content area, so it does not move when the
banner pushes content down and ends up painted on top of the banner. That is the
second symptom in the issue comment; filed separately as bead `beads_by-kjk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)