### PR TITLE
Fix lexicon date_of_manual_update parsing (column overflow on 00003.php)

### DIFF
--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -3,6 +3,9 @@
 module Lexicon
   # Base class for php file ingestion
   class IngestBase < ApplicationService
+    LAST_UPDATE_LABEL = 'עודכן לאחרונה'
+    LAST_UPDATE_RE = /#{LAST_UPDATE_LABEL}:?\s*([^\]\r\n]*)/
+
     def call(lex_file)
       @lex_entry = lex_file.lex_entry
 
@@ -41,15 +44,22 @@ module Lexicon
     end
 
     # Extract the "עודכן לאחרונה:" date string from the PHP footer area.
-    # The label may be surrounded by brackets (e.g. "[עודכן לאחרונה: DATE]").
+    # The label may be surrounded by brackets (e.g. "[עודכן לאחרונה: DATE]") and the colon is
+    # missing in a handful of files. We search the whole document text rather than a specific
+    # element, because unclosed <font> tags in many legacy files make element boundaries
+    # meaningless, and we take the *last* occurrence, because the phrase also shows up inside
+    # bibliography citations while the date we want is always in the footer. The capture stops at
+    # the end of the line (or at a closing bracket) so a mis-parsed document cannot yield a value
+    # far longer than a date.
     def extract_date_of_manual_update(html_doc)
-      html_doc.css('font[size="2"]').each do |node|
-        text = node.text.strip
-        next unless text.include?('עודכן לאחרונה:')
+      text = html_doc.text
+      label_at = text.rindex(LAST_UPDATE_LABEL)
+      return nil if label_at.nil?
 
-        return text.sub(/.*עודכן לאחרונה:\s*/, '').gsub(/\]$/, '').strip.presence
-      end
-      nil
+      date = text[label_at..][LAST_UPDATE_RE, 1].to_s.strip
+      # Files where the label is present but the date was never filled in: don't pick up whatever
+      # markup happens to follow the label.
+      date.match?(/\d/) ? date : nil
     end
 
     # Extract English title from the header table

--- a/spec/fixtures/files/lexicon/date_in_citation_and_footer.php
+++ b/spec/fixtures/files/lexicon/date_in_citation_and_footer.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person date in citation</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1920-2000)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="2">כהן, דנה. על יצירתו. <u>האתר לפסיכולוגיה יונגיאנית</u> &lt;מקוון&gt;, עודכן לאחרונה: 25 ביוני 2018</font></p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+<hr><font size="2">עודכן לאחרונה: 6 בנובמבר 2022</font>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/date_on_next_line.php
+++ b/spec/fixtures/files/lexicon/date_on_next_line.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person date on next line</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1920-2000)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+<font size="2">עודכן לאחרונה:
+7 באפריל 2021</font>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/label_without_date.php
+++ b/spec/fixtures/files/lexicon/label_without_date.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person label without date</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1920-2000)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+<hr><font size="2">עודכן לאחרונה:</font>
+<table align="left" border="0" width="50%">
+  <tr>
+    <td dir="ltr"><font size="2">Some trailing markup</font></td>
+  </tr>
+</table>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/unclosed_font_date.php
+++ b/spec/fixtures/files/lexicon/unclosed_font_date.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person unclosed font</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1920-2000)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<!-- this <font size="2"> is never closed, so everything below it, including the footer,
+     ends up nested inside it once the document is parsed -->
+<font size="2">
+<p>הערה ראשונה על אודות המחבר.</p>
+<p>הערה שנייה, בשורה נפרדת, שאינה חלק מתאריך העדכון.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<hr>עודכן לאחרונה: 2 בספטמבר 2020
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -467,4 +467,51 @@ describe Lexicon::IngestPerson do
       expect(call.date_of_manual_update).to eq('15 במרץ 2024')
     end
   end
+
+  describe 'date of manual update extraction' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'ישראלי, ישראל',
+          fname: fixture,
+          full_path: Rails.root.join('spec/fixtures/files/lexicon', fixture)
+        }
+      )
+    end
+
+    context 'when an unclosed font tag nests the footer inside the bibliography' do
+      let(:fixture) { 'unclosed_font_date.php' }
+
+      it 'extracts the date alone, not the bibliography preceding it' do
+        expect(call.date_of_manual_update).to eq('2 בספטמבר 2020')
+      end
+    end
+
+    context 'when the phrase also appears inside a citation' do
+      let(:fixture) { 'date_in_citation_and_footer.php' }
+
+      it 'takes the footer date rather than the citation one' do
+        expect(call.date_of_manual_update).to eq('6 בנובמבר 2022')
+      end
+    end
+
+    context 'when the date is on the line following the label' do
+      let(:fixture) { 'date_on_next_line.php' }
+
+      it 'extracts the date' do
+        expect(call.date_of_manual_update).to eq('7 באפריל 2021')
+      end
+    end
+
+    context 'when the label is present but no date was filled in' do
+      let(:fixture) { 'label_without_date.php' }
+
+      it 'leaves the date blank rather than grabbing the markup that follows' do
+        expect(call.date_of_manual_update).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## The bug

Migrating `lexicon/00003.php` aborted with a column-length error on `date_of_manual_update`, even though the date in the file is just `2 בספטמבר 2020`. It was a parsing failure, not a data problem.

`Lexicon::IngestBase#extract_date_of_manual_update` used:

```ruby
text.sub(/.*עודכן לאחרונה:\s*/, '')
```

`sub` replaces the first match, not a prefix of the string, and `.` does not match newlines — so this could only strip the label's *own line*. Everything on preceding lines stayed in the "date".

The node it operated on was frequently enormous: `00003.php` has an unclosed `<font size="2">` before `על המחברת ויצירתה:`, so Nokogiri nests the whole remainder of the document — including the footer `<hr>עודכן לאחרונה: …` — inside it. Result: a 381-character value beginning with the bibliography.

## Scale (scanned all 4,950 files in `lexicon/`)

2,950 contain the label. With the old code:

| outcome | files |
|---|---|
| correct | 2,717 |
| **over 255 chars — migration aborts** | **35** (`00474.php` 37,004 chars; `00198.php` 23,556; `00505.php` 16,252) |
| garbage stored under the limit | 5 (e.g. `01169.php` stored `"27 בדצמבר 2017]\r\n…// include page footer…"`) |
| label present, extracted as `nil` | 193 (the `font[size="2"]` selector missed them) |

## The fix

Search the whole document text from the **last** occurrence of the label (the phrase also appears inside bibliography citations; the footer date is always last), capture only to end-of-line or a closing bracket, and require a digit so a label with no date doesn't absorb the markup that follows it.

Re-run over the same 4,950 files through the real code path: **2,763 dates extracted (up from 2,717), zero over 255 chars, longest 37** (`02576001.php`: `2 בנובמבר 2024 – 107 שנה להצהרת בלפור`). Real-file spot checks: `00003` → `2 בספטמבר 2020`; `00266` (date on next line) → `7 באפריל 2021`; `00474` (last digit outside `</font>`) → `5 בדצמבר 2023`; `00198` (phrase in a citation too) → footer date; `04123` (label, then an unrelated table) → `nil`.

## Tests

Four new fixtures + examples in `spec/services/lexicon/ingest_person_spec.rb`:

- `unclosed_font_date.php` — the `00003.php` shape; **fails on master** (returns the bibliography plus the date)
- `date_in_citation_and_footer.php` — phrase in a citation and in the footer; **fails on master** (returns the citation's date)
- `date_on_next_line.php` — date on the line after the label
- `label_without_date.php` — label with no date → `nil`, not the following markup

Ran: `spec/services/lexicon` + `spec/models/lex_entry_spec.rb` + `spec/requests/lexicon` — 580 examples, 0 failures. RuboCop clean on both changed Ruby files. The full suite (40+ min) was not run.

Closes by-c1z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)