### PR TITLE
minuses_to_makafim: turn a line-opening minus into an en dash (beads_by-l1h)

### DIFF
--- a/app/views/shared/_markdown_utils.html.haml
+++ b/app/views/shared/_markdown_utils.html.haml
@@ -35,6 +35,12 @@
       minuses_to_makafim: function() {
         var buf = $(element_id).val();
         var replaced = 0;
+        // A minus opening a line is a dialogue dash, not a makaf. The lookahead spares
+        // '---' and friends, which are markdown horizontal rules rather than punctuation.
+        buf = buf.replace(/^([ \t]*)(-|‑)(?![-‑])/gm, function(occurrence, leading_ws){
+          replaced += 1;
+          return leading_ws + '–';
+        });
         buf = buf.replace(/\S(-|‑)\S/g, function(occurrence){
           var latin = occurrence[0].match(/[A-Za-z]/i) || occurrence[2].match(/[A-Za-z]/i);
           var digits = occurrence[0].match(/[0-9]/) && occurrence[2].match(/[0-9]/);

--- a/spec/system/markdown_action_dropdown_spec.rb
+++ b/spec/system/markdown_action_dropdown_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe 'Markdown editing action dropdown', :js, type: :system do
     expect(selected_action).to eq('minuses_to_makafim')
   end
 
+  describe 'the makafim action' do
+    let(:markdown) { "- דיבור ראשון\n   ‑ דיבור שני\nמילה-מחוברת\n---\n" }
+
+    it 'turns a line-opening minus into an en dash, leaving rules and inner makafim alone' do
+      visit manifestation_edit_path(manifestation)
+      expect(page).to have_css('.js-markdown-action', wait: 5)
+
+      accept_alert do
+        apply_action(I18n.t(:minuses_to_makafim))
+      end
+
+      expect(find('#markdown').value).to eq("– דיבור ראשון\n   – דיבור שני\nמילה־מחוברת\n---\n")
+    end
+  end
+
   describe 'the centering action' do
     it 'wraps the whole caret line when nothing is selected' do
       visit manifestation_edit_path(manifestation)


### PR DESCRIPTION
## What

Adds a rule to the markdown editor's **minuses_to_makafim** action: when a line
begins with a minus (discounting leading whitespace), that minus becomes an en
dash `–` (U+2013) instead of being left alone.

Until now the action only matched minuses flanked by non-space characters
(`/\S(-|‑)\S/`), so a dialogue dash opening a line was never touched.

## Details

- Handles both `-` (U+002D) and `‑` (U+2011), same as the existing rule.
- Leading whitespace is preserved; only the dash itself is replaced.
- These replacements are counted into the existing "בוצעו N החלפות" tally.
- Lines whose leading dash is followed by another dash (`--`, `---`) are
  **skipped** — those are markdown horizontal rules, not punctuation, and
  rewriting them would produce `–--`.

## Caveat worth a reviewer's eye

A markdown bullet list written with `-` (e.g. `- item`) will have its bullet
turned into an en dash. That is inherent to the requested behavior; if the
corpus uses `-` bullets in markdown, the rule should be narrowed (e.g. only
when followed by a Hebrew letter).

## Test plan

New example in `spec/system/markdown_action_dropdown_spec.rb` ("the makafim
action") covering, in one buffer:

- `- דיבור ראשון` → `– דיבור ראשון` (dash at column 0)
- `   ‑ דיבור שני` → `   – דיבור שני` (indented, U+2011)
- `מילה-מחוברת` → `מילה־מחוברת` (inner minus still becomes a makaf)
- `---` left untouched

```
bundle exec rspec spec/system/markdown_action_dropdown_spec.rb
7 examples, 0 failures
```

The full suite was **not** run (40+ min); only the targeted spec above.
`rubocop` clean on the spec; the `ViewLength` haml-lint warning on
`_markdown_utils.html.haml` is pre-existing (124/100 before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)