### PR TITLE
Prevent duplicate authors across the two homepage portrait carousels

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -16,7 +16,9 @@ class WelcomeController < ApplicationController
     @pop_authors = popular_authors
     @pop_authors_this_month = @pop_authors # Temporary hack! TODO: stop cheating and actually count by month
     # @newest_authors = cached_newest_authors # deprecated because we stopped producing portraits
-    @random_authors = Authority.published.has_image.featurable.order(Arel.sql('RAND()')).limit(10)
+    # exclude authors already shown in the most-popular carousel, to avoid duplication across the two carousels
+    @random_authors = Authority.published.has_image.featurable.where.not(id: @pop_authors.map(&:id))
+                               .order(Arel.sql('RAND()')).limit(10)
     @surprise_author = RandomAuthor.call
     @surprise_work = randomize_works(1)[0]
     @authors_in_genre = cached_authors_in_genre

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -36,6 +36,30 @@ describe WelcomeController do
         end
       end
     end
+
+    context 'when an authority appears in the most-popular authors carousel' do
+      render_views false
+
+      let!(:popular_authority) { create(:authority, :with_image) }
+      let!(:other_authorities) { create_list(:authority, 2, :with_image) }
+
+      before do
+        create_list(:ahoy_event, 3, :with_item, item: popular_authority, name: 'view')
+        get :index
+      end
+
+      it 'includes it in the most-popular authors carousel' do
+        expect(assigns(:pop_authors)).to include(popular_authority)
+      end
+
+      it 'excludes it from the random authors carousel' do
+        expect(assigns(:random_authors)).not_to include(popular_authority)
+      end
+
+      it 'still offers the remaining featurable authorities as random authors' do
+        expect(assigns(:random_authors)).to match_array(other_authorities)
+      end
+    end
   end
 
   describe '#featured_author_popup' do


### PR DESCRIPTION
Fixes #1534

## Problem

The homepage renders two author portrait carousels: **most-popular authors** and **random authors**. The random carousel drew from *all* published, featurable authorities with images, so an author could appear in both — including in the off-screen, scrollable portion of the popular carousel, which made the duplication easy to miss until you scrolled.

## Change

`app/controllers/welcome_controller.rb`: exclude the popular carousel's authority IDs from the random authors query.

```ruby
@random_authors = Authority.published.has_image.featurable.where.not(id: @pop_authors.map(&:id))
                           .order(Arel.sql('RAND()')).limit(10)
```

Exclusion is one-directional — the popular carousel keeps all its authors (its ranking is meaningful; the random one is arbitrary). If the featurable pool is small, the random carousel may render fewer than 10 entries.

This is the temporary measure the issue asks for; it becomes moot once the second carousel is narrowed to recently added authors.

## Test plan

Added three examples to `spec/controllers/welcome_controller_spec.rb`, driving real Ahoy `view` events so `Authority.popular_authors` is exercised end-to-end rather than stubbed:

- the viewed authority appears in `@pop_authors`
- it does **not** appear in `@random_authors`
- the remaining featurable authorities are still offered as random authors (guards against a vacuous pass)

Verified the new examples fail on the pre-fix controller (2 of 3 red) and pass with it.

```
bundle exec rspec spec/controllers/welcome_controller_spec.rb
# 19 examples, 0 failures
```

RuboCop is clean on the changed lines (remaining offenses in both files are pre-existing). The full suite was **not** run — it takes 40+ minutes and needs explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)