### PR TITLE
Restore the missing `end` in FixOdtDirectionality#rezip (master is broken)

### DIFF
--- a/app/services/fix_odt_directionality.rb
+++ b/app/services/fix_odt_directionality.rb
@@ -59,6 +59,7 @@ class FixOdtDirectionality < ApplicationService
       end
     end
     buffer.string.force_encoding(Encoding::BINARY)
+  end
 
   def rtl_styles(styles_xml)
     doc = Nokogiri::XML(styles_xml)


### PR DESCRIPTION
## ⚠️ master does not currently parse

`app/services/fix_odt_directionality.rb` is missing the `end` that closes `#rezip`, so the file raises `SyntaxError` and the app will not boot:

```
$ ruby -c app/services/fix_odt_directionality.rb
app/services/fix_odt_directionality.rb:84: syntax error, unexpected end-of-input, expecting `end'
```

## How it happened

The merge of #1585 hand-edited the service. Both edits are good and I've kept them:

- `StringIO.new(String.new)` → `StringIO.new(''.b)`
- `buffer.string` → `buffer.string.force_encoding(Encoding::BINARY)`

But the second edit replaced two lines with one, taking `#rezip`'s `end` with it:

```diff
-    buffer.string
-  end
+    buffer.string.force_encoding(Encoding::BINARY)
```

This PR adds the `end` back. That is the entire change — one line.

## Verification

- `ruby -c app/services/fix_odt_directionality.rb` → Syntax OK
- `bundle exec rspec spec/services/fix_odt_directionality_spec.rb` → 7 examples, 0 failures
- `bundle exec rubocop app/services/fix_odt_directionality.rb` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)