### PR TITLE
Wrap the latest-works pane title in the Authority TOC as well

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1504,6 +1504,16 @@ p.by-genre-name-v02.headline-2-v02 {
 	}
 }
 
+/* The latest-works pane (shared/_latest_works_by_author) has a title longer than the
+   sidebar it sits in is wide, and the base `.headline-2-v02` rule (BY_styles_General.css)
+   truncates it with an ellipsis. In this pane -- on the Authority TOC and on public
+   lexicon entries alike -- let it wrap onto as many lines as it needs. */
+#author-whats-new-bg p.headline-2-v02 {
+  white-space: normal; /* countermands the base rule's `text-wrap: nowrap` */
+  overflow: visible;
+  text-overflow: clip;
+}
+
 /* Sticky navbar for lexicon entries.
  * --lexicon-sticky-top is measured from the fixed #header at runtime (see
  * lexicon/entries/_navbar), because the header's height varies: the entry

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1509,7 +1509,8 @@ p.by-genre-name-v02.headline-2-v02 {
    truncates it with an ellipsis. In this pane -- on the Authority TOC and on public
    lexicon entries alike -- let it wrap onto as many lines as it needs. */
 #author-whats-new-bg p.headline-2-v02 {
-  white-space: normal; /* countermands the base rule's `text-wrap: nowrap` */
+  text-wrap: wrap; /* overrides the base rule's `text-wrap: nowrap` */
+  white-space: normal;
   overflow: visible;
   text-overflow: clip;
 }

--- a/app/assets/stylesheets/lexicon.scss
+++ b/app/assets/stylesheets/lexicon.scss
@@ -178,12 +178,3 @@ ul.lex {
     background-color: transparent;
   }
 }
-
-/* The latest-works pane title is longer than the entry sidebar is wide, and the base
-   `.headline-2-v02` rule (BY_styles_General.css) truncates it with an ellipsis. In this
-   pane, let it wrap onto as many lines as it needs. */
-.author-whats-new-content p.headline-2-v02 {
-  white-space: normal; /* countermands the base rule's `text-wrap: nowrap` */
-  overflow: visible;
-  text-overflow: clip;
-}

--- a/spec/system/author_toc_latest_works_pane_title_spec.rb
+++ b/spec/system/author_toc_latest_works_pane_title_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Companion to spec/system/lexicon/latest_works_pane_title_spec.rb: the same
+# "latest works by this author" pane appears in the Authority TOC sidebar, and its title is
+# likewise longer than the sidebar is wide. `.headline-2-v02` truncates with an ellipsis by
+# default; the title must wrap onto another line instead.
+RSpec.describe 'Latest-works pane title in the Authority TOC', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  it 'wraps the pane title rather than clipping it' do
+    author = create(:authority, name: 'Test Author')
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Test Work', status: :published, author: author)
+    end
+
+    visit authority_path(author)
+
+    # located through Capybara, so a markup change fails with a clear "expected to find css" error
+    # rather than a null dereference inside the script below
+    title = find('#author-whats-new-bg p.headline-2-v02')
+
+    metrics = page.evaluate_script(<<~JS, title)
+      (function(el) {
+        var style = window.getComputedStyle(el);
+        return {
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          whiteSpace: style.whiteSpace,
+          textOverflow: style.textOverflow
+        };
+      })(arguments[0])
+    JS
+
+    expect(metrics['whiteSpace']).not_to eq 'nowrap'
+    expect(metrics['textOverflow']).not_to eq 'ellipsis'
+    # the whole title fits horizontally: nothing is cut off
+    expect(metrics['scrollWidth']).to be <= metrics['clientWidth'] + 1
+  end
+end


### PR DESCRIPTION
Follow-up to #1575 (which fixed #1510 for lexicon entries only).

## Problem

#1575 stopped the base `.headline-2-v02` rule (`text-wrap: nowrap` + ellipsis, from
`BY_styles_General.css`) from clipping the latest-works pane title, but scoped the
override to `.author-whats-new-content` — a class only `lexicon/entries/_show_person`
puts on the pane. The very same pane, rendered from the same partial
(`shared/_latest_works_by_author`), sits in the Authority TOC sidebar
(`authors/toc`), where the title was still truncated to
"יצירותיו האחרונות שראו א…".

## Fix

Rekey the override on `#author-whats-new-bg`, the wrapper both views already share,
and move it from `lexicon.scss` into `application.scss` now that it governs a
main-site page rather than a lexicon-only one. Net +1 line of CSS, no markup changes.

## Test plan

- New `spec/system/author_toc_latest_works_pane_title_spec.rb` mirrors the existing
  lexicon spec: asserts the computed `white-space` is not `nowrap`, `text-overflow`
  is not `ellipsis`, and `scrollWidth <= clientWidth` for the TOC pane's title.
  Verified it **fails** on `lexicon` before the CSS change and passes after.
- `spec/system/author_toc_latest_works_pane_title_spec.rb` +
  `spec/system/lexicon/latest_works_pane_title_spec.rb` — 2 examples, 0 failures.
- `spec/system/author_sidebar_overlap_spec.rb`, `spec/system/author_toc_mobile_layout_spec.rb`,
  `spec/system/lexicon/` — 175 examples, 0 failures.
- The full suite (40+ min) was **not** run; these targeted specs cover the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)