### PR TITLE
Fix 406 when uploading an attachment from the verification workbench

### DIFF
--- a/app/assets/javascripts/lexicon_backend.js
+++ b/app/assets/javascripts/lexicon_backend.js
@@ -62,6 +62,18 @@ function reloadContent(tabContent) {
 
 }
 
+// The attachments panel is the #attachments tab pane on the entry edit page, but the same panel is
+// also shown standalone and inside the verification workbench modal, where there is no pane to
+// refresh in place -- reload the page in those cases.
+function reloadAttachmentsPanel() {
+    const pane = $('#attachments');
+    if (pane.length) {
+        reloadContent(pane);
+    } else {
+        reloadPage();
+    }
+}
+
 function openModal(path, onSuccess = null) {
     $('#generalDlg').data('onSuccess', onSuccess);
 

--- a/app/controllers/lexicon/attachments_controller.rb
+++ b/app/controllers/lexicon/attachments_controller.rb
@@ -17,7 +17,10 @@ module Lexicon
 
     # Returns content of LexEntry attachments panel
     def index
-      render layout: false
+      # Normally loaded as a fragment (entry edit tab pane, verification workbench modal), but the
+      # panel is also reachable by direct navigation, which needs the layout and its JS assets --
+      # without them the remote form below degrades to a plain HTML submit.
+      render layout: request.xhr? ? false : 'lexicon_backend'
     end
 
     def create
@@ -28,6 +31,14 @@ module Lexicon
         @error = t('.file_exists', filename: filename)
       else
         @lex_entry.attachments.attach(file)
+      end
+
+      respond_to do |format|
+        format.js
+        format.html do
+          flash[:alert] = @error if @error.present?
+          redirect_to lexicon_entry_attachments_path(@lex_entry)
+        end
       end
     end
 

--- a/app/views/lexicon/attachments/create.js.erb
+++ b/app/views/lexicon/attachments/create.js.erb
@@ -4,4 +4,4 @@ $('#attachment').val('');
 <% if @error.present? %>
     alert('<%= j @error %>');
 <% end %>
-reloadContent($('#attachments'));
+reloadAttachmentsPanel();

--- a/app/views/lexicon/attachments/destroy.js
+++ b/app/views/lexicon/attachments/destroy.js
@@ -1,1 +1,1 @@
-reloadContent($('#attachments'));
+reloadAttachmentsPanel();

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -357,7 +357,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_attachments')
   .section-actions
-    = link_to t('lexicon.verification.migrated.upload_file'), lexicon_entry_attachments_path(entry), class: 'btn btn-sm btn-success'
+    = link_to t('lexicon.verification.migrated.upload_file'), lexicon_entry_attachments_path(entry), class: 'btn btn-sm btn-success', onclick: 'event.preventDefault(); openModal(this.href);'
     %button.btn.btn-sm{class: checklist['attachments']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: 'attachments'}}
       ✓
       = t('lexicon.verification.migrated.mark_verified')

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -170,7 +170,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_attachments')
   .section-actions
-    = link_to t('lexicon.verification.migrated.upload_file'), lexicon_entry_attachments_path(entry), class: 'btn btn-sm btn-success'
+    = link_to t('lexicon.verification.migrated.upload_file'), lexicon_entry_attachments_path(entry), class: 'btn btn-sm btn-success', onclick: 'event.preventDefault(); openModal(this.href);'
     %button.btn.btn-sm{class: checklist['attachments']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: 'attachments'}}
       ✓
       = t('lexicon.verification.migrated.mark_verified')

--- a/spec/requests/lexicon/attachments_spec.rb
+++ b/spec/requests/lexicon/attachments_spec.rb
@@ -37,6 +37,20 @@ describe '/lexicon/entries/<ENTRY_ID>/attachments' do
       expect(doc.css('tr').count).to eq(3)  # one row in header and two rows for attachments
       expect(doc.css('img').count).to eq(1) # only image attachment should have a preview
     end
+
+    context 'when loaded as an AJAX fragment' do
+      subject(:call) { get "/lex/entries/#{lex_entry.id}/attachments", xhr: true }
+
+      it 'renders without a layout' do
+        expect(call).to eq(200)
+        expect(response.body).not_to include('<html')
+      end
+    end
+
+    it 'renders with the layout on direct navigation, so the remote form has its JS assets' do
+      expect(call).to eq(200)
+      expect(response.body).to include('<html')
+    end
   end
 
   describe 'POST /lexicon/entries/<ENTRY_ID>/attachments' do
@@ -70,6 +84,40 @@ describe '/lexicon/entries/<ENTRY_ID>/attachments' do
         expect(response.body).to include(
           "alert('#{I18n.t('lexicon.attachments.create.file_exists', filename: 'lorem_ipsum.png')}');"
         )
+      end
+    end
+
+    # Regression: a non-XHR submit (what a JS-less page does with a remote form) used to raise
+    # ActionController::UnknownFormat and return 406 *after* the file had already been attached.
+    context 'when submitted as a plain HTML form' do
+      subject(:call) { post "/lex/entries/#{lex_entry.id}/attachments", params: { attachment: file } }
+
+      let(:file) do
+        Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/test_image.jpg'), 'image/jpeg')
+      end
+
+      it 'creates the attachment and redirects back to the panel' do
+        expect { call }.to change { lex_entry.attachments.count }.by(1)
+        expect(response).to redirect_to("/lex/entries/#{lex_entry.id}/attachments")
+
+        expect(attached_filenames).to include('test_image.jpg')
+      end
+
+      context 'when file with the same name already exists' do
+        let!(:image) do
+          lex_entry.attachments.attach(
+            io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
+            filename: 'test_image.jpg'
+          ).last
+        end
+
+        it 'does not create attachment and sets a flash alert' do
+          expect { call }.not_to(change { lex_entry.attachments.count })
+          expect(response).to redirect_to("/lex/entries/#{lex_entry.id}/attachments")
+          expect(flash[:alert]).to eq(
+            I18n.t('lexicon.attachments.create.file_exists', filename: 'test_image.jpg')
+          )
+        end
       end
     end
   end

--- a/spec/system/lexicon/verification_attachment_upload_spec.rb
+++ b/spec/system/lexicon/verification_attachment_upload_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression: the "upload file" button navigated to the layout-less attachments fragment, so no JS
+# was loaded, the remote form fell back to a plain HTML POST, and the response was a 406 even though
+# the file had already been attached.
+RSpec.describe 'Uploading an attachment from the verification page', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:jpeg_path) { Rails.root.join('spec/fixtures/files/test_image.jpg') }
+
+  it 'attaches the uploaded JPEG and shows it in the attachments section' do
+    visit lexicon_verification_path(entry)
+
+    within('#section-attachments') do
+      click_link I18n.t('lexicon.verification.migrated.upload_file')
+    end
+
+    expect(page).to have_css('#generalDlg #new_attachment_form', visible: :visible, wait: 10)
+
+    attach_file 'attachment', jpeg_path
+    click_button I18n.t(:upload)
+
+    # The page reloads once the upload succeeds, re-rendering the attachments section.
+    expect(page).to have_css('#section-attachments', text: 'test_image.jpg', wait: 15)
+
+    expect(entry.attachments.reload.map { |a| a.blob.filename.to_s }).to eq(['test_image.jpg'])
+  end
+end


### PR DESCRIPTION
## Problem

Uploading a file from the migration/verification workbench returned **HTTP 406** — yet the file *was* attached.

Both symptoms are the same event. `attachments.attach(file)` runs, *then* Rails tries to render, finds only `create.js.erb` for an `Accept: text/html` request, raises `ActionController::UnknownFormat`, and returns 406. The blob is already committed by then.

Why the request was HTML instead of JS:

1. The workbench's "upload file" button was a plain `link_to lexicon_entry_attachments_path` — a full page navigation.
2. `Lexicon::AttachmentsController#index` renders `layout: false`, because it is normally loaded as an AJAX fragment into the entry-edit tab pane.
3. Standalone, that means no jQuery and no rails-ujs, so the `remote: true` upload form degraded to a plain HTML POST.
4. → 406.

## Fix

- **`_person_sections.html.haml` / `_publication_sections.html.haml`**: "upload file" now opens the panel in the workbench's existing modal via `openModal()`, matching the sibling "add link" button. The panel keeps its JS context, and the reviewer stays on the workbench.
- **`Lexicon::AttachmentsController`**:
  - `#index` renders the `lexicon_backend` layout unless `request.xhr?`, so a direct visit is a real page with its assets rather than a naked fragment.
  - `#create` gains `respond_to` with an html branch that redirects back to the panel, putting the duplicate-filename message in `flash[:alert]`. No path can 406 again.
- **`lexicon_backend.js`**: new `reloadAttachmentsPanel()` — refreshes `#attachments` in place when the tab pane exists, otherwise `reloadPage()` (which preserves the workbench's scroll positions).
- **`create.js.erb` / `destroy.js`**: call the shared helper instead of `reloadContent($('#attachments'))`, which silently no-opped anywhere but the entry-edit page.

`#destroy` deliberately keeps js-only rendering: without JS, `data-method=delete` never fires at all, so an html branch there would be dead code.

## Test plan

- `spec/system/lexicon/verification_attachment_upload_spec.rb` (new): the reported scenario end to end — upload a JPEG from the workbench, see it appear in the attachments section. **Verified it fails without the fix** (stashed the fix, re-ran, it failed at the modal step).
- `spec/requests/lexicon/attachments_spec.rb`: non-XHR POST creates the attachment and redirects (the direct 406 regression test, with a JPEG); duplicate filename sets `flash[:alert]`; `#index` renders with a layout on direct navigation and without one for XHR.

Ran green:

- `bundle exec rspec spec/requests/lexicon/` → 313 examples, 0 failures
- `bundle exec rspec spec/system/lexicon/` → 171 examples, 0 failures

The full suite was **not** run (40+ min); CI will cover it. RuboCop and haml-lint are clean on the changed lines.

## Known adjacent issue, not fixed here

Submitting the form with no file selected hits `params[:attachment].original_filename` on a blank param → 500. Pre-existing, and out of scope for this fix — happy to guard it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
