### PR TITLE
Render the Authority TOC collections count as text, not a dummy link (by-y07)

### DIFF
--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -41,7 +41,7 @@
                 %div
                   .metadata
                     %span{:style => "font-weight:bold"}= t(:total_collections_including_author)+':'
-                    %a{:href => "#"}= @author.cached_collections_count
+                    = @author.cached_collections_count
                   .metadata
                     %span{:style => "font-weight:bold"}= t(:works_in_the_project)+': '
                     = "#{@author.cached_works_count} #{t(:works)}"


### PR DESCRIPTION
## Problem

In the Authority TOC metadata block, the "total collections including this author" number was wrapped in `%a{:href => "#"}` — a dummy link. It rendered with link styling and a hover background, inviting a click that did nothing.

## Fix

`app/views/authors/toc.html.haml`: render `@author.cached_collections_count` directly, matching the works-count datum immediately below it, which was already plain text.

## Test plan

No spec: verified visually by the maintainer, and a one-line static view change with no behaviour behind it carries no meaningful regression risk.

`bundle exec haml-lint app/views/authors/toc.html.haml` reports only pre-existing lints elsewhere in the file; nothing on the changed line. The full suite was not run (takes 40+ minutes).

Closes by-y07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
