### PR TITLE
Add admin report of downloads by file format, and track KWIC downloads

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1543,7 +1543,29 @@ class AdminController < ApplicationController
     @users = whodunnit_ids.any? ? User.where(id: whodunnit_ids).index_by(&:id) : {}
   end
 
+  # Reports how many downloads were served per file format, broken down by the type of the downloaded object,
+  # so we can tell which formats are actually being used.
+  def downloads_by_format
+    @from = parse_report_date(params[:from], 1.year.ago.to_date)
+    @to = parse_report_date(params[:to], Date.current)
+
+    @counts = Ahoy::Event.download_counts_by_format(@from.beginning_of_day, @to.end_of_day)
+    @item_types = @counts.keys.map(&:last).compact.uniq.sort
+    @formats = @counts.keys.map(&:first).uniq.sort_by(&:to_s)
+    @format_totals = @formats.index_with do |format|
+      @item_types.sum { |item_type| @counts.fetch([format, item_type], 0) }
+    end
+    @grand_total = @format_totals.values.sum
+  end
+
   private
+
+  # Both report dates are optional, and a malformed one should fall back to the default rather than blow up
+  def parse_report_date(value, default)
+    value.present? ? Date.parse(value) : default
+  rescue Date::Error
+    default
+  end
 
   def parse_manifestation_ids(input)
     ids = []

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -682,6 +682,7 @@ class AuthorsController < ApplicationController
 
     # Send as downloadable file
     filename = "#{@author.name.gsub(/[^0-9א-תA-Za-z.\-]/, '_')}_kwic.txt"
+    track_download(@author, 'kwic')
     send_data content, filename: filename, type: 'text/plain; charset=utf-8', disposition: 'attachment'
   end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -469,6 +469,7 @@ class CollectionsController < ApplicationController
 
     filename = "#{@collection.title.gsub(/[^0-9א-תA-Za-z.\-]/, '_')}_kwic.txt"
 
+    track_download(@collection, 'kwic')
     send_data kwic_text,
               filename: filename,
               type: 'text/plain; charset=utf-8',

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -986,6 +986,7 @@ class ManifestationController < ApplicationController
 
     filename = "#{@m.title.gsub(/[^0-9א-תA-Za-z.\-]/, '_')}_kwic.txt"
 
+    track_download(@m, 'kwic')
     send_data kwic_text,
               filename: filename,
               type: 'text/plain; charset=utf-8',

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -29,6 +29,10 @@ module Ahoy
 
     self.table_name = 'ahoy_events'
 
+    # `format` is stored inside the JSON properties by Tracking#track_download, and unlike `id` and `type`
+    # it has no virtual column, so we have to extract it explicitly when aggregating.
+    FORMAT_EXPRESSION = Arel.sql("json_unquote(json_extract(properties, '$.format'))")
+
     belongs_to :visit
     belongs_to :user, optional: true
 
@@ -37,5 +41,14 @@ module Ahoy
     belongs_to :item, optional: true, polymorphic: true
 
     validates :name, presence: true, inclusion: { in: ALLOWED_NAMES }
+
+    # Aggregates download events in the given time range.
+    # @return [Hash] mapping [format, item_type] pairs to the number of downloads.
+    #   Events recorded before format tracking was introduced have a nil format.
+    def self.download_counts_by_format(from, to)
+      where(name: 'download', time: from..to)
+        .group(FORMAT_EXPRESSION, :item_type)
+        .count
+    end
   end
 end

--- a/app/views/admin/downloads_by_format.html.haml
+++ b/app/views/admin/downloads_by_format.html.haml
@@ -12,7 +12,7 @@
     %p= t(:no_results)
   - else
     %h3= "#{t(:total)}: #{@grand_total}"
-    %table{ style: 'cell-spacing: 10;' }
+    %table{ style: 'border-spacing: 10px; border-collapse: separate;' }
       %tr
         %th= t(:file_format)
         - @item_types.each do |item_type|

--- a/app/views/admin/downloads_by_format.html.haml
+++ b/app/views/admin/downloads_by_format.html.haml
@@ -1,0 +1,26 @@
+.backend
+  %h2= t(:downloads_by_format)
+
+  = form_tag admin_downloads_by_format_path, method: :get do
+    = label_tag :from, t(:fromdate)
+    = text_field_tag :from, @from.to_s, class: 'form-control', placeholder: 'YYYY-MM-DD'
+    = label_tag :to, t(:todate)
+    = text_field_tag :to, @to.to_s, class: 'form-control', placeholder: 'YYYY-MM-DD'
+    = submit_tag t(:submit), class: 'btn btn-primary'
+
+  - if @grand_total.zero?
+    %p= t(:no_results)
+  - else
+    %h3= "#{t(:total)}: #{@grand_total}"
+    %table{ style: 'cell-spacing: 10;' }
+      %tr
+        %th= t(:file_format)
+        - @item_types.each do |item_type|
+          %th= t("activerecord.models.#{item_type.underscore}", default: item_type)
+        %th= t(:total)
+      - @formats.each do |doctype|
+        %tr
+          %td= doctype.present? ? doctype.upcase : t(:unknown)
+          - @item_types.each do |item_type|
+            %td= @counts.fetch([doctype, item_type], 0)
+          %td= @format_totals[doctype]

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -115,6 +115,8 @@
       %p
         %b= link_to t(:first_manifestations_between_dates), admin_first_manifestations_between_dates_path
       %p
+        %b= link_to t(:downloads_by_format), admin_downloads_by_format_path
+      %p
         %b= link_to t(:authors_without_works), admin_authors_without_works_path
         = ' ('+Rails.cache.read('report_authors_without_works').to_s+')'
       %p

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -13,6 +13,7 @@ en:
     todate: To Date
   activerecord:
     models:
+      anthology: Anthology
       authority: Authority
       collection: Collection
       collection_item: Collection Item
@@ -26,6 +27,7 @@ en:
       lex_person: Lexicon Person
       lex_person_work: Lexicon Person's Work
       lex_publication: Lexicon Publication
+      manifestation: Work
       person: Person
     errors:
       messages:

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -13,6 +13,7 @@ he:
     todate: עד תאריך
   activerecord:
     models:
+      anthology: מקראה
       authority: מחבר
       collection: אוסף
       collection_item: פריט באוסף
@@ -26,6 +27,7 @@ he:
       lex_person: אדם בלקסיקון
       lex_person_work: יצירת אדם בלקסיקון
       lex_publication: כותר בלקסיקון
+      manifestation: יצירה
       person: אדם
     errors:
       messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1534,6 +1534,8 @@ en:
   select_all: Select all
   format_to_save: Format to save
   download_to_file: Save Text to File
+  downloads_by_format: Downloads by Format
+  file_format: File Format
   dpublished: Published
   dfirst_published: First Published
   duploaded: Uploaded to Site

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -675,6 +675,8 @@ he:
   download: הורדה
   download_to_file: שמירת הטקסט לקובץ
   download_ebook: הורדת ספר דיגיטלי
+  downloads_by_format: הורדות לפי תבנית
+  file_format: תבנית הקובץ
   print: הדפסה
   cite: ציטוט
   additional: נוספים

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,7 @@ Bybeconv::Application.routes.draw do
   get 'admin/texts_between_dates'
   get 'admin/authority_records_between_dates'
   get 'admin/first_manifestations_between_dates'
+  get 'admin/downloads_by_format'
   get 'admin/suspicious_titles'
   get 'admin/slash_in_titles'
   get 'admin/similar_titles'

--- a/spec/controllers/admin_controller_downloads_by_format_spec.rb
+++ b/spec/controllers/admin_controller_downloads_by_format_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AdminController do
+  render_views
+
+  let(:editor) { create(:user, editor: true) }
+  let(:manifestation) { create(:manifestation) }
+  let(:collection) { create(:collection) }
+
+  describe '#downloads_by_format' do
+    context 'when user is not an editor' do
+      before { session[:user_id] = create(:user, editor: false).id }
+
+      it 'redirects to home page' do
+        get :downloads_by_format
+
+        expect(response).to redirect_to('/')
+      end
+    end
+
+    context 'when user is an editor' do
+      before { session[:user_id] = editor.id }
+
+      it 'defaults to the last year when no dates are given' do
+        get :downloads_by_format
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:from)).to eq 1.year.ago.to_date
+        expect(assigns(:to)).to eq Date.current
+      end
+
+      it 'falls back to the defaults when given unparseable dates' do
+        get :downloads_by_format, params: { from: 'not-a-date', to: '???' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:from)).to eq 1.year.ago.to_date
+        expect(assigns(:to)).to eq Date.current
+      end
+
+      it 'reports no results when nothing was downloaded' do
+        get :downloads_by_format
+
+        expect(assigns(:grand_total)).to eq 0
+        expect(response.body).to include(I18n.t(:no_results))
+      end
+
+      it 'aggregates downloads per format and item type' do
+        create_list(:ahoy_event, 3, :with_item, name: 'download', item: manifestation, doctype: 'epub',
+                                                time: 2.days.ago)
+        create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'pdf', time: 2.days.ago)
+        create_list(:ahoy_event, 2, :with_item, name: 'download', item: collection, doctype: 'epub', time: 2.days.ago)
+
+        get :downloads_by_format
+
+        expect(assigns(:grand_total)).to eq 6
+        expect(assigns(:formats)).to eq %w(epub pdf)
+        expect(assigns(:item_types)).to eq %w(Collection Manifestation)
+        expect(assigns(:format_totals)).to eq('epub' => 5, 'pdf' => 1)
+        expect(response.body).to include('EPUB', 'PDF')
+      end
+
+      it 'honours the requested date range' do
+        create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'docx', time: 2.days.ago)
+        create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'docx', time: 40.days.ago)
+
+        get :downloads_by_format, params: { from: 7.days.ago.to_date.to_s, to: Date.current.to_s }
+
+        expect(assigns(:grand_total)).to eq 1
+      end
+
+      it 'includes downloads recorded today, at the end of the range' do
+        create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'txt', time: Time.current)
+
+        get :downloads_by_format, params: { from: 7.days.ago.to_date.to_s, to: Date.current.to_s }
+
+        expect(assigns(:grand_total)).to eq 1
+      end
+
+      it 'labels downloads that predate format tracking as unknown' do
+        create(:ahoy_event, :with_item, name: 'download', item: manifestation, time: 2.days.ago)
+
+        get :downloads_by_format
+
+        expect(assigns(:formats)).to eq [nil]
+        expect(response.body).to include(I18n.t(:unknown))
+      end
+    end
+  end
+end

--- a/spec/controllers/authority_kwic_browser_spec.rb
+++ b/spec/controllers/authority_kwic_browser_spec.rb
@@ -466,6 +466,15 @@ describe AuthorsController do
         expect(content).to include('[First Work')
         expect(content).to include('[Second Work')
       end
+
+      it 'records an Ahoy download event so the download shows up in the by-format report' do
+        stub_browser_user_agent
+        subject
+
+        event = Ahoy::Event.find_by(name: 'download')
+        expect(event).to be_present
+        expect(event.properties).to include('type' => 'Authority', 'id' => authority.id, 'format' => 'kwic')
+      end
     end
 
     context 'when concordance does not exist yet' do
@@ -488,6 +497,12 @@ describe AuthorsController do
         subject
         expect(response).to have_http_status(:redirect)
         expect(flash[:notice]).to eq(I18n.t(:kwic_being_generated))
+      end
+
+      it 'records no download event, since nothing was actually downloaded' do
+        stub_browser_user_agent
+        subject
+        expect(Ahoy::Event.where(name: 'download')).to be_empty
       end
     end
 

--- a/spec/controllers/collection_kwic_browser_spec.rb
+++ b/spec/controllers/collection_kwic_browser_spec.rb
@@ -481,6 +481,15 @@ describe CollectionsController do
         expect(content).to include('[First Work')
         expect(content).to include('[Second Work')
       end
+
+      it 'records an Ahoy download event so the download shows up in the by-format report' do
+        stub_browser_user_agent
+        subject
+
+        event = Ahoy::Event.find_by(name: 'download')
+        expect(event).to be_present
+        expect(event.properties).to include('type' => 'Collection', 'id' => collection.id, 'format' => 'kwic')
+      end
     end
 
     context 'with filter parameter' do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -413,9 +413,7 @@ describe CollectionsController do
       end
 
       it 'records an Ahoy download event carrying the requested format' do
-        # Ahoy.track_bots is false, and the default controller-spec user agent ('Rails Testing') is
-        # classified as a bot, so we must present a browser user agent for the event to be recorded.
-        request.user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120'
+        stub_browser_user_agent
         get :download, params: { collection_id: collection.id, format: 'html', download_scope: 'full' }
 
         event = Ahoy::Event.find_by(name: 'download')

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -411,6 +411,17 @@ describe CollectionsController do
         expect(downloadable).to be_present
         expect(downloadable.stored_file).to be_attached
       end
+
+      it 'records an Ahoy download event carrying the requested format' do
+        # Ahoy.track_bots is false, and the default controller-spec user agent ('Rails Testing') is
+        # classified as a bot, so we must present a browser user agent for the event to be recorded.
+        request.user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120'
+        get :download, params: { collection_id: collection.id, format: 'html', download_scope: 'full' }
+
+        event = Ahoy::Event.find_by(name: 'download')
+        expect(event).to be_present
+        expect(event.properties).to include('type' => 'Collection', 'id' => collection.id, 'format' => 'html')
+      end
     end
 
     context 'with selective download (partial scope)' do

--- a/spec/controllers/manifestation_kwic_browser_spec.rb
+++ b/spec/controllers/manifestation_kwic_browser_spec.rb
@@ -275,6 +275,15 @@ describe ManifestationController do
         expect(content).to include('קונקורדנציה בתבנית KWIC')
         expect(content).to include('מילה:')
       end
+
+      it 'records an Ahoy download event so the download shows up in the by-format report' do
+        stub_browser_user_agent
+        subject
+
+        event = Ahoy::Event.find_by(name: 'download')
+        expect(event).to be_present
+        expect(event.properties).to include('type' => 'Manifestation', 'id' => manifestation.id, 'format' => 'kwic')
+      end
     end
 
     context 'with filter parameter' do

--- a/spec/factories/ahoy_events.rb
+++ b/spec/factories/ahoy_events.rb
@@ -16,13 +16,17 @@ FactoryBot.define do
     trait :with_item do
       transient do
         item { create(:authority) }
+        # Only download events carry a file format
+        doctype { nil }
       end
 
       controller { item.class.name.pluralize }
       action { name }
 
       properties do
-        { id: item.id, type: item.class.name, controller: controller, action: action }
+        props = { id: item.id, type: item.class.name, controller: controller, action: action }
+        props[:format] = doctype if doctype.present?
+        props
       end
     end
   end

--- a/spec/models/ahoy/event_spec.rb
+++ b/spec/models/ahoy/event_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Ahoy::Event do
+  describe '.download_counts_by_format' do
+    subject(:counts) { described_class.download_counts_by_format(2.months.ago, Time.current) }
+
+    let(:manifestation) { create(:manifestation) }
+    let(:collection) { create(:collection) }
+
+    it 'returns an empty hash when there are no download events' do
+      create(:ahoy_event, :with_item, name: 'view', item: manifestation, time: 1.day.ago)
+
+      expect(counts).to eq({})
+    end
+
+    it 'counts downloads grouped by format and item type' do
+      create_list(:ahoy_event, 3, :with_item, name: 'download', item: manifestation, doctype: 'epub',
+                                              time: 1.day.ago)
+      create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'pdf', time: 1.day.ago)
+      create_list(:ahoy_event, 2, :with_item, name: 'download', item: collection, doctype: 'epub', time: 1.day.ago)
+
+      expect(counts).to eq(
+        %w(epub Manifestation) => 3,
+        %w(pdf Manifestation) => 1,
+        %w(epub Collection) => 2
+      )
+    end
+
+    it 'ignores events of other names' do
+      create(:ahoy_event, :with_item, name: 'view', item: manifestation, time: 1.day.ago)
+      create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'docx', time: 1.day.ago)
+
+      expect(counts).to eq(%w(docx Manifestation) => 1)
+    end
+
+    it 'ignores events outside the given time range' do
+      create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'docx', time: 1.day.ago)
+      create(:ahoy_event, :with_item, name: 'download', item: manifestation, doctype: 'docx', time: 1.year.ago)
+
+      expect(counts).to eq(%w(docx Manifestation) => 1)
+    end
+
+    it 'reports a nil format for legacy events recorded before format tracking' do
+      create(:ahoy_event, :with_item, name: 'download', item: manifestation, time: 1.day.ago)
+
+      expect(counts).to eq([nil, 'Manifestation'] => 1)
+    end
+  end
+end

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -10,6 +10,15 @@ module TestHelpers
   end
   # rubocop:enable RSpec/AnyInstance
 
+  BROWSER_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120'
+
+  # Ahoy.track_bots is false and the default controller-spec user agent ('Rails Testing') is
+  # classified as a bot, so tracking silently records nothing. Call this before the request in any
+  # spec that asserts on Ahoy::Event rows.
+  def stub_browser_user_agent
+    request.user_agent = BROWSER_USER_AGENT
+  end
+
   # Creates an editor user with edit_catalog privileges for testing
   # Returns the created user, or the existing one if already created in this test run
   def create_catalog_editor


### PR DESCRIPTION
## What

Adds an editor report at **`/admin/downloads_by_format`** (linked from the admin dashboard's Reports box) showing how many downloads were served per file format, broken down by the type of object downloaded, over a date range.

Also **tracks KWIC concordance downloads**, which were previously invisible to the report (see below).

Closes by-641, by-b73.

## Why

Download events have been recording the requested format since `ec3fe56f7` (2025-07-01) — `Tracking#track_download(record, format)` stores `type`, `id` and `format` on the Ahoy event. But there was no way to read that in aggregate short of hand-written SQL against `ahoy_events.properties`, so the question "which formats actually get used?" was unanswerable in practice.

## Changes

### The report

- `Ahoy::Event.download_counts_by_format(from, to)` — groups `download` events by format and item type. `format` lives in the JSON `properties` and, unlike `id`/`type`, has no virtual column, so it's extracted explicitly.
- `AdminController#downloads_by_format` + HAML view. Date range defaults to the last year; a malformed date falls back to the default rather than raising (the sibling `*_between_dates` reports raise on garbage input — this one doesn't).
- Events predating format tracking show as "unknown" rather than being silently dropped.
- Added `manifestation` and `anthology` to `activerecord.models` in both locales so the breakdown columns get Hebrew labels.
- `downloads_by_format` / `file_format` keys added to `he.yml` and `en.yml`.

### KWIC download tracking

The `kwic_download` actions `send_data` straight to the browser without calling `track_download`, so KWIC concordance downloads never reached `ahoy_events` and were invisible in this report. All three now track as format `kwic` — the same format name the regular download form already uses — so they appear in the report broken down by Authority / Manifestation / Collection:

- `authors#kwic_download` (`authors_controller.rb:684`)
- `manifestation#kwic_download` (`manifestation_controller.rb:987`)
- `collections#kwic_download` (`collections_controller.rb:470`)

The call sits after the early returns, so a request that only schedules async generation and redirects is **not** counted as a download — there's a regression test for that.

Anthology and collection KWIC downloads that go through the ordinary download form were already tracked; this only closes the dedicated concordance-browser download path.

### Spec helper

The browser-user-agent incantation moved into a shared `stub_browser_user_agent` in `spec/support/test_helpers.rb`. It was about to be copy-pasted a fourth time.

## Test plan

New specs, all passing:

- `spec/models/ahoy/event_spec.rb` (5 examples) — grouping, name filtering, time-range filtering, nil-format legacy events.
- `spec/controllers/admin_controller_downloads_by_format_spec.rb` (8 examples, `render_views`) — editor gating, date defaults, malformed-date fallback, aggregation, range honouring, end-of-day inclusion, unknown-format labelling.
- `spec/controllers/collections_controller_spec.rb` — asserts `#download` really does write an Ahoy event carrying the format, since that is the data this report reads.
- The three `*_kwic_browser_spec.rb` files — one example each asserting the download event is written with `format => 'kwic'` and the right `type`/`id`, plus a negative example asserting the async-generation redirect records nothing.

```
bundle exec rspec spec/controllers/authority_kwic_browser_spec.rb \
  spec/controllers/manifestation_kwic_browser_spec.rb \
  spec/controllers/collection_kwic_browser_spec.rb
# => 80 examples, 0 failures

bundle exec rspec spec/controllers/collections_controller_spec.rb \
  spec/controllers/admin_controller_downloads_by_format_spec.rb \
  spec/models/ahoy/event_spec.rb spec/controllers/concerns/tracking_spec.rb
# => 90 examples, 0 failures
```

RuboCop on the changed files: 167 offenses before, 171 after. The 4 added are all `RSpec/NamedSubject`, one per new example calling each file's existing bare `subject` — the convention throughout those files, which already carry 74 instances of it. No other cop is affected.

**The full suite was not run** — it takes 40+ minutes and needs your approval.

## Non-obvious thing worth knowing

`Ahoy.track_bots` is `false`, and the default controller-spec user agent (`Rails Testing`) is classified as a bot — so **no Ahoy event is recorded in a controller spec unless you set a browser `request.user_agent`**. That is what `stub_browser_user_agent` is for.

## Remaining known gap, deliberately out of scope

**`CompactEvents` destroys the format breakdown every January.** `app/services/compact_events.rb:22` rolls the previous year's events into `year_totals` grouped by `year, item_type, item_id, name` — `format` is dropped — and then `delete_all`s the source events. So this report can only ever show the current year plus whatever hasn't been compacted yet. Preserving format across the rollup needs a migration.

Happy to do that in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
