### PR TITLE
Fix syntax error in author TOC action bar spec

### DIFF
--- a/spec/system/author_toc_action_bar_spec.rb
+++ b/spec/system/author_toc_action_bar_spec.rb
@@ -2,6 +2,43 @@
 
 require 'rails_helper'
 
+# Holds ManifestationController#snippets open at the server, so an example can assert on
+# the loading mask while a request is provably still in the air rather than racing it.
+#
+# The Capybara server runs in this process, so a stub set in an example reaches it -- but
+# on another thread, hence the handshake: the server thread announces itself and parks in
+# #hold, the example thread waits for that announcement with #await, and lets the action
+# through with #release.
+class SnippetsGate
+  def initialize(timeout)
+    @timeout = timeout
+    @arrivals = Queue.new
+    @mutex = Mutex.new
+    @cv = ConditionVariable.new
+    @released = false
+  end
+
+  # Server thread: announce this request and park until the example releases it. Falls
+  # through after `timeout` so a failing example cannot wedge the suite.
+  def hold
+    @arrivals << true
+    @mutex.synchronize { @cv.wait(@mutex, @timeout) unless @released }
+  end
+
+  # Example thread: block until a request has actually reached the held action.
+  def await
+    raise 'no snippets request reached the controller' if @arrivals.pop(timeout: @timeout).nil?
+  end
+
+  # Example thread: let every parked request, and any that follow, complete.
+  def release
+    @mutex.synchronize do
+      @released = true
+      @cv.broadcast
+    end
+  end
+end
+
 # The Authority TOC action bar carries different actions per view (bead r81):
 # the grouped (volumes) view gets Collapse all / Expand all, while the flat texts
 # list gets the list/summaries display switch. The summaries view fetches each
@@ -39,27 +76,14 @@ describe 'Author TOC action bar', :js do
     find("#sort_by option[value='#{value}']").select_option
   end
 
-  # Hold the snippets response back long enough for the loading mask to be
-  # observable (the Capybara server runs in this process, so the stub reaches it).
-  # `status` lets an example exercise the failure path.
-  #
-  # Returns a callable that releases the controller action once the example has
-  # observed the loading mask.
+  # Holds the snippets action open; see SnippetsGate. `status` lets an example
+  # exercise the failure path instead of the real response.
   def delay_snippets(status: nil, timeout: 10)
-    mutex = Mutex.new
-    cv = ConditionVariable.new
-    released = false
-
-    release = lambda do
-      mutex.synchronize do
-        released = true
-        cv.broadcast
-      end
-    end
+    gate = SnippetsGate.new(timeout)
 
     # rubocop:disable RSpec/AnyInstance -- the controller instance is the server's, not ours
     allow_any_instance_of(ManifestationController).to receive(:snippets).and_wrap_original do |orig, *args|
-      mutex.synchronize { cv.wait(mutex, timeout) unless released }
+      gate.hold
 
       if status.nil?
         orig.call(*args)
@@ -69,7 +93,7 @@ describe 'Author TOC action bar', :js do
     end
     # rubocop:enable RSpec/AnyInstance
 
-    release
+    gate
   end
 
   it 'swaps the collapse/expand buttons for the display switch in the flat list, and back' do
@@ -121,17 +145,23 @@ describe 'Author TOC action bar', :js do
   # The flat list is unpaginated, so fetching the excerpts of a prolific author can
   # take a couple of seconds with nothing on screen to show for it (bead 11x).
   it 'masks the page while the excerpts are being fetched, and unmasks once they are in' do
-    release_snippets = delay_snippets
+    snippets = delay_snippets
     visit authority_path(author)
     choose_sort('title')
     expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
 
     find('#tocmode_snippets').click
 
+    # With the request parked at the controller the page cannot move on, so the
+    # state below is what the reader is left looking at, not a moment we caught.
+    snippets.await
+
     expect(page).to have_css('#PopupMask')
     expect(page).to have_css('#spinnerdiv', visible: :visible)
+    # Nothing to read yet: that is precisely what the mask is there to cover.
+    expect(page).to have_no_css('.toc-snippet', visible: :all)
 
-    release_snippets.call
+    snippets.release
 
     expect(page).to have_css('.toc-snippet', count: 2, wait: 10)
     expect(page).to have_no_css('#PopupMask')
@@ -139,15 +169,18 @@ describe 'Author TOC action bar', :js do
   end
 
   it 'takes the mask down even when the excerpt request fails' do
-    release_snippets = delay_snippets(status: :internal_server_error)
+    snippets = delay_snippets(status: :internal_server_error)
     visit authority_path(author)
     choose_sort('title')
     expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
 
     find('#tocmode_snippets').click
-    expect(page).to have_css('#PopupMask')
+    snippets.await
 
-    release_snippets.call
+    expect(page).to have_css('#PopupMask')
+    expect(page).to have_css('#spinnerdiv', visible: :visible)
+
+    snippets.release
 
     # No excerpts to show, but the reader must not be left staring at a masked page.
     expect(page).to have_no_css('#PopupMask', wait: 10)

--- a/spec/system/author_toc_action_bar_spec.rb
+++ b/spec/system/author_toc_action_bar_spec.rb
@@ -46,8 +46,6 @@ describe 'Author TOC action bar', :js do
   # Returns a callable that releases the controller action once the example has
   # observed the loading mask.
   def delay_snippets(status: nil, timeout: 10)
-    require 'thread'
-
     mutex = Mutex.new
     cv = ConditionVariable.new
     released = false
@@ -72,8 +70,6 @@ describe 'Author TOC action bar', :js do
     # rubocop:enable RSpec/AnyInstance
 
     release
-  end
-    # rubocop:enable RSpec/AnyInstance
   end
 
   it 'swaps the collapse/expand buttons for the display switch in the flat list, and back' do
@@ -125,7 +121,7 @@ describe 'Author TOC action bar', :js do
   # The flat list is unpaginated, so fetching the excerpts of a prolific author can
   # take a couple of seconds with nothing on screen to show for it (bead 11x).
   it 'masks the page while the excerpts are being fetched, and unmasks once they are in' do
-    delay_snippets(1.5)
+    release_snippets = delay_snippets
     visit authority_path(author)
     choose_sort('title')
     expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
@@ -135,19 +131,23 @@ describe 'Author TOC action bar', :js do
     expect(page).to have_css('#PopupMask')
     expect(page).to have_css('#spinnerdiv', visible: :visible)
 
+    release_snippets.call
+
     expect(page).to have_css('.toc-snippet', count: 2, wait: 10)
     expect(page).to have_no_css('#PopupMask')
     expect(page).to have_css('#spinnerdiv', visible: :hidden)
   end
 
   it 'takes the mask down even when the excerpt request fails' do
-    delay_snippets(1.5, status: :internal_server_error)
+    release_snippets = delay_snippets(status: :internal_server_error)
     visit authority_path(author)
     choose_sort('title')
     expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
 
     find('#tocmode_snippets').click
     expect(page).to have_css('#PopupMask')
+
+    release_snippets.call
 
     # No excerpts to show, but the reader must not be left staring at a masked page.
     expect(page).to have_no_css('#PopupMask', wait: 10)


### PR DESCRIPTION
## The breakage

`spec/system/author_toc_action_bar_spec.rb` does not parse on `lexicon`:

```
$ ruby -c spec/system/author_toc_action_bar_spec.rb
spec/system/author_toc_action_bar_spec.rb:199: syntax error, unexpected `end' (SyntaxError)
```

PR #1562 (beads_by-11x) inserted the new `delay_snippets` helper but left two lines of an earlier version sitting behind it — a stray `# rubocop:enable RSpec/AnyInstance` comment and an `end` that closed the `describe` block early, orphaning the file's final `end`. Any full-suite run dies on loading this file.

## Second defect in the same commit

Once the file parses, the two examples #1562 added still cannot run: they call

```ruby
delay_snippets(1.5)
delay_snippets(1.5, status: :internal_server_error)
```

against `def delay_snippets(status: nil, timeout: 10)` — a positional argument the helper does not accept (`ArgumentError`). They also never called the release lambda the helper returns and documents, so the stubbed controller action would have sat blocked until its 10s condition-variable timeout.

## Second commit: the mask examples now prove the mask

With the file merely repaired, both mask examples still passed **with the delaying stub neutered** — they asserted `#PopupMask` immediately after the click, which the real (fast) request happened to satisfy. Neither would have caught the mask vanishing from the product code.

The fire-and-forget release lambda is replaced by a `SnippetsGate` the example shakes hands with: the server thread announces its arrival before parking, and `#await` blocks the example until a request has actually reached the held action. Everything asserted after that point is the state the reader is left in *while the fetch is outstanding* — the mask, the spinner, and the absence of any excerpt — rather than a moment the example managed to catch.

Verified by regressing the product code in `app/views/authors/_generated_toc.html.haml`:

| Regression | Old examples | New examples |
| --- | --- | --- |
| drop `startModal('spinnerdiv')` from `maskUp()` | passed | **both fail** on `#PopupMask` |
| batch handler `.always` → `.done` (failed batch leaves page masked) | — | **only the failure-path example fails**, on the mask never coming down |

Both regressions were reverted; the product code is untouched by this PR.

## Also

Dropped the redundant `require 'thread'` inside the same helper, which RuboCop flagged. The file now reports **no offenses**.

## Testing

```
$ bundle exec rspec spec/system/author_toc_action_bar_spec.rb
7 examples, 0 failures
```

(Chrome/WebDriver was available, so nothing was skipped.) A `ruby -c` sweep over all of `app/`, `lib/`, `config/` and `spec/` finds no other unparseable file.

Still not covered, and worth its own bead if you want it: the flip side of the masking rule — that batches fetched later, while *scrolling*, must **not** raise the mask. Exercising the non-eager path needs enough works to push rows past the observer's 400px margin, so it is a heavier example than these two rather than a tweak to them.

Closes beads_by-dmr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
