### PR TITLE
Restore the Authority#toc side panels' full width (by-ccq)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1559,7 +1559,11 @@ p.by-genre-name-v02.headline-2-v02 {
     flex-wrap: nowrap;
   }
 
-  .author-page-content .col-12 > .row > .col:not(.author-side-menu-area) {
+  // The two columns spell their spacer differently: the TOC column uses
+  // .author-side-menu-area, the sidebar column .side-menu-area-left (which is
+  // display:none on desktop, where no rail floats over it).
+  .author-page-content .col-12 > .row
+  > .col:not(.author-side-menu-area):not(.side-menu-area-left) {
     min-width: 0;
   }
 

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -139,7 +139,12 @@
     .col-12.col-lg-4
       .row
         %a{name: 'curated_g', 'class' => 'g_anch'}
-        .col.author-side-menu-area
+        -# Spacer keeping this column clear of the sticky in-page nav rail. Only
+           the narrow (<= 991px) rail floats over this column, since there the
+           sidebar stacks under the TOC column; on desktop the rail is beside the
+           TOC column only, so .side-menu-area-left collapses (display:none) and
+           the side panels get the column's full width.
+        .col.side-menu-area-left
         .col
           = render partial: 'shared/about_pby'
           = render partial: 'shared/donation_box_negative'

--- a/spec/system/author_toc_mobile_layout_spec.rb
+++ b/spec/system/author_toc_mobile_layout_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe 'Author TOC mobile layout', :js, type: :system do
     visit_toc_at_mobile_width
 
     sidebar_row = '.author-page-content .col-12.col-lg-4 > .row'
-    sidebar_col = "#{sidebar_row} > .col:not(.author-side-menu-area)"
+    # This column's spacer is .side-menu-area-left (the main column's is
+    # .author-side-menu-area) -- exclude both so we measure the content col.
+    sidebar_col = "#{sidebar_row} > .col:not(.author-side-menu-area):not(.side-menu-area-left)"
     expect(page).to have_css(sidebar_col, wait: 5)
 
     # The spacer and the content col must stay on one line, or the content col

--- a/spec/system/author_toc_sidebar_panel_width_spec.rb
+++ b/spec/system/author_toc_sidebar_panel_width_spec.rb
@@ -53,13 +53,13 @@ describe 'Author TOC sidebar panel width', :js do
     # Below 992px the sidebar stacks under the TOC column, so the sticky rail
     # floats over it too and its spacer must stay on the line. RTL page: the
     # rail is on the right, so the panels must end to its left.
-    rail_right, panel_right = page.evaluate_script(<<~JS)
-      [document.querySelector('.author-side-nav-col').getBoundingClientRect().right,
+    rail_left, panel_right = page.evaluate_script(<<~JS)
+      [document.querySelector('.author-side-nav-col').getBoundingClientRect().left,
        document.querySelector('#{sidebar_card}').getBoundingClientRect().right]
     JS
 
-    expect(panel_right).to be <= rail_right,
+    expect(panel_right).to be <= rail_left,
                            "Side panel right edge (#{panel_right.round}px) overlaps " \
-                           "the nav rail (right edge #{rail_right.round}px)"
+                           "the nav rail (left edge #{rail_left.round}px)"
   end
 end

--- a/spec/system/author_toc_sidebar_panel_width_spec.rb
+++ b/spec/system/author_toc_sidebar_panel_width_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression for by-ccq: the Lexicon merge (#1578) renamed the sidebar column's
+# spacer div from .side-menu-area-left (display:none on desktop) to
+# .author-side-menu-area (a 230px flex basis meant for the TOC column, which is
+# the only one the sticky nav rail floats over). That reserved 230px inside the
+# col-lg-4 sidebar for nothing, squeezing the panels down to 216px in a 476px
+# column at a 1600px viewport.
+describe 'Author TOC sidebar panel width', :js do
+  let(:author) { create(:authority, name: 'Test Author Sidebar Width') }
+  let(:sidebar_col) { '.author-page-content > .row > .col-12.col-lg-4' }
+  let(:sidebar_card) { "#{sidebar_col} .by-card-v02" }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Test Work Sidebar Width', status: :published, author: author)
+    end
+    visit authority_path(author)
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  # Width of the sidebar column and of the first panel in it.
+  def sidebar_metrics
+    expect(page).to have_css(sidebar_card)
+    page.evaluate_script(<<~JS)
+      [document.querySelector('#{sidebar_col}').getBoundingClientRect().width,
+       document.querySelector('#{sidebar_card}').getBoundingClientRect().width]
+    JS
+  end
+
+  it 'gives the side panels nearly the whole sidebar column on a wide desktop' do
+    page.driver.browser.manage.window.resize_to(1600, 900)
+    col_width, card_width = sidebar_metrics
+
+    # The panels sit in a .col inside the column, so only the grid gutters
+    # (~30px) should separate the two widths -- not a 230px rail spacer.
+    expect(card_width).to be > (col_width - 60),
+                          "Side panel is #{card_width.round}px inside a #{col_width.round}px " \
+                          'sidebar column -- the spacer is eating its width'
+  end
+
+  it 'keeps the side panels clear of the nav rail below 992px' do
+    page.driver.browser.manage.window.resize_to(768, 900)
+    expect(page).to have_css(sidebar_card)
+
+    # Below 992px the sidebar stacks under the TOC column, so the sticky rail
+    # floats over it too and its spacer must stay on the line. RTL page: the
+    # rail is on the right, so the panels must end to its left.
+    rail_right, panel_right = page.evaluate_script(<<~JS)
+      [document.querySelector('.author-side-nav-col').getBoundingClientRect().right,
+       document.querySelector('#{sidebar_card}').getBoundingClientRect().right]
+    JS
+
+    expect(panel_right).to be <= rail_right,
+                           "Side panel right edge (#{panel_right.round}px) overlaps " \
+                           "the nav rail (right edge #{rail_right.round}px)"
+  end
+end


### PR DESCRIPTION
The Lexicon merge (#1578) renamed the spacer div in the `col-lg-4` sidebar column of `authors/toc` from `.side-menu-area-left` to `.author-side-menu-area`.

The two are **not** interchangeable:

| class | ≥992px | ≤991px |
|---|---|---|
| `.author-side-menu-area` | `flex: 0 0 230px` | `flex: 0 0 50px` |
| `.side-menu-area-left` | `display: none` | `flex: 0 0 50px` |

The 230px reservation exists to keep content clear of the sticky in-page nav rail (`.author-side-nav-col`), which on desktop only ever floats over the `col-lg-8` TOC column — never over the sidebar. `.side-menu-area-left` is exactly the sidebar variant: collapsed on desktop, and a 50px spacer below 992px, where the sidebar stacks under the TOC column and the rail does float over it too.

So on desktop the sidebar was reserving 230px for nothing. Measured at a 1600px viewport, before/after:

```
before:  col=476  spacer=230  panel=216
after:   col=476  spacer=0    panel=446
```

(At some widths, e.g. 1440px, the row wrapped instead of squeezing, so the shrinkage came and went with viewport width — which matches the "seem to have shrunk" phrasing in the report.)

## Changes

- `app/views/authors/toc.html.haml` — restore `.col.side-menu-area-left` on the sidebar spacer, with a comment explaining why the two columns spell their spacer differently.
- `app/assets/stylesheets/application.scss` — the ≤991px `min-width: 0` rule targets "the content col, not the spacer" via `:not(.author-side-menu-area)`; extend it to exclude `.side-menu-area-left` too. No behavioural change today (the spacer is `flex-shrink: 0`, so `min-width` cannot bite), but it keeps the selector matching its stated intent.

The lexicon's own person page (`lexicon/entries/_show_person`) still uses `.side-menu-area-left` for the same spacer, so this also puts the two pages back in sync.

## Tests

New `spec/system/author_toc_sidebar_panel_width_spec.rb`:
- panels take nearly the whole sidebar column at 1600px — **verified to fail without the fix** (`Side panel is 216px inside a 476px sidebar column`)
- panels stay clear of the nav rail at 768px (guards the ≤991px spacer that must stay)

Updated `spec/system/author_toc_mobile_layout_spec.rb`: its `> .col:not(.author-side-menu-area)` selector picked out the sidebar's content col by excluding the spacer's class; now that the spacer is `.side-menu-area-left` again the selector was matching the spacer instead, so it excludes both classes.

```
$ bundle exec rspec spec/system/author_toc_sidebar_panel_width_spec.rb \
    spec/system/author_sidebar_overlap_spec.rb \
    spec/system/author_toc_mobile_layout_spec.rb \
    spec/system/author_navbar_mobile_overflow_spec.rb \
    spec/system/author_toc_mobile_filter_spec.rb \
    spec/system/authors_modal_viewport_spec.rb
18 examples, 0 failures
```

RuboCop and haml-lint clean on the changed files (the pre-existing haml-lint warnings in `toc.html.haml` are untouched). The full suite was **not** run — it takes 40+ minutes and needs your go-ahead.

Closes by-ccq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)