### PR TITLE
Enforce gh api for PR reads and writes

### DIFF
--- a/.claude/hooks/block-gh-pr-view-edit.sh
+++ b/.claude/hooks/block-gh-pr-view-edit.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse/Bash hook: refuse `gh pr view` and `gh pr edit`, and hand back the `gh api`
+# equivalent so the caller can re-issue the command correctly instead of guessing.
+#
+# Why: this repo has a classic GitHub Project attached, so `gh pr edit` queries the deprecated
+# projectCards GraphQL field and fails. Project policy is that ALL PR reads and writes go
+# through the REST API. See .claude/rules/gh-pr-via-api.md.
+set -uo pipefail
+
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+
+# Match `gh pr view|edit` at the start of the command or after a shell separator, so that
+# `git log --grep='gh pr view'` and similar incidental mentions are not blocked.
+if ! printf '%s' "$cmd" |
+  grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*gh[[:space:]]+pr[[:space:]]+(view|edit)([[:space:]]|$)'; then
+  exit 0
+fi
+
+read -r -d '' reason <<'EOF' || true
+`gh pr view` and `gh pr edit` are blocked in this repo -- go straight to `gh api`.
+
+`gh pr edit` fails outright here (classic GitHub Project attached -> deprecated projectCards
+GraphQL field), and the standing policy is that every PR read/write uses the REST API.
+
+  PR metadata:    gh api repos/projectbenyehuda/bybe/pulls/<n>
+  Review bodies:  gh api repos/projectbenyehuda/bybe/pulls/<n>/reviews
+  Line comments:  gh api repos/projectbenyehuda/bybe/pulls/<n>/comments
+  Issue comments: gh api repos/projectbenyehuda/bybe/issues/<n>/comments
+  Files changed:  gh api repos/projectbenyehuda/bybe/pulls/<n>/files
+  Edit title:     gh api repos/projectbenyehuda/bybe/pulls/<n> -X PATCH -f title='New title'
+  Edit body:      gh api repos/projectbenyehuda/bybe/pulls/<n> -X PATCH -F body=@/tmp/body.md
+
+Add --jq '...' to narrow the response. Use -F body=@file (not -f body="$(cat ...)") so
+multi-line markdown survives intact.
+EOF
+
+jq -n --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'

--- a/.claude/hooks/block-gh-pr-view-edit.sh
+++ b/.claude/hooks/block-gh-pr-view-edit.sh
@@ -1,23 +1,23 @@
-#!/usr/bin/env bash
-# PreToolUse/Bash hook: refuse `gh pr view` and `gh pr edit`, and hand back the `gh api`
-# equivalent so the caller can re-issue the command correctly instead of guessing.
-#
-# Why: this repo has a classic GitHub Project attached, so `gh pr edit` queries the deprecated
-# projectCards GraphQL field and fails. Project policy is that ALL PR reads and writes go
-# through the REST API. See .claude/rules/gh-pr-via-api.md.
-set -uo pipefail
+#!/usr/bin/env python3
+"""PreToolUse/Bash hook: refuse `gh pr view` and `gh pr edit`.
 
-cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+Hands back the `gh api` equivalent so the caller can re-issue the command correctly
+instead of guessing.
 
-# Match `gh pr view|edit` at the start of the command or after a shell separator, so that
-# `git log --grep='gh pr view'` and similar incidental mentions are not blocked.
-if ! printf '%s' "$cmd" |
-  grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*gh[[:space:]]+pr[[:space:]]+(view|edit)([[:space:]]|$)'; then
-  exit 0
-fi
+Why: this repo has a classic GitHub Project attached, so `gh pr edit` queries the
+deprecated projectCards GraphQL field and fails. Project policy is that ALL PR reads
+and writes go through the REST API. See .claude/rules/gh-pr-via-api.md.
 
-read -r -d '' reason <<'EOF' || true
-`gh pr view` and `gh pr edit` are blocked in this repo -- go straight to `gh api`.
+Only a real invocation is blocked. Heredoc bodies and quoted strings are stripped
+first, so writing *about* these commands -- in a commit message, a PR body, a grep
+pattern, a rules file -- is not blocked.
+"""
+
+import json
+import re
+import sys
+
+REASON = """`gh pr view` and `gh pr edit` are blocked in this repo -- go straight to `gh api`.
 
 `gh pr edit` fails outright here (classic GitHub Project attached -> deprecated projectCards
 GraphQL field), and the standing policy is that every PR read/write uses the REST API.
@@ -31,13 +31,68 @@ GraphQL field), and the standing policy is that every PR read/write uses the RES
   Edit body:      gh api repos/projectbenyehuda/bybe/pulls/<n> -X PATCH -F body=@/tmp/body.md
 
 Add --jq '...' to narrow the response. Use -F body=@file (not -f body="$(cat ...)") so
-multi-line markdown survives intact.
-EOF
+multi-line markdown survives intact."""
 
-jq -n --arg r "$reason" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: $r
-  }
-}'
+HEREDOC_OPEN = re.compile(r"""<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1""")
+# A blocked call: `gh` as the first word of a command segment, then `pr`, then view/edit.
+BLOCKED = re.compile(r"^\s*gh\s+pr\s+(view|edit)(\s|$)")
+SEGMENT_SEPARATORS = re.compile(r"&&|\|\||[;|&()\n]")
+
+
+def strip_heredocs(command: str) -> str:
+    """Drop heredoc bodies, keeping the line that opens them."""
+    kept, skip_until = [], None
+    for line in command.split("\n"):
+        if skip_until is not None:
+            if line.strip() == skip_until:
+                skip_until = None
+            continue
+        kept.append(line)
+        opener = HEREDOC_OPEN.search(line)
+        if opener:
+            skip_until = opener.group(2)
+    return "\n".join(kept)
+
+
+def strip_quoted(text: str) -> str:
+    """Blank out single-quoted, double-quoted, and backticked spans."""
+    out, quote = [], None
+    for ch in text:
+        if quote:
+            if ch == quote:
+                quote = None
+            out.append(" ")
+            continue
+        if ch in "'\"`":
+            quote = ch
+            out.append(" ")
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
+def main() -> int:
+    try:
+        command = json.load(sys.stdin).get("tool_input", {}).get("command", "")
+    except (json.JSONDecodeError, AttributeError):
+        return 0
+
+    cleaned = strip_quoted(strip_heredocs(command))
+    if not any(BLOCKED.match(seg) for seg in SEGMENT_SEPARATORS.split(cleaned)):
+        return 0
+
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": REASON,
+            }
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/block-gh-pr-view-edit_test.py
+++ b/.claude/hooks/block-gh-pr-view-edit_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regression tests for the block-gh-pr-view-edit PreToolUse hook.
+
+Run from the project root:  python3 .claude/hooks/block-gh-pr-view-edit_test.py
+
+The heredoc case is the reason this file exists: the first version of the hook matched
+`gh pr view` anywhere after a shell separator, so a markdown table row inside a heredoc
+(`| `gh pr view 1589` | denied |`) blocked an unrelated `gh pr create`.
+"""
+
+import json
+import subprocess
+import sys
+
+HOOK = ".claude/hooks/block-gh-pr-view-edit.sh"
+
+HEREDOC = """cat > /tmp/body.md <<'EOF'
+| `gh pr view 1589 --json reviews` | denied |
+gh pr view 1589
+- deny rules for Bash(gh pr view:*) and Bash(gh pr edit:*)
+EOF
+gh pr create --base master --body-file /tmp/body.md"""
+
+CASES = [
+    ("gh pr view 1589 --json state", "deny"),
+    ("gh pr edit 1589 --body x", "deny"),
+    ("git push && gh pr edit 1589 --body x", "deny"),
+    ("git push; gh pr view 1589", "deny"),
+    ("  gh   pr   view  1589", "deny"),
+    ("gh api repos/projectbenyehuda/bybe/pulls/1589", "allow"),
+    ("gh pr create --base master", "allow"),
+    ("gh pr list", "allow"),
+    ("gh pr diff 1589", "allow"),
+    ("git log --grep='gh pr view'", "allow"),
+    ("grep -rn 'gh pr edit' CLAUDE.md", "allow"),
+    ('git commit -m "stop using gh pr view here"', "allow"),
+    (HEREDOC, "allow"),
+]
+
+
+def main() -> int:
+    failures = 0
+    for command, expected in CASES:
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+        result = subprocess.run([HOOK], input=payload, capture_output=True, text=True)
+        actual = "deny" if result.stdout.strip() else "allow"
+        if actual != expected:
+            failures += 1
+            print(f"FAIL want={expected} got={actual}: {command!r}")
+
+    print(f"{len(CASES) - failures}/{len(CASES)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/rules/gh-pr-via-api.md
+++ b/.claude/rules/gh-pr-via-api.md
@@ -1,0 +1,59 @@
+# All PR Reads and Writes Go Through `gh api`
+
+## The rule
+
+**Never run `gh pr view` or `gh pr edit` on this repo. Go straight to `gh api`.**
+
+Both are blocked at the permission layer (`.claude/settings.json` `permissions.deny`) and by a
+PreToolUse hook (`.claude/hooks/block-gh-pr-view-edit.sh`) that refuses the call and prints the
+`gh api` equivalent. Attempting them wastes a turn — there is no fallback path where they work.
+
+## Why
+
+- **`gh pr edit` fails outright.** This repo has a classic GitHub Project attached. `gh pr edit`
+  queries the deprecated `projectCards` GraphQL field, so GitHub returns a deprecation error and
+  the command exits 1.
+- **`gh pr view` is policy.** Even where it succeeds, the standing instruction is that every PR
+  read goes through the REST API, so there is one predictable, `--jq`-filterable path.
+
+Still fine to use: `gh pr create`, `gh pr list`, `gh pr comment`, `gh pr close`, `gh pr checks`,
+`gh pr diff`. Only `view` and `edit` are blocked.
+
+## The recipes
+
+```bash
+# Read
+gh api repos/projectbenyehuda/bybe/pulls/<n>                       # PR metadata
+gh api repos/projectbenyehuda/bybe/pulls/<n>/reviews               # review BODIES
+gh api repos/projectbenyehuda/bybe/pulls/<n>/comments              # line comments
+gh api repos/projectbenyehuda/bybe/issues/<n>/comments             # conversation comments
+gh api repos/projectbenyehuda/bybe/pulls/<n>/files                 # files changed
+
+# Write
+gh api repos/projectbenyehuda/bybe/pulls/<n> -X PATCH -f title='New title'
+gh api repos/projectbenyehuda/bybe/pulls/<n> -X PATCH -F body=@/tmp/body.md
+```
+
+Narrow responses with `--jq` rather than piping whole payloads through `head`:
+
+```bash
+gh api repos/projectbenyehuda/bybe/pulls/<n>/reviews --jq '.[] | {author: .user.login, state, body}'
+```
+
+**Use `-F body=@file`, not `-f body="$(cat ...)"`** — the `@file` form preserves multi-line
+markdown intact. Verified working 2026-08-22 on PRs #1581 and #1589.
+
+## Fetching a code review: you need BOTH endpoints
+
+`/pulls/<n>/comments` returns only per-line comments. The substantive review text — a bot's summary
+and recommendations — lives in the review **body** on `/pulls/<n>/reviews`. Fetch both, or you will
+miss the actual review. See the "Addressing PR code review comments" section of CLAUDE.md.
+
+## Historical context
+
+Added 2026-08-22. The user had already asked more than once to always use `gh api`, but the block
+kept getting bypassed because `CLAUDE.md` itself prescribed `gh pr view <number> --json
+reviews,comments` in its review-handling section, and `.claude/settings.local.json` explicitly
+allowlisted `Bash(gh pr view:*)` and `Bash(gh pr edit:*)`. Instructions alone were not enough —
+the allowlist entries were removed, deny rules and a blocking hook were added, and the CLAUDE.md
+recipe was rewritten to `gh api`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": [
+      "Bash(gh pr view:*)",
+      "Bash(gh pr edit:*)"
+    ],
+    "ask": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/block-gh-pr-view-edit.sh",
+            "if": "Bash(gh *)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,21 +385,28 @@ Important reminders:
 
 Addressing PR code review comments:
 
-**CRITICAL**: When asked to address PR code review comments, use this two-step process:
+**CRITICAL**: Use `gh api`, never `gh pr view` / `gh pr edit` — both are blocked on this repo
+(see `.claude/rules/gh-pr-via-api.md`). A review has TWO separate parts, and you must fetch both:
 
-1. **Get review metadata**: Run `gh pr view <number> --json reviews,comments` to see all reviews
-2. **Fetch full review content**: If reviews exist with actual content (not just line comments from bots), use WebFetch on the review URL to get the full substantive review. The URL format is:
+1. **Review bodies** (the substantive analysis, summary, and recommendations):
+   ```bash
+   gh api repos/projectbenyehuda/bybe/pulls/<number>/reviews \
+     --jq '.[] | {author: .user.login, state, body}'
    ```
-   https://github.com/projectbenyehuda/bybe/pull/<number>#pullrequestreview-<review-id>
+2. **Line comments** (lint issues, isolated per-line feedback):
+   ```bash
+   gh api repos/projectbenyehuda/bybe/pulls/<number>/comments \
+     --jq '.[] | {path, line, body}'
    ```
 
 **Why this matters**:
-- `gh api repos/.../pulls/<number>/comments` only returns individual line comments (lint issues, isolated feedback)
-- It does NOT return the full review body text or comprehensive review content
-- Bot reviews (github-actions, copilot-pull-request-reviewer) often provide detailed analysis in the review body, not just line comments
-- WebFetch on the review URL provides the complete review including summary, analysis, and all recommendations
+- The `/comments` endpoint returns ONLY individual line comments — it does NOT return review body text
+- Bot reviews (github-actions, copilot-pull-request-reviewer) often put their real analysis in the
+  review body, which lives on `/reviews`
+- **Don't rely solely on the comments API** — it will miss substantive reviews!
 
-**Don't rely solely on the comments API** - it will miss substantive reviews!
+If a review body is truncated or references content the API doesn't return, fall back to WebFetch on
+`https://github.com/projectbenyehuda/bybe/pull/<number>#pullrequestreview-<review-id>`.
 
 For more details, see README.md in the project home directory.
 


### PR DESCRIPTION
## Problem

`gh pr edit` fails outright on this repo: the attached classic GitHub Project makes it query the deprecated `projectCards` GraphQL field, so GitHub returns a deprecation error and the command exits 1. The standing instruction is that every PR read/write goes through the REST API instead.

Nothing enforced that, and one thing actively contradicted it:

- `CLAUDE.md` prescribed the `gh pr` read command in its "Addressing PR code review comments" section — the exact task where the policy matters most.
- `.claude/settings.local.json` allowlisted both blocked subcommands.
- No `deny` rule and no hook existed anywhere.

## Changes

- **`.claude/settings.json`** (new, checked in): `deny` rules for the two blocked subcommands, plus a `PreToolUse`/`Bash` hook gated on `if: Bash(gh *)`.
- **`.claude/hooks/block-gh-pr-view-edit.sh`** (new): refuses them and returns the `gh api` equivalent in `permissionDecisionReason`, so the caller re-issues correctly instead of guessing. Matches only at a command boundary and skips quoted/heredoc text, so incidental mentions in commit messages, greps, and PR bodies still run.
- **`CLAUDE.md`**: review-fetching recipe rewritten to `gh api`, fetching **both** `/pulls/<n>/reviews` (the substantive review bodies) and `/pulls/<n>/comments` (per-line notes). WebFetch is kept as a fallback for truncated bodies.
- **`.claude/rules/gh-pr-via-api.md`** (new): the recipes, the reason, and the `-F body=@file` caveat for multi-line markdown.

`gh pr create`, `list`, `comment`, `close`, `checks`, and `diff` remain allowed — only the two problem subcommands are blocked.

The two stale allowlist entries were removed from `.claude/settings.local.json`, which is gitignored via `.git/info/exclude` and so isn't part of this diff.

## Test plan

Pipe-tested the hook against synthetic PreToolUse payloads. Denied: the blocked subcommand at the start of a command, and after a `&&`. Allowed: `gh api`, `gh pr create`, `gh pr list`, a `git log --grep` mentioning the blocked name, a `grep -rn` for it, and a heredoc whose body quotes it.

Then confirmed live: running the blocked read command in-session was refused and returned the `gh api` recipes. `jq -e` validates the hook nesting and the deny array in `.claude/settings.json`.

No application code touched; nothing to run against the RSpec suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
