### PR TITLE
Always show authority credits alphabetically, and sort the manual credits column on save

### DIFF
--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -109,6 +109,9 @@ class Authority < ApplicationRecord
 
   before_save :update_other_designation, if: :name_changed?
   before_save :normalize_sort_name
+  before_save :sort_legacy_credits, if: :legacy_credits_changed?
+  # editing the manual credits changes the merged list, so the cache must go (cf. Collection)
+  before_save :clear_cached_credits, if: :legacy_credits_changed?
 
   after_commit :update_manifestation_responsibility_statements, on: :update, if: :saved_change_to_name?
   # covers create, update and destroy of a pageless authority, as well as the flag being turned off
@@ -165,6 +168,18 @@ class Authority < ApplicationRecord
     self.sort_name = sort_name.gsub(/[\u05BE\u002D\u2013\u2014]/, ' ')
   end
 
+  # Keep the manually-maintained credits alphabetically sorted, so they are easier to edit later
+  # (and so they match the order in which credits are displayed).
+  def sort_legacy_credits
+    return if legacy_credits.blank?
+
+    self.legacy_credits = self.class.sorted_credit_lines(legacy_credits.lines).join("\n")
+  end
+
+  def clear_cached_credits
+    self.cached_credits = nil
+  end
+
   # return all collections of type volume that are associated with this authority
   def volumes
     Collection.joins(:involved_authorities).where(collection_type: 'volume', involved_authorities: { authority_id: id })
@@ -200,19 +215,25 @@ class Authority < ApplicationRecord
     )
   end
 
-  def fetch_credits
-    return cached_credits if cached_credits.present?
+  # Clean up a list of raw credit lines: strip them, drop blanks and placeholders,
+  # de-duplicate, and sort alphabetically.
+  def self.sorted_credit_lines(lines)
+    lines.map(&:strip).reject { |line| line.blank? || line == '...' }.uniq.sort
+  end
 
+  def fetch_credits
+    # Sorting (and de-duplicating) on read too, so that credits cached before this behavior was
+    # introduced, or cached by some other code path, are still presented as one clean list.
+    return self.class.sorted_credit_lines(cached_credits.lines).join("\n") if cached_credits.present?
+
+    # manual credits and the ones harvested from the works are merged into a single list, so a
+    # volunteer listed in both appears only once
     credits = []
     credits += legacy_credits.lines if legacy_credits.present?
     published_manifestations.each do |m|
       credits += m.credits.lines if m.credits.present?
     end
-    credits.map!(&:strip)
-    credits.uniq!
-    credits.reject! { |c| c == '...' }
-    credits.sort!
-    self.cached_credits = credits.join("\n")
+    self.cached_credits = self.class.sorted_credit_lines(credits).join("\n")
     save!
     return cached_credits
   end

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -997,4 +997,53 @@ describe Authority do
       expect(result).not_to include(popular_non_featurable)
     end
   end
+
+  describe 'credits' do
+    let(:authority) { create(:authority, legacy_credits: legacy_credits) }
+    let(:legacy_credits) { nil }
+
+    describe '#fetch_credits' do
+      subject(:fetched_credits) { authority.fetch_credits.lines.map(&:strip) }
+
+      let(:legacy_credits) { "רינה רוזן\nגלי סנדיק" }
+
+      before do
+        create(:manifestation, author: authority, credits: "נורית רכס\nגלי סנדיק")
+        create(:manifestation, author: authority, credits: "אביבה שמר\n...\n\nשלומית אפל")
+      end
+
+      # 'גלי סנדיק' appears both in the manual credits and in a work's credits, and 'נורית רכס'
+      # appears in two different works
+      it 'merges manual and harvested credits into a sorted list with no repetitions' do
+        expect(fetched_credits).to eq ['אביבה שמר', 'גלי סנדיק', 'נורית רכס', 'רינה רוזן', 'שלומית אפל']
+      end
+
+      it 'sorts and dedups credits cached in an arbitrary order (e.g. cached by older code)' do
+        authority.update_column(:cached_credits, "נורית רכס\nאביבה שמר\nנורית רכס")
+        expect(fetched_credits).to eq ['אביבה שמר', 'נורית רכס']
+      end
+
+      it 'recomputes the credits when the manual credits are edited' do
+        expect(fetched_credits).to include 'רינה רוזן'
+        authority.update!(legacy_credits: 'גלי סנדיק')
+        expect(authority.fetch_credits.lines.map(&:strip)).not_to include 'רינה רוזן'
+      end
+    end
+
+    describe 'legacy_credits normalization on save' do
+      let(:legacy_credits) { " נורית רכס \nגלי סנדיק\n\nנורית רכס\nאביבה שמר" } # with a repeated name
+
+      it 'stores the manually-maintained credits sorted, stripped and deduplicated' do
+        expect(authority.reload.legacy_credits).to eq "אביבה שמר\nגלי סנדיק\nנורית רכס"
+      end
+
+      context 'when legacy_credits is blank' do
+        let(:legacy_credits) { nil }
+
+        it 'leaves it alone' do
+          expect(authority.reload.legacy_credits).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Credits shown on the author TOC page are now guaranteed to be alphabetical, deduplicated across all sources, and the manually-maintained credits column is kept sorted in the DB.

- `Authority.sorted_credit_lines` — one place that strips lines, drops blanks and `...` placeholders, de-duplicates and sorts.
- `Authority#fetch_credits` now normalizes on **read** as well as on write. Previously a `cached_credits` value written before sorting was introduced (May 2025, #500) short-circuited the method and was rendered in whatever order it had been cached in.
- Uniqueness is enforced over the **merged** list, so a volunteer named both in the manual credits and in a work's credits appears exactly once.
- New `before_save` on `Authority`: `legacy_credits` (the manual credits column edited in the author form) is stored stripped, deduplicated and alphabetically sorted, so it is easier to edit later; changing it clears `cached_credits` (mirrors what `Collection` already does for its `credits` column).

## Not touched

`Toc#credit_section` — the credits of the ~150 authorities still on a legacy TOC. That field is structured Markdown (headings such as `## הגיהו`, separators), so sorting its lines would mangle it. Say the word if those should be handled too.

## Test plan

New examples in `spec/models/authority_spec.rb` covering: merged sorted/deduplicated output, a cache stored out of order and with a repetition, recomputation after the manual credits are edited, and the on-save normalization of `legacy_credits` (including the blank case).

```
bundle exec rspec spec/models/authority_spec.rb spec/models/collection_spec.rb spec/controllers/authors_controller_spec.rb
# 273 examples, 0 failures, 1 pending (pre-existing)
```

RuboCop clean on both changed files (only pre-existing offenses remain). The full suite was **not** run — it takes 40+ minutes and needs the maintainer's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)