### PR TITLE
Fix link-checker false negatives: drop "link" from User-Agent, widen HEAD fallback

### DIFF
--- a/app/services/lexicon/check_external_links.rb
+++ b/app/services/lexicon/check_external_links.rb
@@ -10,7 +10,7 @@ module Lexicon
   #
   # For each link (LexLink or LexCitation.link):
   # - Validates that the target host is not a private/loopback address (SSRF guard)
-  # - Makes an HTTP HEAD request (falls back to GET on 405)
+  # - Makes an HTTP HEAD request (falls back to GET when the server rejects HEAD)
   # - Follows up to MAX_REDIRECTS redirects
   # - Stores the final HTTP status code on the record (nil = check failed)
   # - 4xx/5xx codes indicate a broken link
@@ -20,6 +20,17 @@ module Lexicon
     MAX_REDIRECTS = 5
     TIMEOUT_SECONDS = 15
     REDIRECT_STATUSES = [301, 302, 303, 307, 308].freeze
+
+    # Statuses that commonly mean "this server dislikes HEAD" rather than "this URL is broken".
+    # Plenty of servers reject HEAD with 400/403/501 instead of the correct 405, so we retry
+    # once with GET before believing the link is dead.
+    HEAD_REJECTED_STATUSES = [400, 403, 405, 501].freeze
+
+    # Deliberately does NOT contain the word "link": mod_security's stock bad-bot rules match
+    # /link/ (as in "linkchecker") in the User-Agent and answer 403 to everything. www.text.org.il
+    # does exactly this -- `Project-Ben-Yehuda/1.0 (link-checker; +...)` gets a blanket 403 there
+    # while `Project-Ben-Yehuda/1.0 (+...)` gets 200. Keep us identifiable, just not by that token.
+    USER_AGENT = 'Project-Ben-Yehuda/1.0 (+https://benyehuda.org)'
 
     # RFC1918, loopback, link-local, and IPv6 private ranges to block (SSRF guard)
     PRIVATE_IP_RANGES = [
@@ -108,8 +119,8 @@ module Lexicon
         request = Net::HTTP::Head.new(uri.request_uri, default_headers)
         response = http.request(request)
 
-        # Fall back to GET if HEAD is not allowed
-        if response.code.to_i == 405
+        # Fall back to GET if the server appears to be rejecting the HEAD method itself
+        if HEAD_REJECTED_STATUSES.include?(response.code.to_i)
           request = Net::HTTP::Get.new(uri.request_uri, default_headers)
           response = http.request(request)
         end
@@ -119,7 +130,7 @@ module Lexicon
     end
 
     def default_headers
-      { 'User-Agent' => 'Project-Ben-Yehuda/1.0 (link-checker; +https://benyehuda.org)' }
+      { 'User-Agent' => USER_AGENT }
     end
 
     def parse_uri(url)

--- a/spec/services/lexicon/check_external_links_spec.rb
+++ b/spec/services/lexicon/check_external_links_spec.rb
@@ -108,17 +108,82 @@ describe Lexicon::CheckExternalLinks do
     end
   end
 
-  context 'when HEAD returns 405 (Method Not Allowed), falls back to GET' do
-    let!(:link) { create(:lex_link, item: person, url: 'http://example.com/head-not-allowed') }
+  # Many servers reject the HEAD method with something other than the correct 405 -- notably a
+  # bare 403, which is indistinguishable from "broken" unless we retry with GET.
+  describe 'falling back to GET when the server rejects HEAD' do
+    [400, 403, 405, 501].each do |head_status|
+      context "when HEAD returns #{head_status} but GET succeeds" do
+        let!(:link) { create(:lex_link, item: person, url: 'http://example.com/head-rejected') }
 
-    before do
-      stub_request(:head, 'http://example.com/head-not-allowed').to_return(status: 405)
-      stub_request(:get, 'http://example.com/head-not-allowed').to_return(status: 200)
+        before do
+          stub_request(:head, 'http://example.com/head-rejected').to_return(status: head_status)
+          stub_request(:get, 'http://example.com/head-rejected').to_return(status: 200)
+        end
+
+        it 'records 200 and does not mark the link broken' do
+          call
+          expect(link.reload.http_status).to eq(200)
+          expect(link.reload).not_to be_broken
+        end
+      end
     end
 
-    it 'falls back to GET and records 200' do
-      call
-      expect(link.reload.http_status).to eq(200)
+    context 'when both HEAD and GET are refused (genuinely gated or broken)' do
+      let!(:link) { create(:lex_link, item: person, url: 'http://example.com/gated') }
+
+      before do
+        stub_request(:head, 'http://example.com/gated').to_return(status: 403)
+        stub_request(:get, 'http://example.com/gated').to_return(status: 403)
+      end
+
+      it 'records the 403 and marks the link broken' do
+        call
+        expect(link.reload.http_status).to eq(403)
+        expect(link.reload).to be_broken
+      end
+    end
+
+    context 'when HEAD returns a status that is not a HEAD rejection' do
+      let!(:link) { create(:lex_link, item: person, url: 'http://example.com/really-missing') }
+
+      before do
+        stub_request(:head, 'http://example.com/really-missing').to_return(status: 404)
+      end
+
+      it 'does not retry with GET' do
+        call
+        expect(link.reload.http_status).to eq(404)
+        assert_not_requested(:get, 'http://example.com/really-missing')
+      end
+    end
+  end
+
+  # Regression: www.text.org.il's mod_security rules 403 any User-Agent containing "link"
+  # (matching "linkchecker"), which made every link on that host look broken. See #1594.
+  describe 'the User-Agent sent to external servers' do
+    # WebMock's request registry is not reset between examples in this file, so each example
+    # uses its own URL to keep request counts from leaking into the next one.
+    let!(:link) { create(:lex_link, item: person, url: url) }
+
+    before { stub_request(:head, url).to_return(status: 200) }
+
+    context 'when checking a link' do
+      let(:url) { 'http://example.com/ua-no-link-token' }
+
+      it 'sends no User-Agent containing "link", which trips stock bad-bot WAF rules' do
+        call
+        assert_not_requested(:head, url, headers: { 'User-Agent' => /link/i })
+      end
+    end
+
+    context 'when identifying ourselves' do
+      let(:url) { 'http://example.com/ua-identifies-project' }
+
+      it 'names the project and its URL' do
+        call
+        assert_requested(:head, url,
+                         headers: { 'User-Agent' => %r{\AProject-Ben-Yehuda/.*benyehuda\.org} })
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

Lexicon ingestion link checking reports persistent false "broken link" results for two hosts. They turned out to have **different** causes, and only one is fixable.

### `www.text.org.il` — fixed here

Not Cloudflare. The host runs LiteSpeed with `vary: User-Agent` and a stock mod_security bad-bot rule that 403s any User-Agent containing the substring **`link`** (matching "linkchecker"). Bisected against `https://www.text.org.il/index.php`:

| User-Agent | Result |
|---|---|
| `Project-Ben-Yehuda/1.0 (link-checker; +https://benyehuda.org)` | **403** |
| `Project-Ben-Yehuda/1.0 (link-checker)` | **403** |
| `Project-Ben-Yehuda/1.0 (link)` | **403** |
| `Project-Ben-Yehuda/1.0 (+https://benyehuda.org)` | 200 |
| `Project-Ben-Yehuda/1.0 (checker; +https://benyehuda.org)` | 200 |
| `Ruby` | 200 |

The host's root path answers 200 either way, which is why this looked intermittent — only the deep paths that lexicon entries actually cite were affected. **HEAD was ruled out as the cause**: GET fails identically.

### `www.nli.org.il` — NOT fixed here, tracked in `by-9jz`

A zone-wide Cloudflare **managed challenge**, not a block:

```
HTTP/2 403
cf-mitigated: challenge
server: cloudflare
critical-ch: Sec-CH-UA-...
```

Even `/robots.txt` and `/favicon.ico` 403. It fails identically with HEAD *and* GET, with our UA *and* a full Chrome UA plus Accept headers. Passing it requires executing the JS challenge and presenting a browser TLS fingerprint, which `Net::HTTP` cannot do — so every NLI 403 we record is a false negative by construction. Since checks run from an AWS datacenter ASN, Cloudflare scores us worse than the residential IP these probes came from, so this will not improve on its own.

## Changes

- **`app/services/lexicon/check_external_links.rb`**
  - New `USER_AGENT` constant without the `link` token, with a comment explaining exactly why — this is the kind of thing that gets "cleaned up" back to `link-checker` by a future reader.
  - `HEAD_REJECTED_STATUSES = [400, 403, 405, 501]` widens the GET fallback, which previously fired only on 405. Many servers reject the HEAD *method* with 400/403/501 instead, which was indistinguishable from a dead link. Independent of the two hosts above.
  - Updated the stale class-doc line that said "falls back to GET on 405".

## Test plan

`spec/services/lexicon/check_external_links_spec.rb` — 36 examples, 0 failures.

- Parameterised fallback coverage for each of 400/403/405/501 → GET → 200 → not broken.
- HEAD 403 + GET 403 → still recorded 403 and still broken (the fallback must not paper over real failures).
- HEAD 404 → **no** GET retry (fallback stays narrow).
- UA regression guards: no `link` token sent, and we still identify project + URL.

The UA guard was **mutation-tested** — restoring the old `link-checker` UA makes it fail, confirming it isn't passing vacuously. (An earlier version of that assertion did pass vacuously because `req.headers['User-Agent']` reads nil inside a WebMock `with` block; it now uses WebMock header matching.)

Also ran green: `spec/requests/lexicon/links_spec.rb`, `spec/requests/lexicon/citations_spec.rb`, `spec/models/lex_citation_spec.rb`, `spec/services/lexicon/monday_report_spec.rb` — 138 examples, 0 failures total.

RuboCop clean on both changed files.

**The full suite was not run** (40+ min, needs approval per `.claude/rules/full-test-suite-runtime.md`).

## Verification needed from prod

All probes above ran from a dev machine, not from prod. Since checks run from **AWS us-east-1b**, please confirm the UA fix there — I can't rule out an additional IP-reputation rule on that host:

```bash
curl -sS -o /dev/null -I -w 'old=%{http_code}\n' -A 'Project-Ben-Yehuda/1.0 (link-checker; +https://benyehuda.org)' https://www.text.org.il/index.php
curl -sS -o /dev/null -I -w 'new=%{http_code}\n' -A 'Project-Ben-Yehuda/1.0 (+https://benyehuda.org)'             https://www.text.org.il/index.php
```

`old=403 new=200` confirms it.

## Follow-up

`by-9jz` covers the NLI case: add an `unverifiable` flag via migration, detect the gate *generically* from response headers rather than a hardcoded hostname allowlist, exclude it from `broken_link?`, and show verifying editors a neutral "verify this manually" badge instead of a red broken-link warning. Deliberately not a blanket whitelist that assumes such links never break — "we can't tell" is the honest state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
