### PR TITLE
Collapse single-text volumes in a volume series' view (#1488)

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -673,6 +673,7 @@ class CollectionsController < ApplicationController
 
   def prep_for_show
     @htmls = []
+    @collapsed_texts = {} # collection_item id => the lone Manifestation its ToC would have listed
     counter = { value: 1 } # Use hash to maintain reference across recursive calls
     parent_authorities = @collection.involved_authorities.map { |ia| [ia.authority_id, ia.role] }
 
@@ -697,6 +698,11 @@ class CollectionsController < ApplicationController
         next unless (@collection.periodical? && ci.item.collection_type == 'periodical_issue') ||
                     (@collection.volume_series? && ci.item.collection_type == 'volume')
 
+        # A volume/issue whose whole ToC is a single text would list that text's title -- the very
+        # same title -- right under its own heading, so Collection#show collapses the two into one
+        # heading (see #1488). The ToC itself is still built, for the print and download variants.
+        sole_text = ci.item.sole_toc_manifestation
+        @collapsed_texts[ci.id] = sole_text if sole_text.present?
         html = ci.item.toc_html(url_builder: method(:url_for))
         @htmls << [ci.item.title, ci.involved_authorities_by_role('editor'), html, false,
                    ci.genre, counter[:value], ci, 0, [], nil] # nil for footnote (TOC items don't have footnotes)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -228,6 +228,26 @@ class Collection < ApplicationRecord
     end
   end
 
+  # A collection whose entire table of contents is a single text is displayed *collapsed*: the
+  # containing view shows one heading, linking straight to that text, instead of repeating the
+  # very same title as both the collection's heading and its one-item ToC. Returns that lone
+  # Manifestation, or nil when the ToC has anything else to show. Sub-collections holding nothing
+  # but that one text (e.g. volume -> series -> text) are collapsed away as well.
+  def sole_toc_manifestation
+    # mirror the items toc_html_item would actually render: paratexts and empty placeholders are skipped
+    items = collection_items.reject do |ci|
+      ci.paratext || (ci.item.nil? && ci.markdown.blank? && ci.alt_title.blank?)
+    end
+    return nil unless items.one?
+
+    ci = items.first
+    return nil if ci.item.nil? || !ci.public?
+    return ci.item.sole_toc_manifestation if ci.item.is_a?(Collection)
+    return nil unless ci.item_type == 'Manifestation'
+
+    ci.item
+  end
+
   # same genre-glyph markup used elsewhere in Collection#show for non-periodical/volume_series items
   def toc_html_genre_glyph(genre)
     helpers = ApplicationController.helpers

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -219,7 +219,9 @@
             %a{ name: "collitem_text_#{i}" }
             - card_attrs = { data: { item_id: ci.item_id, item_type: ci.item_type } }
             - card_attrs[:style] = "margin-right: #{nesting_level * 10}px;" if nesting_level > 0
-            - if html.nil? && ci.item_type == 'Collection'
+            -# a sub-collection whose whole ToC is a single text is collapsed into it: heading only (#1488)
+            - collapsed_text = @collapsed_texts[ci.id]
+            - if collapsed_text.present? || (html.nil? && ci.item_type == 'Collection')
               -# This is a sub-collection header - render with full detail
               -# Stable anchor (keyed by sub-collection id) so search results and deep links can jump here
               %a{ name: "collection_#{ci.item_id}" }
@@ -227,8 +229,10 @@
                 .by-card-header-v02
                   .by-icon-v02
                   .headline-1-v02
-                    - link = url_for_collection_item(ci)
-                    %span.by-icon-v02{title: textify_genre(genre)}= glyph_for_genre(genre)
+                    -# a collapsed heading takes over the link and genre glyph of the text it stands for
+                    - link = collapsed_text.present? ? url_for(collapsed_text) : url_for_collection_item(ci)
+                    - glyph_genre = collapsed_text.present? ? collapsed_text.genre : genre
+                    %span.by-icon-v02{title: textify_genre(glyph_genre)}= glyph_for_genre(glyph_genre)
                     - if link.present?
                       = link_to '‏' + title, link # RLM character to help with LTR elements in title. Fixes #664
                     - else

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -255,6 +255,34 @@ describe CollectionsController do
         end
       end
     end
+
+    context 'when a volume_series holds volumes of a single text each' do
+      subject! { get :show, params: { id: collection.id } }
+
+      let(:sole_text) { create(:manifestation, title: 'The Only Text') }
+      let(:one_text_volume) do
+        create(:collection, title: 'The Only Text', collection_type: 'volume', manifestations: [sole_text])
+      end
+      let(:multi_text_volume) do
+        create(:collection, title: 'A Fuller Volume', collection_type: 'volume',
+                            manifestations: create_list(:manifestation, 2))
+      end
+      let(:collection) do
+        create(:collection, collection_type: 'volume_series',
+                            included_collections: [one_text_volume, multi_text_volume])
+      end
+
+      it 'collapses the single-text volume, showing its title only once' do
+        card = Capybara.string(response.body).find(".proofable[data-item-id='#{one_text_volume.id}']")
+        expect(card).to have_link('The Only Text', href: manifestation_path(sole_text), count: 1)
+        expect(card).to have_no_css('.collection_toc')
+      end
+
+      it 'still lists the table of contents of a volume holding several texts' do
+        card = Capybara.string(response.body).find(".proofable[data-item-id='#{multi_text_volume.id}']")
+        expect(card).to have_css('.collection_toc li', count: 2)
+      end
+    end
   end
 
   describe '#show with search query parameter' do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1054,6 +1054,57 @@ expect(html).to include("by-icon-v02\" title=\"#{expected_genre_title}\">t</span
     end
   end
 
+  describe '#sole_toc_manifestation' do
+    let(:volume) { create(:collection, collection_type: :volume) }
+    let(:manifestation) { create(:manifestation) }
+
+    it 'returns the single text a one-item collection would list' do
+      create(:collection_item, collection: volume, item: manifestation, seqno: 1)
+      expect(volume.sole_toc_manifestation).to eq manifestation
+    end
+
+    it 'returns nil when the collection holds more than one text' do
+      create(:collection_item, collection: volume, item: manifestation, seqno: 1)
+      create(:collection_item, collection: volume, item: create(:manifestation), seqno: 2)
+      expect(volume.sole_toc_manifestation).to be_nil
+    end
+
+    it 'returns nil for an empty collection' do
+      expect(volume.sole_toc_manifestation).to be_nil
+    end
+
+    it 'ignores paratexts and empty placeholders, which the ToC skips anyway' do
+      create(:collection_item, collection: volume, item: manifestation, seqno: 1)
+      create(:collection_item, collection: volume, item: nil, markdown: 'a note', paratext: true, seqno: 2)
+      create(:collection_item, collection: volume, item: nil, alt_title: nil, markdown: nil, seqno: 3)
+      expect(volume.sole_toc_manifestation).to eq manifestation
+    end
+
+    it 'returns nil when a non-paratext note accompanies the text, since the ToC lists it too' do
+      create(:collection_item, collection: volume, item: manifestation, seqno: 1)
+      create(:collection_item, collection: volume, item: nil, markdown: 'see also: something else', seqno: 2)
+      expect(volume.sole_toc_manifestation).to be_nil
+    end
+
+    it 'looks through sub-collections that hold nothing but that one text' do
+      series = create(:collection, collection_type: :series)
+      create(:collection_item, collection: volume, item: series, seqno: 1)
+      create(:collection_item, collection: series, item: manifestation, seqno: 1)
+      expect(volume.sole_toc_manifestation).to eq manifestation
+    end
+
+    it 'returns nil when a sub-collection holds several texts' do
+      series = create(:collection, collection_type: :series, manifestations: create_list(:manifestation, 2))
+      create(:collection_item, collection: volume, item: series, seqno: 1)
+      expect(volume.sole_toc_manifestation).to be_nil
+    end
+
+    it 'returns nil when the single text is not published' do
+      create(:collection_item, collection: volume, item: create(:manifestation, status: :unpublished), seqno: 1)
+      expect(volume.sole_toc_manifestation).to be_nil
+    end
+  end
+
   describe '#invalidate_cached_credits!' do
     let(:collection) { create(:collection, collection_type: :volume) }
     let(:authority) { create(:authority) }


### PR DESCRIPTION
Fixes #1488.

## Problem

On `Collection#show` for a **volume_series** (סדרת כרכים), every child volume is rendered as a card headed by the volume's title, with that volume's table of contents below it. When a volume holds just one text — the common case for a series of novels — the ToC's single entry repeats the very same title right under the heading, so the collection title and the text title are shown twice (see the screenshot in the issue).

## Fix

Such a volume is now **collapsed into its text**, the same way a single-text collection is collapsed elsewhere in the site: one heading, which takes over the text's link (straight to `/read/:id`) and its genre glyph, and no one-entry ToC underneath.

- `Collection#sole_toc_manifestation` returns the lone Manifestation a collection's ToC would list, or `nil`. It mirrors what `toc_html_item` actually renders (paratexts and empty placeholders are skipped, since they aren't displayed either), and it looks through sub-collections that hold nothing but that one text (volume → series → text).
- The collapse is **skipped** whenever the ToC has anything else to show — several texts, an unpublished text, or an accompanying note (e.g. a "ראו גם" cross-reference) — so nothing that was on the page disappears.
- The collapse is applied in the view only. `@htmls` is unchanged, so the **print and download** variants of a collection produce byte-identical output (verified against a local volume series).

### Before / after (local dev, a volume holding one text)

```html
<!-- before -->
<div class="headline-1-v02"><a href="/collections/11189">‏מלחמה ושלום – אפילוגים ואחרית דבר</a></div>
<div class="by-card-content-v02 textcard"><div class="collection_toc"><ul><li>
  <span class="by-icon-v02" title="פרוזה">l</span>
  <a href="/read/3185">‏מלחמה ושלום – אפילוגים ואחרית דבר מאת לב טולסטוי</a>
</li></ul></div></div>

<!-- after -->
<div class="headline-1-v02">
  <span class="by-icon-v02" title="פרוזה">l</span>
  <a href="/read/3185">‏מלחמה ושלום – אפילוגים ואחרית דבר</a>
</div>
```

## Test plan

- New model specs for `Collection#sole_toc_manifestation` (8 examples): single text, several texts, empty, paratexts/placeholders ignored, non-paratext note present, nested sub-collection, multi-text sub-collection, unpublished text.
- New controller specs on `Collection#show` for a volume_series: the single-text volume's card collapses (title linked once to the text, no `.collection_toc`), while a multi-text volume keeps its full ToC. Verified the first one fails without the fix.
- Ran: `spec/models/collection_spec.rb`, `spec/controllers/collections_controller_spec.rb`, `spec/requests/collection_lex_citations_spec.rb`, `spec/requests/collection_show_ip_status_spec.rb`, `spec/requests/collection_items_spec.rb`, and the collection/periodical system specs (`periodical_toc_display`, `collection_volume_series_nav`, `collection_show_orig_lang`, `collection_show_authorities`, `periodical_navbar_prefix`, `collection_selective_download_print`) — all green.
- The full suite (40+ min) was **not** run; it needs your go-ahead.
- RuboCop and haml-lint: no new offenses on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)