### PR TITLE
Normalize line endings before scanning for footnote discrepancies

### DIFF
--- a/app/services/detect_footnote_discrepancies.rb
+++ b/app/services/detect_footnote_discrepancies.rb
@@ -17,12 +17,19 @@ class DetectFootnoteDiscrepancies < ApplicationService
   # legacy path) only distributes them among the works when the buffer is split. So the
   # section is recorded to say where an orphan is, never to decide whether it is one.
   SECTION_SEPARATOR = /\A&&&\s+(.*)/
+  # Markdown reaching us from legacy files and from pastes can carry CRLF or bare-CR line
+  # endings. String#lines only splits on LF, so a bare-CR buffer would look like a single
+  # line: nothing would match the anchored BODY_MARKER and every reference in the text would
+  # be reported as orphaned, even though MultiMarkdown normalizes the endings and renders the
+  # footnotes fine. Normalizing also keeps the reported line numbers in step with the textarea
+  # the report links into, since the browser presents a bare-CR value as LF-separated lines.
+  LINE_ENDING = /\r\n?/
 
   # @param markdown [String] the markdown to scan
   # @return [Hash] :orphan_references and :orphan_bodies, each an array of
   #   { id:, lines: [Integer], section: String or nil }, ordered by first appearance
   def call(markdown)
-    references, bodies = scan(markdown.to_s)
+    references, bodies = scan(markdown.to_s.gsub(LINE_ENDING, "\n"))
     # sets, not arrays: a text can carry hundreds of footnotes, and this runs on every
     # render of an editing screen
     body_ids = bodies.to_set { |entry| entry[:id] }

--- a/app/services/detect_footnote_discrepancies.rb
+++ b/app/services/detect_footnote_discrepancies.rb
@@ -29,7 +29,7 @@ class DetectFootnoteDiscrepancies < ApplicationService
   # @return [Hash] :orphan_references and :orphan_bodies, each an array of
   #   { id:, lines: [Integer], section: String or nil }, ordered by first appearance
   def call(markdown)
-    references, bodies = scan(markdown.to_s.gsub(LINE_ENDING, "\n"))
+    references, bodies = scan(normalize_line_endings(markdown.to_s))
     # sets, not arrays: a text can carry hundreds of footnotes, and this runs on every
     # render of an editing screen
     body_ids = bodies.to_set { |entry| entry[:id] }
@@ -40,6 +40,13 @@ class DetectFootnoteDiscrepancies < ApplicationService
   end
 
   private
+
+  # Rewriting the buffer is skipped when there is nothing to rewrite: this runs on every
+  # render of an editing screen, where the buffer is usually LF-only already and large enough
+  # (a few hundred KB) for a needless full-string copy to cost several milliseconds.
+  def normalize_line_endings(markdown)
+    markdown.include?("\r") ? markdown.gsub(LINE_ENDING, "\n") : markdown
+  end
 
   # Collects every reference and every body, tagged with the '&&&' section it falls in (nil
   # for a buffer holding a single work) and its 1-based line number in the whole buffer. A

--- a/spec/services/detect_footnote_discrepancies_spec.rb
+++ b/spec/services/detect_footnote_discrepancies_spec.rb
@@ -83,6 +83,38 @@ describe DetectFootnoteDiscrepancies do
     end
   end
 
+  # Legacy files and pastes reach us with foreign line endings. MultiMarkdown normalizes them
+  # and renders the footnotes fine, and the browser shows the buffer as ordinary lines, so a
+  # scan that only knows about LF would raise an alarm about a text that is perfectly correct.
+  describe 'markdown with CRLF line endings' do
+    let(:markdown) { "טקסט עם הערה[^1] ועוד אחת[^2]\r\n\r\n[^1]: גוף ההערה\r\n" }
+
+    it 'recognises the bodies and numbers the lines as the editor sees them' do
+      expect(result[:orphan_references]).to eq([{ id: '2', lines: [1], section: nil }])
+      expect(result[:orphan_bodies]).to eq([])
+    end
+  end
+
+  describe 'markdown with bare CR line endings' do
+    let(:markdown) { "טקסט עם הערה[^1] ועוד אחת[^2]\r\r[^1]: גוף ההערה\r[^7]: גוף יתום\r" }
+
+    it 'recognises the bodies and numbers the lines as the editor sees them' do
+      expect(result[:orphan_references]).to eq([{ id: '2', lines: [1], section: nil }])
+      expect(result[:orphan_bodies]).to eq([{ id: '7', lines: [4], section: nil }])
+    end
+
+    context 'with &&& separators' do
+      let(:markdown) { "&&& יצירה ראשונה\rטקסט[^1]\r\r&&& יצירה שנייה\rטקסט אחר[^2]\r" }
+
+      it 'still splits the buffer into works' do
+        expect(result[:orphan_references]).to eq(
+          [{ id: '1', lines: [2], section: 'יצירה ראשונה' },
+           { id: '2', lines: [5], section: 'יצירה שנייה' }]
+        )
+      end
+    end
+  end
+
   describe 'blank markdown' do
     let(:markdown) { nil }
 


### PR DESCRIPTION
## Problem

A markdown buffer reported hundreds of "footnote body missing" rows — including for `[^1]` and `[^255]` — even though every one of those bodies is present in the text.

`DetectFootnoteDiscrepancies` splits the buffer with `String#lines`, which splits **only on LF**. `BODY_MARKER` is anchored (`/\A {0,3}\[\^([^\]\n]+)\]:/`), so on a buffer with old-Mac bare-`\r` line endings the whole thing is one "line": **zero bodies are found and every single reference is reported as orphaned**.

Nothing else in the pipeline cares about the endings, which is what makes the report look like pure noise:

- MultiMarkdown normalizes bare CR before rendering, so the preview shows the footnotes correctly.
- The browser normalizes a bare-CR value to LF in the textarea, so the buffer *looks* like ordinary lines on screen.

Reproduced on a 314K-character real-world buffer:

| line endings | orphan refs | orphan bodies | reports `[^1]`? | reports `[^255]`? |
|---|---|---|---|---|
| LF | 144 | 17 | no | no |
| CRLF | 144 | 17 | no | no |
| bare CR | **959** | **0** | **yes** | **yes** |

(The 144/17 are genuine orphans in that text.)

## Fix

Fold `\r\n` and bare `\r` to `\n` before scanning. This also puts the reported line numbers back in step with the textarea the report links into, since the browser presents a bare-CR value as LF-separated lines — so the "jump to line" links land in the right place.

After the fix all three variants of the same buffer produce identical results.

## Test plan

- New service specs for CRLF, bare CR, and bare CR combined with `&&&` section separators (asserting both the pairing and the line numbers).
- `bundle exec rspec spec/services/detect_footnote_discrepancies_spec.rb` — 18 examples, 0 failures.
- `bundle exec rspec spec/controllers/footnote_discrepancies_spec.rb spec/system/footnote_discrepancies_spec.rb` — 17 examples, 0 failures.
- Full suite: **2271 examples, 0 failures, 14 pending** (pending are pre-existing and unrelated).
- RuboCop clean on both changed files.

Fixes by-61g.

🤖 Generated with [Claude Code](https://claude.com/claude-code)