### PR TITLE
Show periodicals lacking public content to editors (by-1r0)

### DIFF
--- a/.claude/rules/reuse-existing-helpers.md
+++ b/.claude/rules/reuse-existing-helpers.md
@@ -1,0 +1,62 @@
+# Reuse Existing Helpers — Search Before You Write One
+
+## The rule
+
+**Before writing any helper, utility, or convenience method, search the repo for
+an existing one that already does the job.** If one exists, use it. If one
+almost exists, extend it in place rather than writing a parallel version next to
+it.
+
+This applies to specs just as much as to app code. A private `def` at the top of
+a spec file is still a utility function, and it is the most common place this
+rule gets broken.
+
+## Where the shared helpers already live
+
+| Kind | Location |
+| --- | --- |
+| Spec login / auth stubbing | `spec/support/test_helpers.rb` (included for `:system`, `:request`, `:controller`) |
+| Capybara / WebDriver guards | `spec/support/system_spec_helpers.rb` (e.g. `webdriver_available?`) |
+| Elasticsearch/Chewy in specs | `spec/support/es_helpers.rb` (e.g. `import_and_await`) |
+| Custom matchers | `spec/support/negated_matchers.rb` |
+| Shared example groups | `spec/support/shared_examples/` |
+| View helpers | `app/helpers/` |
+| Reusable business logic | `app/services/` |
+
+**Logging a user in inside a spec is `login_as(user)` from
+`spec/support/test_helpers.rb`.** Do not hand-roll
+`allow_any_instance_of(ApplicationController).to receive(:current_user)` in an
+individual spec file — that stub lives in exactly one place, with exactly one
+RuboCop exemption. For the privileged-editor variants use the existing
+`login_as_catalog_editor`, `login_as_batch_editor`, `login_as_moderator`, or
+`login_as_lexicon_editor`.
+
+## How to check (30 seconds, do it every time)
+
+```bash
+ls spec/support/                             # what shared spec helpers exist?
+grep -rn "def <the_thing_you_were_about_to_write>" spec/ app/ lib/
+grep -rn "<the distinctive line you were about to copy>" spec/ app/ lib/
+```
+
+If the grep for the *line you were about to write* returns hits in more than one
+file, that line wants to be a shared helper — put it in `spec/support/` (or
+`app/helpers/`, `app/services/`) and call it from both places.
+
+## Warning signs you are reinventing something
+
+- You are about to add a file-local `# rubocop:disable` for a pattern that the
+  rest of the codebase also uses → the exemption belongs at the one shared
+  definition, not scattered per file.
+- You are copying a two-or-three-line incantation out of another spec.
+- Your new method's name is a near-synonym of one that already exists
+  (`login_as` vs. `sign_in_user`, `stub_current_user`, …).
+
+## Historical context
+
+Added 2026-08-22 after PR #1589: a request spec defined its own local
+`login_as` helper plus a per-file `RuboCop:disable RSpec/AnyInstance`, when
+`spec/support/test_helpers.rb` was already included for `type: :request` and was
+the natural home for it. Copilot's review caught it. The fix was to add a shared
+`login_as(user)` there and route the existing `login_as_*_editor` helpers
+through it.

--- a/app/controllers/periodicals_controller.rb
+++ b/app/controllers/periodicals_controller.rb
@@ -9,9 +9,14 @@ class PeriodicalsController < ApplicationController
                             .where(id: with_issue_ids)
                             .order(:title)
                             .to_a
-    # a periodical whose issues hold nothing publicly accessible would only lead readers to empty pages
-    with_public_works = Collection.ids_with_published_manifestations(periodicals.map(&:id)).to_set
-    @periodicals = periodicals.select { |p| with_public_works.include?(p.id) }
+    # a periodical whose issues hold nothing publicly accessible would only lead readers to empty
+    # pages, but editors need to see those periodicals in order to work on them
+    @periodicals = if current_user&.editor?
+                     periodicals
+                   else
+                     with_public_works = Collection.ids_with_published_manifestations(periodicals.map(&:id)).to_set
+                     periodicals.select { |p| with_public_works.include?(p.id) }
+                   end
     @periodicals_count = @periodicals.size
     # non-primary works (e.g. an issue's editorial column) are parts of a larger text, not standalone works
     @popular_works = ManifestationsIndex.query(match: { in_periodical: true })

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -253,6 +253,39 @@ RSpec.describe 'Periodicals', type: :request do
       expect(assigns(:periodicals_count)).to eq(assigns(:periodicals).size)
     end
 
+    # rubocop:disable RSpec/AnyInstance -- matches how the rest of the suite logs a user in
+    def login_as(user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+    # rubocop:enable RSpec/AnyInstance
+
+    context 'when an editor is logged in' do
+      before { login_as(create(:user, editor: true)) }
+
+      it 'lists the periodicals lacking publicly accessible works too' do
+        get '/periodicals'
+        expect(assigns(:periodicals)).to include(
+          periodical_with_published, periodical_unpublished_only, periodical_empty_issues
+        )
+      end
+
+      it 'renders the otherwise-suppressed periodicals on the page' do
+        get '/periodicals'
+        expect(response.body).to include('Unpublished Only Periodical')
+        expect(response.body).to include('Empty Issues Periodical')
+      end
+    end
+
+    context 'when a logged-in non-editor is browsing' do
+      before { login_as(create(:user)) }
+
+      it 'still suppresses the periodicals lacking publicly accessible works' do
+        get '/periodicals'
+        expect(assigns(:periodicals)).to include(periodical_with_published)
+        expect(assigns(:periodicals)).not_to include(periodical_unpublished_only, periodical_empty_issues)
+      end
+    end
+
     context 'when the published work sits in a sub-collection of the issue' do
       let!(:periodical_nested) do
         create(:collection, collection_type: 'periodical', title: 'Nested Works Periodical')

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -253,12 +253,6 @@ RSpec.describe 'Periodicals', type: :request do
       expect(assigns(:periodicals_count)).to eq(assigns(:periodicals).size)
     end
 
-    # rubocop:disable RSpec/AnyInstance -- matches how the rest of the suite logs a user in
-    def login_as(user)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-    end
-    # rubocop:enable RSpec/AnyInstance
-
     context 'when an editor is logged in' do
       before { login_as(create(:user, editor: true)) }
 

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 module TestHelpers
+  # Logs the given user in for the duration of the example. This is the single place the suite
+  # stubs authentication -- reach for it instead of hand-rolling the stub in individual specs.
+  # rubocop:disable RSpec/AnyInstance -- the app has no password login to drive; OmniAuth only
+  def login_as(user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    user
+  end
+  # rubocop:enable RSpec/AnyInstance
+
   # Creates an editor user with edit_catalog privileges for testing
   # Returns the created user, or the existing one if already created in this test run
   def create_catalog_editor
@@ -15,7 +24,7 @@ module TestHelpers
   # Login helper for system specs using rack_test driver
   def login_as_catalog_editor
     user = create_catalog_editor
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    login_as(user)
     allow_any_instance_of(ApplicationController).to receive(:require_editor).and_return(true)
     user
   end
@@ -32,7 +41,7 @@ module TestHelpers
   # Login helper for mass-update / saved-selections specs
   def login_as_batch_editor
     user = create_batch_editor
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    login_as(user)
     allow_any_instance_of(ApplicationController).to receive(:require_editor).and_return(true)
     user
   end
@@ -51,7 +60,7 @@ module TestHelpers
   # Login helper for tag moderation specs
   def login_as_moderator
     user = create_moderator
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    login_as(user)
     allow_any_instance_of(ApplicationController).to receive(:require_editor).and_return(true)
     # Store user for mock_tagging_lock to use
     @current_test_user = user
@@ -85,7 +94,7 @@ module TestHelpers
   # Login helper for lexicon specs
   def login_as_lexicon_editor
     user = create_lexicon_editor
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    login_as(user)
     allow_any_instance_of(ApplicationController).to receive(:require_editor).and_return(true)
     user
   end


### PR DESCRIPTION
## What

The `/periodicals` index suppresses periodicals whose issues hold nothing publicly accessible, so readers aren't led to empty pages. Editors, however, need to see those periodicals in order to work on them.

This skips the "has publicly accessible works" filter when the logged-in user is an editor. Anonymous visitors and logged-in non-editors see exactly what they saw before.

```ruby
@periodicals = if current_user&.editor?
                 periodicals
               else
                 with_public_works = Collection.ids_with_published_manifestations(periodicals.map(&:id)).to_set
                 periodicals.select { |p| with_public_works.include?(p.id) }
               end
```

## Deliberately unchanged

- The zero-issue filter (`where(id: with_issue_ids)`): a periodical with no issues at all is still hidden from everyone, including editors.
- No visual marker in the view distinguishing an empty periodical from a populated one — an editor just sees "0 texts".
- `@random_periodical` still samples from `@periodicals`, so for an editor the featured spotlight can now land on a contentless periodical.

## Test plan

Three new examples in `spec/requests/periodicals_spec.rb`, under the existing "suppression of periodicals without publicly accessible works" describe block:

- an editor sees the unpublished-only and empty-issue periodicals in `@periodicals`
- an editor sees their titles rendered on the page
- a logged-in non-editor still does not (regression guard on the unchanged path)

`bundle exec rspec spec/requests/periodicals_spec.rb` → 25 examples, 0 failures.

RuboCop on both changed files reports only pre-existing offenses on untouched lines.

The full suite was not run (40+ min); CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)