### PR TITLE
Hide author-card genre chips when a non-genre TOC filter is active

### DIFF
--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -327,6 +327,17 @@
 
       function hasProps(d) { return d.featured || d.recommended || d.aboutness || d.tagging; }
 
+      // Is any section OTHER than genre narrowing the list? The author-card genre
+      // chips show a per-genre count of the author's whole oeuvre, so once another
+      // filter is in effect they no longer describe what the list is showing, and
+      // the card hides them (the pane's own genre facet, with live faceted counts,
+      // takes over). Genre-only filtering leaves the chips up, so they stay usable
+      // as toggles.
+      function otherSectionsActive(s) {
+        return !!(s.name || s.langs.length || s.translatedAny || s.chars.length ||
+                  s.fromYear != null || s.toYear != null);
+      }
+
       // Does a node match every active filter section, optionally excluding one section.
       function matches(d, s, exclude) {
         if (exclude !== 'name' && s.name && d.title.indexOf(s.name) === -1) { return false; }
@@ -396,7 +407,7 @@
         });
         updateCounts(state, all);
         // Keep the author-card genre chips in sync with the pane's genre facet.
-        if (window.syncGenreChips) { window.syncGenreChips(); }
+        if (window.syncGenreChips) { window.syncGenreChips(otherSectionsActive(state)); }
       }
 
       // A filter interaction can shrink the flat list dramatically, leaving a

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -233,7 +233,12 @@
     // Mirror the pane's genre facet on the chips: with no genre selected every
     // chip looks active (nothing is filtered out); once some genres are selected
     // only those chips stay active and the rest are struck through.
-    window.syncGenreChips = function() {
+    // The counts on the chips are for the author's whole oeuvre, so once a filter
+    // other than genre is narrowing the list they would contradict what is on
+    // screen: hide the whole list then, and let the pane's genre facet (whose
+    // counts are faceted against the other filters) speak for the genres.
+    window.syncGenreChips = function(otherFiltersActive) {
+      $('.author-works-by-type').toggle(!otherFiltersActive);
       var anyChecked = $('.toc-filter-genre:checked').length > 0;
       $('.genre-toggle').each(function() {
         var checked = $('#toc-filter-genre-' + $(this).data('genre')).prop('checked');

--- a/spec/system/author_toc_filters_spec.rb
+++ b/spec/system/author_toc_filters_spec.rb
@@ -126,6 +126,51 @@ describe 'Author TOC flat-list filters', :js do
     end
   end
 
+  # The chips count the author's whole oeuvre, so they contradict the list once
+  # something other than genre is filtering it.
+  it 'hides the author-card genre chips while a non-genre filter is active' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist')
+    expect(page).to have_css('.author-works-by-type', visible: :visible)
+
+    choose_sort('title')
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
+    # entering filter mode with nothing filtered leaves the chips alone
+    expect(page).to have_css('.author-works-by-type', visible: :visible)
+
+    # a genre-only filter keeps them up, so they remain usable as toggles
+    check 'toc-filter-genre-poetry'
+    within('#sorted_card') { expect(page).to have_no_content('Beta Story') }
+    expect(page).to have_css('.author-works-by-type', visible: :visible)
+
+    # any other section hides them
+    check 'toc-filter-translated'
+    expect(page).to have_css('.author-works-by-type', visible: :hidden)
+
+    # ...and clearing that section brings them back
+    uncheck 'toc-filter-translated'
+    expect(page).to have_css('.author-works-by-type', visible: :visible)
+
+    fill_in 'toc-filter-name', with: 'Alpha'
+    expect(page).to have_css('.author-works-by-type', visible: :hidden)
+
+    find('#toc-filter-reset').click
+    expect(page).to have_css('.author-works-by-type', visible: :visible)
+  end
+
+  it 'restores the genre chips when leaving filter mode for the grouped view' do
+    visit authority_path(author)
+    choose_sort('title')
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
+
+    check 'toc-filter-translated'
+    expect(page).to have_css('.author-works-by-type', visible: :hidden)
+
+    choose_sort('colls')
+    expect(page).to have_css('#toc_filters_pane', visible: :hidden)
+    expect(page).to have_css('.author-works-by-type', visible: :visible)
+  end
+
   it 'preserves active filters when switching between flat-list sort orders' do
     visit authority_path(author)
     choose_sort('title')


### PR DESCRIPTION
## What

In `Authority#toc`, the `.author-works-by-type` genre chip list is now hidden as soon as the flat-list filters pane is narrowing the list by anything **other than** genre.

## Why

The chip counts (`שירה (12)` etc.) are computed server-side from `cached_genre_stats` — they describe the author's whole oeuvre. Once a free-text / language / character / date-range filter is in effect, those numbers contradict the list on screen. The filters pane's own genre facet stays visible in that state and its counts *are* faceted against the other active filters, so nothing is lost.

Genre-only filtering deliberately keeps the chips visible: they are the shortcut into the pane's genre facet, and hiding them on a chip click would make them a one-way door (you could no longer click the same chip to un-toggle it).

## How

- `_generated_toc.html.haml`: new `otherSectionsActive(state)` helper; `apply()` passes it to `window.syncGenreChips()`.
- `toc.html.haml`: `syncGenreChips(otherFiltersActive)` toggles `.author-works-by-type` visibility. Called with no argument on page load (grouped view) → chips shown.

Leaving flat mode already routes through `TocFilters.reset()` → `apply()`, so the chips come back on their own when returning to the grouped view.

## Test plan

Two new examples in `spec/system/author_toc_filters_spec.rb`:
- chips stay up in the grouped view, on entering filter mode, and under a genre-only filter; hide under `translated` and under a free-text filter; reappear when that section is cleared and on `#toc-filter-reset`
- chips are restored when switching back to the grouped (`colls`) sort while a non-genre filter was active

Ran:
- `bundle exec rspec spec/system/author_toc_filters_spec.rb` → 14 examples, 0 failures
- `bundle exec rspec spec/system/author_toc_mobile_filter_spec.rb` → 7 examples, 0 failures
- `rubocop` clean on the spec; `haml-lint` reports only pre-existing offenses on the two views (none on changed lines)

The full suite was **not** run (40+ min); it needs a maintainer's go-ahead.

Closes beads_by-8u9

🤖 Generated with [Claude Code](https://claude.com/claude-code)