### PR TITLE
Match footnote bodies buffer-wide in the full-markdown panes

### DIFF
--- a/app/controllers/html_file_controller.rb
+++ b/app/controllers/html_file_controller.rb
@@ -129,8 +129,9 @@ class HtmlFileController < ApplicationController
       @html = MultiMarkdown.new(@markdown.gsub(/^&&& (.*)/, '<hr style="border-color:#2b0d22;border-width:20px;margin-top:40px"/><h1>\1</h1>')).to_html.force_encoding('UTF-8') # TODO: figure out why to_html defaults to ASCII 8-bit
     end
     @html = highlight_suspicious_markdown(@html)
-    # split works are ingested separately, so each '&&&' part is its own footnote namespace
-    @footnote_discrepancies = DetectFootnoteDiscrepancies.call(@markdown, split_on_sections: true)
+    # a body may sit in any '&&&' section: split_parts only moves it to the work it belongs
+    # to when the file is split
+    @footnote_discrepancies = DetectFootnoteDiscrepancies.call(@markdown)
   end
 
   def edit

--- a/app/controllers/ingestibles_controller.rb
+++ b/app/controllers/ingestibles_controller.rb
@@ -421,8 +421,9 @@ end
     @html = ''
     @disable_submit = false
     @markdown_titles = []
-    # each '&&&' section becomes a work of its own on ingestion, so footnotes may not cross one
-    @footnote_discrepancies = DetectFootnoteDiscrepancies.call(@ingestible.markdown, split_on_sections: true)
+    # a body may sit in any '&&&' section: relocate_footnotes only moves it to the work it
+    # belongs to when the buffer is split into texts
+    @footnote_discrepancies = DetectFootnoteDiscrepancies.call(@ingestible.markdown)
     return if @ingestible.works_buffer.blank?
 
     sections = JSON.parse(@ingestible.works_buffer)

--- a/app/services/detect_footnote_discrepancies.rb
+++ b/app/services/detect_footnote_discrepancies.rb
@@ -10,68 +10,57 @@ class DetectFootnoteDiscrepancies < ApplicationService
   # MMD tolerates up to three leading spaces before a block-level marker.
   BODY_MARKER = /\A {0,3}\[\^([^\]\n]+)\]:/
   REFERENCE = /\[\^([^\]\n]+)\]/
-  # Both the ingestible full-markdown buffer and legacy HtmlFile markdown pack several
-  # works into one textarea, separated by these lines. Each work becomes its own document
-  # on ingestion, so footnotes may not cross a separator.
+  # Both the ingestible full-markdown buffer and legacy HtmlFile markdown pack several works
+  # into one textarea, separated by these lines. A body is NOT required to sit in the same
+  # section as its reference: the docx conversion piles every footnote body at the very
+  # bottom of the buffer, and Ingestible#relocate_footnotes (HtmlFile#split_parts for the
+  # legacy path) only distributes them among the works when the buffer is split. So the
+  # section is recorded to say where an orphan is, never to decide whether it is one.
   SECTION_SEPARATOR = /\A&&&\s+(.*)/
 
   # @param markdown [String] the markdown to scan
-  # @param split_on_sections [Boolean] treat '&&& title' lines as separate footnote namespaces
   # @return [Hash] :orphan_references and :orphan_bodies, each an array of
   #   { id:, lines: [Integer], section: String or nil }, ordered by first appearance
-  def call(markdown, split_on_sections: false)
-    orphan_references = []
-    orphan_bodies = []
+  def call(markdown)
+    references, bodies = scan(markdown.to_s)
+    # sets, not arrays: a text can carry hundreds of footnotes, and this runs on every
+    # render of an editing screen
+    body_ids = bodies.to_set { |entry| entry[:id] }
+    reference_ids = references.to_set { |entry| entry[:id] }
 
-    sections(markdown.to_s, split_on_sections).each do |section|
-      references, bodies = scan(section)
-      # sets, not arrays: a text can carry hundreds of footnotes, and this runs on every
-      # render of an editing screen
-      body_ids = bodies.to_set { |entry| entry[:id] }
-      reference_ids = references.to_set { |entry| entry[:id] }
-      orphan_references.concat(references.reject { |entry| body_ids.include?(entry[:id]) })
-      orphan_bodies.concat(bodies.reject { |entry| reference_ids.include?(entry[:id]) })
-    end
-
-    { orphan_references: group(orphan_references), orphan_bodies: group(orphan_bodies) }
+    { orphan_references: group(references.reject { |entry| body_ids.include?(entry[:id]) }),
+      orphan_bodies: group(bodies.reject { |entry| reference_ids.include?(entry[:id]) }) }
   end
 
   private
 
-  # Splits the markdown into [title, lines-with-1-based-numbers] pairs. Without
-  # split_on_sections there is a single nameless section spanning the whole buffer.
-  def sections(markdown, split_on_sections)
-    numbered = markdown.lines.each_with_index.map { |line, index| [line, index + 1] }
-    return [{ title: nil, lines: numbered }] unless split_on_sections
-
-    result = [{ title: nil, lines: [] }]
-    numbered.each do |line, number|
-      match = SECTION_SEPARATOR.match(line)
-      if match
-        result << { title: match[1].strip, lines: [] }
-      else
-        result.last[:lines] << [line, number]
-      end
-    end
-    result.reject { |section| section[:lines].empty? }
-  end
-
-  # Collects every reference and every body in one section. A body line may itself contain
-  # references after its marker, so the marker is consumed before scanning the remainder.
-  def scan(section)
+  # Collects every reference and every body, tagged with the '&&&' section it falls in (nil
+  # for a buffer holding a single work) and its 1-based line number in the whole buffer. A
+  # body line may itself contain references after its marker, so the marker is consumed
+  # before scanning the remainder.
+  def scan(markdown)
     references = []
     bodies = []
-    section[:lines].each do |line, number|
+    section = nil
+
+    markdown.lines.each_with_index do |line, index|
+      separator = SECTION_SEPARATOR.match(line)
+      if separator
+        section = separator[1].strip
+        next
+      end
+
       rest = line
       body_match = BODY_MARKER.match(line)
       if body_match
-        bodies << { id: body_match[1], line: number, section: section[:title] }
+        bodies << { id: body_match[1], line: index + 1, section: section }
         rest = body_match.post_match
       end
       rest.scan(REFERENCE) do |(id)|
-        references << { id: id, line: number, section: section[:title] }
+        references << { id: id, line: index + 1, section: section }
       end
     end
+
     [references, bodies]
   end
 

--- a/spec/controllers/footnote_discrepancies_spec.rb
+++ b/spec/controllers/footnote_discrepancies_spec.rb
@@ -51,12 +51,10 @@ describe 'footnote discrepancy scanning on the markdown-editing screens' do
     context 'with works separated by &&&' do
       let(:markdown) { "&&& ראשונה\nטקסט[^1]\n\n&&& שנייה\n[^1]: גוף ההערה\n" }
 
-      it 'does not match footnotes across the separator' do
+      # split_parts piles the bodies at the bottom until the file is actually split
+      it 'matches footnotes across the separator' do
         get :edit_markdown, params: { id: html_file.id }
-        expect(assigns(:footnote_discrepancies)).to eq(
-          orphan_references: [{ id: '1', lines: [2], section: 'ראשונה' }],
-          orphan_bodies: [{ id: '1', lines: [5], section: 'שנייה' }]
-        )
+        expect(assigns(:footnote_discrepancies)).to eq(orphan_references: [], orphan_bodies: [])
       end
     end
   end
@@ -64,16 +62,26 @@ describe 'footnote discrepancy scanning on the markdown-editing screens' do
   describe IngestiblesController do
     include_context 'when editor logged in', :edit_catalog
 
-    let!(:ingestible) do
-      create(:ingestible, :with_buffers, markdown: "&&& ראשונה\nטקסט[^1]\n\n&&& שנייה\n[^1]: גוף ההערה\n")
+    let(:markdown) { "&&& ראשונה\nטקסט[^1]\n\n&&& שנייה\n[^1]: גוף ההערה\n" }
+    let!(:ingestible) { create(:ingestible, :with_buffers, markdown: markdown) }
+
+    # the docx conversion leaves every body at the bottom of the buffer, so the full-markdown
+    # pane must accept a body sitting in a later work than its reference
+    it 'accepts a body anywhere in the buffer' do
+      get :edit, params: { id: ingestible.id }
+      expect(assigns(:footnote_discrepancies)).to eq(orphan_references: [], orphan_bodies: [])
     end
 
-    it 'scans the full markdown, per &&& section' do
-      get :edit, params: { id: ingestible.id }
-      expect(assigns(:footnote_discrepancies)).to eq(
-        orphan_references: [{ id: '1', lines: [2], section: 'ראשונה' }],
-        orphan_bodies: [{ id: '1', lines: [5], section: 'שנייה' }]
-      )
+    context 'when a footnote really has no counterpart' do
+      let(:markdown) { "&&& ראשונה\nטקסט[^1]\n\n&&& שנייה\n[^2]: גוף ההערה\n" }
+
+      it 'names the work each orphan sits in' do
+        get :edit, params: { id: ingestible.id }
+        expect(assigns(:footnote_discrepancies)).to eq(
+          orphan_references: [{ id: '1', lines: [2], section: 'ראשונה' }],
+          orphan_bodies: [{ id: '2', lines: [5], section: 'שנייה' }]
+        )
+      end
     end
 
     it 'scans the text shown in the texts tab' do

--- a/spec/services/detect_footnote_discrepancies_spec.rb
+++ b/spec/services/detect_footnote_discrepancies_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 describe DetectFootnoteDiscrepancies do
-  subject(:result) { described_class.call(markdown, **options) }
-
-  let(:options) { {} }
+  subject(:result) { described_class.call(markdown) }
 
   describe 'markdown with matching footnotes' do
     let(:markdown) { "טקסט עם הערה[^1] ועוד אחת[^2]\n\n[^1]: גוף ההערה\n[^2]: גוף ההערה השנייה\n" }
@@ -93,15 +91,16 @@ describe DetectFootnoteDiscrepancies do
     end
   end
 
+  # The docx conversion leaves every footnote body at the bottom of the buffer; the bodies
+  # are only moved into the work they belong to when the buffer is split into texts. So a
+  # reference in one '&&&' section is satisfied by a body in another.
   describe 'markdown split into works by &&& separators' do
-    let(:options) { { split_on_sections: true } }
     let(:markdown) do
       "&&& יצירה ראשונה\nטקסט[^1]\n\n&&& יצירה שנייה\nטקסט אחר\n\n[^1]: גוף ההערה\n"
     end
 
-    it 'does not let a reference match a body in another work' do
-      expect(result[:orphan_references]).to eq([{ id: '1', lines: [2], section: 'יצירה ראשונה' }])
-      expect(result[:orphan_bodies]).to eq([{ id: '1', lines: [7], section: 'יצירה שנייה' }])
+    it 'lets a reference match a body in another work' do
+      expect(result).to eq(orphan_references: [], orphan_bodies: [])
     end
 
     context 'when reference and body sit in the same work' do
@@ -112,21 +111,31 @@ describe DetectFootnoteDiscrepancies do
       end
     end
 
-    context 'when the same markdown is scanned as a single document' do
-      let(:options) { { split_on_sections: false } }
+    context 'when a footnote is genuinely missing its counterpart' do
       let(:markdown) do
-        "&&& יצירה ראשונה\nטקסט[^1]\n\n&&& יצירה שנייה\nטקסט אחר\n\n[^1]: גוף ההערה\n"
+        "&&& יצירה ראשונה\nטקסט[^1]\n\n&&& יצירה שנייה\nטקסט אחר\n\n[^2]: גוף ההערה\n"
       end
 
-      it 'matches across the separators' do
-        expect(result).to eq(orphan_references: [], orphan_bodies: [])
+      it 'names the work each orphan sits in' do
+        expect(result[:orphan_references]).to eq([{ id: '1', lines: [2], section: 'יצירה ראשונה' }])
+        expect(result[:orphan_bodies]).to eq([{ id: '2', lines: [7], section: 'יצירה שנייה' }])
+      end
+    end
+
+    context 'when the same identifier is orphaned in two works' do
+      let(:markdown) { "&&& ראשונה\nטקסט[^1]\n\n&&& שנייה\nטקסט אחר[^1]\n" }
+
+      it 'reports it once per work, so each can be located' do
+        expect(result[:orphan_references]).to eq(
+          [{ id: '1', lines: [2], section: 'ראשונה' }, { id: '1', lines: [5], section: 'שנייה' }]
+        )
       end
     end
 
     context 'when text precedes the first separator' do
       let(:markdown) { "פתיח[^1]\n\n&&& יצירה ראשונה\nטקסט\n" }
 
-      it 'scans that leading text as its own untitled section' do
+      it 'leaves that leading text unlabelled' do
         expect(result[:orphan_references]).to eq([{ id: '1', lines: [1], section: nil }])
       end
     end


### PR DESCRIPTION
Follow-up to #1572.

## The problem

In an Ingestible holding several works, the docx conversion piles **every** footnote body at the very bottom of the buffer — i.e. inside the last `&&&` section. `Ingestible#relocate_footnotes` only distributes them to the work each belongs to when the buffer is split into `IngestibleText`s (its own comment: *"any footnotes are **only** in the last piece, even if they belong in earlier pieces"*).

Scanning the full-markdown pane per `&&&` section therefore reported, on a perfectly good text, every earlier work's references as orphaned **and** every body at the bottom as orphaned — i.e. the indicator fired on essentially every multi-work ingestible.

`HtmlFile#split_parts` is a near-verbatim copy of the same relocation logic, so the legacy `html_file` markdown-editing screen had the identical false positives; it is fixed here too.

## The fix

A footnote body is now accepted **anywhere in the buffer**. The `&&&` section is still recorded and still shown ("in section X"), but only to say *where* an orphan sits — never to decide *whether* it is one.

That leaves `split_on_sections:` with no callers, so it and the whole section-splitting pass are gone: `DetectFootnoteDiscrepancies` now makes a single line-by-line pass carrying a running section label. Net −13 lines in the service.

Unaffected: the per-text screens (manifestation, ingestible texts tab, `ingestible_texts#edit`). Those scan a single text whose footnotes have already been relocated, and contain no `&&&` separators, so their behaviour is unchanged.

## Test plan

- `spec/services/detect_footnote_discrepancies_spec.rb` — the sectioning block reworked: a reference matching a body in a *later* work now reports nothing; a genuinely missing counterpart is still reported and still named with its work; a new case covers the same id orphaned in two works (reported once per work, so each can be located).
- `spec/controllers/footnote_discrepancies_spec.rb` — the `HtmlFile` and `Ingestible` `&&&` cases assert the buffer-wide match, plus a new case asserting real orphans are still labelled by work.
- Relevant suites run green: service + controller (23 examples), `spec/system/footnote_discrepancies_spec.rb` (9), `ingestibles_controller` / `html_file_controller` / `ingestible` model (133). RuboCop clean on the changed files.

Closes by-1cw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
