### PR TITLE
Wrap the latest-works pane title on lexicon entry pages

### DIFF
--- a/app/assets/stylesheets/lexicon.scss
+++ b/app/assets/stylesheets/lexicon.scss
@@ -178,3 +178,12 @@ ul.lex {
     background-color: transparent;
   }
 }
+
+/* The latest-works pane title is longer than the entry sidebar is wide, and the base
+   `.headline-2-v02` rule (BY_styles_General.css) truncates it with an ellipsis. In this
+   pane, let it wrap onto as many lines as it needs. */
+.author-whats-new-content p.headline-2-v02 {
+  text-wrap: wrap;
+  overflow: visible;
+  text-overflow: clip;
+}

--- a/app/assets/stylesheets/lexicon.scss
+++ b/app/assets/stylesheets/lexicon.scss
@@ -183,7 +183,7 @@ ul.lex {
    `.headline-2-v02` rule (BY_styles_General.css) truncates it with an ellipsis. In this
    pane, let it wrap onto as many lines as it needs. */
 .author-whats-new-content p.headline-2-v02 {
-  text-wrap: wrap;
+  white-space: normal; /* countermands the base rule's `text-wrap: nowrap` */
   overflow: visible;
   text-overflow: clip;
 }

--- a/spec/system/lexicon/latest_works_pane_title_spec.rb
+++ b/spec/system/lexicon/latest_works_pane_title_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The "latest works by this author" pane on a public lexicon entry has a title long enough to
+# overflow the narrow entry sidebar. `.headline-2-v02` truncates with an ellipsis by default,
+# which cut the title off; it must wrap onto a second line instead.
+RSpec.describe 'Latest-works pane title', :js, type: :system do
+  let(:authority) { create(:authority, status: :published) }
+  let(:person) { create(:lex_person, authority: authority) }
+  let!(:entry) { create(:lex_entry, :person, title: 'Test Person', lex_item: person, status: :published) }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    visit lexicon_entry_path(entry)
+  end
+
+  it 'wraps the pane title rather than clipping it' do
+    expect(page).to have_css('.author-whats-new-content p.headline-2-v02')
+
+    metrics = page.evaluate_script(<<~JS)
+      (function() {
+        var el = document.querySelector('.author-whats-new-content p.headline-2-v02');
+        var style = window.getComputedStyle(el);
+        return {
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          whiteSpace: style.whiteSpace,
+          textOverflow: style.textOverflow
+        };
+      })()
+    JS
+
+    expect(metrics['whiteSpace']).not_to eq 'nowrap'
+    expect(metrics['textOverflow']).not_to eq 'ellipsis'
+    # the whole title fits horizontally: nothing is cut off
+    expect(metrics['scrollWidth']).to be <= metrics['clientWidth'] + 1
+  end
+end

--- a/spec/system/lexicon/latest_works_pane_title_spec.rb
+++ b/spec/system/lexicon/latest_works_pane_title_spec.rb
@@ -16,11 +16,12 @@ RSpec.describe 'Latest-works pane title', :js, type: :system do
   end
 
   it 'wraps the pane title rather than clipping it' do
-    expect(page).to have_css('.author-whats-new-content p.headline-2-v02')
+    # located through Capybara, so a markup change fails with a clear "expected to find css" error
+    # rather than a null dereference inside the script below
+    title = find('.author-whats-new-content p.headline-2-v02')
 
-    metrics = page.evaluate_script(<<~JS)
-      (function() {
-        var el = document.querySelector('.author-whats-new-content p.headline-2-v02');
+    metrics = page.evaluate_script(<<~JS, title)
+      (function(el) {
         var style = window.getComputedStyle(el);
         return {
           scrollWidth: el.scrollWidth,
@@ -28,7 +29,7 @@ RSpec.describe 'Latest-works pane title', :js, type: :system do
           whiteSpace: style.whiteSpace,
           textOverflow: style.textOverflow
         };
-      })()
+      })(arguments[0])
     JS
 
     expect(metrics['whiteSpace']).not_to eq 'nowrap'


### PR DESCRIPTION
## Problem

On the public lexicon entry page, the sidebar pane listing the author's latest uploaded works had its title clipped: `.headline-2-v02` (BY_styles_General.css) sets `text-wrap: nowrap; overflow: hidden; text-overflow: ellipsis`, and the title is longer than the sidebar is wide, so it rendered as `יצירותיו האחרונות שראו א…`.

## Fix

`app/assets/stylesheets/lexicon.scss`: allow the title to wrap in that pane only, scoped to `.author-whats-new-content` (a class used solely by the lexicon entry sidebar), so the author TOC page and every other `.headline-2-v02` keep their existing ellipsis behaviour.

## Test plan

- New system spec `spec/system/lexicon/latest_works_pane_title_spec.rb` asserts the title element does not compute to `white-space: nowrap` / `text-overflow: ellipsis` and that its `scrollWidth` fits within its `clientWidth` (nothing cut off). Verified it fails on the pre-fix CSS and passes after.
- Also ran `spec/system/lexicon/bio_image_float_spec.rb`, `entry_navbar_sticky_offset_spec.rb`, `citation_text_links_spec.rb` (same page) — 8 examples, 0 failures.
- Full suite not run (40+ min, needs your approval).

Closes beads_by-e7m

🤖 Generated with [Claude Code](https://claude.com/claude-code)