### PR TITLE
Show person-entry migration progress stats on /lex/files

### DIFF
--- a/app/controllers/lexicon/files_controller.rb
+++ b/app/controllers/lexicon/files_controller.rb
@@ -58,6 +58,8 @@ module Lexicon
                         .preload(:lex_entry)
                         .order(Arel.sql(sort_clause))
                         .page(@page)
+
+      set_person_migration_stats
     end
 
     def migrate
@@ -91,6 +93,17 @@ module Lexicon
     end
 
     private
+
+    # Overall progress of the person-entry migration, shown above the queue. Deliberately
+    # ignores the filters in effect, so the numbers mean the same thing on every visit.
+    def set_person_migration_stats
+      person_entries = LexEntry.joins(:lex_file).where(lex_files: { entrytype: :person })
+      @person_entry_count = person_entries.count
+      @raw_person_entry_count = person_entries.where(status: :raw).count
+      @migrated_person_entry_count = person_entries.where.not(status: LexEntry::UNINGESTED_STATUSES).count
+      @migrated_person_percentage =
+        @person_entry_count.zero? ? 0 : (@migrated_person_entry_count * 100.0 / @person_entry_count).round(1)
+    end
 
     def set_lex_file
       @lex_file = LexFile.find(params[:id])

--- a/app/controllers/lexicon/files_controller.rb
+++ b/app/controllers/lexicon/files_controller.rb
@@ -101,10 +101,11 @@ module Lexicon
                                  .where(lex_files: { entrytype: :person })
                                  .group(:status)
                                  .count
+      # Grouping on an enum column keys the result by the enum's labels ('raw'), not by the
+      # integers stored in the column.
       @person_entry_count = counts_by_status.values.sum
-      @raw_person_entry_count = counts_by_status[LexEntry.statuses['raw']] || 0
-      uningested_values = LexEntry.statuses.values_at(*LexEntry::UNINGESTED_STATUSES)
-      uningested_count = counts_by_status.slice(*uningested_values).values.sum
+      @raw_person_entry_count = counts_by_status['raw'].to_i
+      uningested_count = counts_by_status.values_at(*LexEntry::UNINGESTED_STATUSES).compact.sum
       @migrated_person_entry_count = @person_entry_count - uningested_count
       @migrated_person_percentage =
         @person_entry_count.zero? ? 0 : (@migrated_person_entry_count * 100.0 / @person_entry_count).round(1)

--- a/app/controllers/lexicon/files_controller.rb
+++ b/app/controllers/lexicon/files_controller.rb
@@ -97,10 +97,15 @@ module Lexicon
     # Overall progress of the person-entry migration, shown above the queue. Deliberately
     # ignores the filters in effect, so the numbers mean the same thing on every visit.
     def set_person_migration_stats
-      person_entries = LexEntry.joins(:lex_file).where(lex_files: { entrytype: :person })
-      @person_entry_count = person_entries.count
-      @raw_person_entry_count = person_entries.where(status: :raw).count
-      @migrated_person_entry_count = person_entries.where.not(status: LexEntry::UNINGESTED_STATUSES).count
+      counts_by_status = LexEntry.joins(:lex_file)
+                                 .where(lex_files: { entrytype: :person })
+                                 .group(:status)
+                                 .count
+      @person_entry_count = counts_by_status.values.sum
+      @raw_person_entry_count = counts_by_status[LexEntry.statuses['raw']] || 0
+      uningested_values = LexEntry.statuses.values_at(*LexEntry::UNINGESTED_STATUSES)
+      uningested_count = counts_by_status.slice(*uningested_values).values.sum
+      @migrated_person_entry_count = @person_entry_count - uningested_count
       @migrated_person_percentage =
         @person_entry_count.zero? ? 0 : (@migrated_person_entry_count * 100.0 / @person_entry_count).round(1)
     end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -20,6 +20,11 @@ class LexEntry < ApplicationRecord
   # Statuses related to migration process
   MIGRATION_STATUSES = %w(raw migrating error verifying verified escalated).freeze
 
+  # Statuses in which the legacy file has not (yet) been successfully ingested: either
+  # untouched, in flight, or failed. Everything else means the ingestion completed, whatever
+  # the entry's subsequent editorial state.
+  UNINGESTED_STATUSES = %w(raw migrating error).freeze
+
   enum :status, {
     draft: 0,       # entry created but not ready for public access
     published: 1,   # entry approved for public access

--- a/app/views/lexicon/files/index.html.haml
+++ b/app/views/lexicon/files/index.html.haml
@@ -2,6 +2,17 @@
   %div{ style: 'margin-top:10px' }
     %h1= t('.title') + ': ' + t('.subtitle')
 
+    .lex-migration-stats.mb-3
+      %p.mb-1
+        = t('.stats',
+            total: number_with_delimiter(@person_entry_count),
+            migrated: number_with_delimiter(@migrated_person_entry_count),
+            raw: number_with_delimiter(@raw_person_entry_count))
+      .progress{ style: 'height: 20px;' }
+        .progress-bar{ role: 'progressbar', style: "width: #{@migrated_person_percentage}%",
+                       aria: { valuenow: @migrated_person_percentage, valuemin: '0', valuemax: '100' } }
+          #{@migrated_person_percentage}%
+
     = form_tag lexicon_files_path, method: :get, id: :filter, class: 'form-inline' do
       = label_tag :entrytype, LexFile.human_attribute_name(:entrytype), class: 'mr-2'
       = select_tag :entrytype,

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -141,6 +141,7 @@ en:
         subtitle: List of files
         title_placeholder: Search by title...
         fname_placeholder: Search by filename...
+        stats: "Person entries: %{total} | fully migrated: %{migrated} | still raw: %{raw}"
         entry_status_filter: Entry Status
         my_locked_title: Files locked by me
         locked_by_others_title: Files locked by other editors

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -142,6 +142,7 @@ he:
         subtitle: רשימת הקבצים
         title_placeholder: חיפוש לפי כותרת...
         fname_placeholder: חפש לפי שם קובץ...
+        stats: "ערכי אישים: %{total} | הוסבו במלואם: %{migrated} | ממתינים להסבה: %{raw}"
         entry_status_filter: סטטוס ערך
         my_locked_title: קבצים נעולים על ידי
         locked_by_others_title: קבצים נעולים על ידי עורכים אחרים

--- a/spec/requests/lexicon/files_spec.rb
+++ b/spec/requests/lexicon/files_spec.rb
@@ -35,6 +35,50 @@ describe '/lexicon/files' do
       end
     end
 
+    context 'with the person migration progress stats' do
+      let(:params) { {} }
+
+      before do
+        create_list(:lex_file, 3, :person, entry_status: :raw)
+        create(:lex_file, :person, entry_status: :migrating)
+        create(:lex_file, :person, entry_status: :draft)
+        create(:lex_file, :person, entry_status: :verifying)
+        create(:lex_file, :person, entry_status: :published)
+        # publications must not be counted at all
+        create(:lex_file, :publication, entry_status: :raw)
+        create(:lex_file, :publication, entry_status: :published)
+      end
+
+      it 'counts person entries by migration state and renders the progress bar' do
+        call
+        expect(assigns(:person_entry_count)).to eq(7)
+        expect(assigns(:raw_person_entry_count)).to eq(3)
+        expect(assigns(:migrated_person_entry_count)).to eq(3) # draft, verifying, published
+        expect(assigns(:migrated_person_percentage)).to eq(42.9)
+        expect(response.body).to include(
+          I18n.t('lexicon.files.index.stats', total: 7, migrated: 3, raw: 3)
+        )
+        expect(response.body).to include('width: 42.9%')
+      end
+
+      it 'ignores the active filters, reporting global progress' do
+        get '/lex/files', params: { entry_statuses: ['published'], title: 'no-such-title' }
+        expect(assigns(:lex_files)).to be_empty
+        expect(assigns(:person_entry_count)).to eq(7)
+        expect(assigns(:migrated_person_entry_count)).to eq(3)
+      end
+    end
+
+    context 'when there are no person entries at all' do
+      let(:params) { {} }
+
+      it 'reports zero percent without dividing by zero' do
+        call
+        expect(assigns(:person_entry_count)).to eq(0)
+        expect(assigns(:migrated_person_percentage)).to eq(0)
+      end
+    end
+
     context 'when the entrytype filter is explicitly blanked' do
       let(:params) { { entrytype: '' } }
 


### PR DESCRIPTION
## What

Adds progress statistics below the title of `/lex/files` (the lexicon migration queue):

- **Total** person entries
- **Fully migrated** count
- **Still raw** count
- A Bootstrap progress bar with the percentage complete (migrated ÷ total person entries)

## Definitions / decisions

- **"Fully migrated" = ingestion finished**: entry status is *not* `raw`, `migrating`, or `error`
  (new constant `LexEntry::UNINGESTED_STATUSES`). Entries in `draft`/`verifying`/`verified`/
  `escalated`/`published`/`deprecated` all count as migrated, whatever their later editorial
  state. So `total = migrated + raw + (migrating/error in flight)`.
- **Stats ignore the active filters** and always cover all person entries, so the number means
  the same thing on every visit. Confirmed with the requester before implementing.
- Only person entries are counted (publications are excluded entirely).

## Files

- `app/controllers/lexicon/files_controller.rb`: `set_person_migration_stats` — three counts
  plus a zero-safe percentage.
- `app/models/lex_entry.rb`: `UNINGESTED_STATUSES` constant.
- `app/views/lexicon/files/index.html.haml`: stats line + progress bar, matching the markup
  already used in the verification queue.
- `config/locales/lexicon.{he,en}.yml`: new `stats` key.

## Test plan

New request specs in `spec/requests/lexicon/files_spec.rb`:

- counts person entries by migration state (raw / migrating / draft / verifying / published),
  ignores publications, renders the localized stats line and the `width: 42.9%` bar;
- stats are unaffected by the status/title filters;
- zero person entries → 0%, no division by zero.

```
bundle exec rspec spec/requests/lexicon/files_spec.rb spec/models/lex_entry_spec.rb \
  spec/controllers/lexicon/entries_controller_spec.rb
# 147 examples, 0 failures
```

RuboCop and haml-lint clean on all changed files. The full suite (40+ min) was **not** run —
it needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
