### PR TITLE
Write generated DOCX files as binary

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -632,8 +632,10 @@ class CollectionsController < ApplicationController
         FileUtils.rm_f(pdfname)
       end
     when 'docx'
-      content = PandocRuby.convert(html, M: 'dir=rtl', from: :html, to: :docx).force_encoding('UTF-8')
-      send_data content, filename: filename, type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      # requires pandoc 1.17.3 or higher, for correct directionality
+      content = PandocRuby.convert(html, M: 'dir=rtl', from: :html, to: :docx)
+      send_data content, filename: filename,
+                         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     when 'odt'
       # pandoc's ODT writer ignores dir=rtl, so FixOdtDirectionality applies the RTL defaults
       content = FixOdtDirectionality.call(PandocRuby.convert(html, from: :html, to: :odt))

--- a/app/services/fix_odt_directionality.rb
+++ b/app/services/fix_odt_directionality.rb
@@ -59,6 +59,7 @@ class FixOdtDirectionality < ApplicationService
       end
     end
     buffer.string.force_encoding(Encoding::BINARY)
+  end
 
   def rtl_styles(styles_xml)
     doc = Nokogiri::XML(styles_xml)

--- a/app/services/make_fresh_downloadable.rb
+++ b/app/services/make_fresh_downloadable.rb
@@ -26,8 +26,9 @@ class MakeFreshDownloadable < ApplicationService
         end
       when 'docx'
         begin
-          temp_file = Tempfile.new('tmp_doc_' + download_entity.id.to_s, 'tmp/')
-          temp_file.puts(PandocRuby.convert(html, M: 'dir=rtl', from: :html, to: :docx).force_encoding('UTF-8')) # requires pandoc 1.17.3 or higher, for correct directionality
+          temp_file = Tempfile.new('tmp_doc_' + download_entity.id.to_s, 'tmp/', binmode: true)
+          # requires pandoc 1.17.3 or higher, for correct directionality
+          temp_file.write(PandocRuby.convert(html, M: 'dir=rtl', from: :html, to: :docx))
           temp_file.chmod(0o644)
           temp_file.rewind
           dl.stored_file.attach(io: temp_file, filename: filename)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -453,6 +453,24 @@ describe CollectionsController do
         expect(properties['fo:text-align']).to eq('end')
       end
 
+      it 'sends an intact right-to-left DOCX' do
+        get :download, params: {
+          collection_id: collection.id,
+          format: 'docx',
+          download_scope: 'partial',
+          manifestation_ids: [manifestation1.id]
+        }
+
+        expect(response).to be_successful
+
+        document = nil
+        Zip::File.open_buffer(StringIO.new(response.body.dup.force_encoding(Encoding::BINARY))) do |zip|
+          document = zip.get_entry('word/document.xml').get_input_stream.read
+        end
+
+        expect(document).to include('<w:bidi />')
+      end
+
       it 'does not overwrite existing full collection cache' do
         # First, create a full collection downloadable
         get :download, params: { collection_id: collection.id, format: 'html', download_scope: 'full' }

--- a/spec/services/make_fresh_downloadable_spec.rb
+++ b/spec/services/make_fresh_downloadable_spec.rb
@@ -97,5 +97,36 @@ RSpec.describe MakeFreshDownloadable do
         expect(properties['fo:text-align']).to eq('end')
       end
     end
+
+    context "with the 'docx' format" do
+      # The archive used to be written with IO#puts, which appends a newline after the ZIP
+      # end-of-central-directory record, leaving trailing garbage in every DOCX we served.
+      it 'stores the archive pandoc produced byte for byte' do
+        pandoc_output = nil
+        allow(PandocRuby).to receive(:convert).and_wrap_original do |original, *args, **kwargs|
+          pandoc_output = original.call(*args, **kwargs)
+        end
+
+        downloadable = service.call('docx', 'test.docx', '<p>פסקה בעברית.</p>', manifestation, 'מחבר')
+
+        # Compare sizes and digests rather than the archives themselves, so a failure reports a
+        # readable diff instead of dumping kilobytes of binary
+        stored = downloadable.stored_file.download
+        expect(stored.bytesize).to eq(pandoc_output.bytesize)
+        expect(Digest::SHA256.hexdigest(stored)).to eq(Digest::SHA256.hexdigest(pandoc_output))
+      end
+
+      # Unlike ODT, pandoc's DOCX writer does honour dir=rtl, so no post-processing is needed
+      it 'produces a right-to-left document' do
+        downloadable = service.call('docx', 'test.docx', '<p>פסקה בעברית.</p>', manifestation, 'מחבר')
+
+        document = nil
+        Zip::File.open_buffer(StringIO.new(downloadable.stored_file.download)) do |zip|
+          document = zip.get_entry('word/document.xml').get_input_stream.read
+        end
+
+        expect(document).to include('<w:bidi />')
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #1585, cleaning up the DOCX side of the same code.

> **Base branch**: this is stacked on #1586 (the one-line fix that unbreaks master), because specs cannot run against a `master` that does not parse. Merge #1586 first, then this retargets to `master` cleanly — the two touch disjoint files.

## Two defects, both masked well enough to go unnoticed

### 1. A stray byte after the end of every DOCX archive

`IO#puts` appends a newline when the string does not already end in one. A ZIP archive ends with its end-of-central-directory record, so every DOCX we stored carried a stray `0x0A` after the EOCD:

```
PandocRuby output:  10529 bytes
what we stored:     10530 bytes   (delta 1)
last 4 bytes:       [0, 0, 0, 10]
EOCD at end of file? false
```

Readers that scan backwards for the EOCD tolerate this, which is why nobody noticed, but it is trailing garbage in a binary format and stricter readers may object.

### 2. Binary mislabelled as UTF-8

`PandocRuby.convert` already returns **ASCII-8BIT**, so `.force_encoding('UTF-8')` was actively mislabelling binary as text. It was harmless only by coincidence: UTF-8 matches `Encoding.default_external`, so Ruby attempted no transcoding. The same pattern *did* blow up on the ODT path in #1585 (`Encoding::UndefinedConversionError: "\xC6" from ASCII-8BIT to UTF-8`) the moment the bytes came back correctly tagged.

## Fix

Use `IO#write` on a `binmode: true` handle and drop the `force_encoding`, matching what the ODT branch already does. Applied at both DOCX call sites:

- `MakeFreshDownloadable` — the cached download path
- `CollectionsController#send_generated_file` — the uncached partial-collection download

## Test plan

- `spec/services/make_fresh_downloadable_spec.rb`
  - **byte-for-byte**: the stored archive equals what pandoc produced (size + SHA-256, so failures print a readable diff rather than kilobytes of binary). I confirmed this spec **fails against the old `IO#puts` code** — one byte too many — and passes against this one.
  - the DOCX is RTL (`<w:bidi />`), documenting that pandoc's DOCX writer *does* honour `dir=rtl` and so needs no `FixOdtDirectionality` equivalent
- `spec/controllers/collections_controller_spec.rb` — the partial-collection DOCX download arrives as an intact, parseable, RTL archive

Ran `fix_odt_directionality_spec`, `fix_docx_inherited_formatting_spec`, `make_fresh_downloadable_spec`, `collections_controller_spec`, `collections_kwic_download_spec`, `spec/api/v1/texts_api_spec`, `spec/lib/bybe_utils_epub_spec` — **161 examples, 0 failures**. The full suite was **not** run (40+ min, needs your approval).

RuboCop clean on all changed lines; this also clears two pre-existing `Layout/LineLength` offences on the lines it rewrites.

## Not touched

The `IO#puts` calls in the `html`, `txt` and `kwic` branches. Those write text, where a trailing newline is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)