### PR TITLE
Remove obsolete bd sync steps from agent instructions

### DIFF
--- a/.claude/rules/beads-tracking.md
+++ b/.claude/rules/beads-tracking.md
@@ -57,7 +57,7 @@ bd close bd-42 --reason "Completed" --json
 3. **Create feature branch**: See git-workflow.md (NEVER work directly on existing branches!)
 4. **Work on it**: Implement, test, document
 5. **Discover new work?** Create linked issue: `bd create "Found bug" -p 1 --deps discovered-from:<parent-id>`
-6. **Complete**: `bd close <id>` after PR is created (not after merge), then `bd sync`
+6. **Complete**: `bd close <id>` after PR is created (not after merge)
 
 ## Auto-Sync
 
@@ -129,4 +129,3 @@ Run `bd <command> --help` to see all available flags for any command.
 - ✅ Always use `--json` flag for programmatic use
 - ✅ Link discovered work with `discovered-from` dependencies
 - ✅ Store AI planning docs in `history/` directory
-- ✅ Run `bd sync` before and after commits

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -56,9 +56,7 @@ If you accidentally pushed to master/main:
 3. **Make your changes and commit to YOUR branch:**
    ```bash
    git add <files>
-   bd sync  # sync beads changes
    git commit -m "Your commit message"
-   bd sync  # sync beads changes again
    ```
    - Never run `git commit` while on master/main!
    - Double-check with `git branch --show-current` if unsure
@@ -83,7 +81,6 @@ If you accidentally pushed to master/main:
 6. **Close the bead** after PR is created:
    ```bash
    bd close <bead-id> --reason "Created PR #123"
-   bd sync
    ```
    - Close the bead AFTER creating the PR, not after merge
    - Include the PR number in the close reason
@@ -99,7 +96,6 @@ Before running ANY git command, verify:
 - [ ] Am I on a branch I created in this session? (`git branch --show-current`)
 - [ ] If not, have I created a new feature/fix branch?
 - [ ] Am I about to push to my own branch, not master/main?
-- [ ] Have I run `bd sync` before and after committing?
 - [ ] Will I create a PR with `--base <recorded-base-branch>` after pushing?
 
 **If any answer is NO, do NOT proceed with git push!**

--- a/.claude/startup-hook.sh
+++ b/.claude/startup-hook.sh
@@ -25,13 +25,10 @@ cat << 'EOF'
 
 [ ] 2. git status              (check what changed)
 [ ] 3. git add <files>         (stage code changes)
-[ ] 4. bd sync                 (commit beads changes)
-[ ] 5. git commit -m "..."     (commit code with proper message)
-[ ] 6. bd sync                 (commit any new beads changes)
-[ ] 7. git push -u origin <your-feature-branch>  (push YOUR branch, not master!)
-[ ] 8. gh pr create --title "..." --body "..."   (create Pull Request)
-[ ] 9. bd close <id> --reason "Created PR #XXX"  (close bead AFTER PR created)
-[ ] 10. bd sync                (final sync)
+[ ] 4. git commit -m "..."     (commit code with proper message)
+[ ] 5. git push -u origin <your-feature-branch>  (push YOUR branch, not master!)
+[ ] 6. gh pr create --title "..." --body "..."   (create Pull Request)
+[ ] 7. bd close <id> --reason "Created PR #XXX"  (close bead AFTER PR created)
 ```
 
 ## ⛔ THE MOST IMPORTANT RULE ⛔
@@ -77,9 +74,7 @@ git checkout -b feature/by-6b7-collapse-buttons
 
 # 3. Make changes, then commit
 git add app/views/authors/toc.html.haml
-bd sync
 git commit -m "Implement collapse/expand buttons"
-bd sync
 
 # 4. Push YOUR branch
 git push -u origin feature/by-6b7-collapse-buttons
@@ -89,7 +84,6 @@ gh pr create --title "Implement collapse/expand all buttons" --body "..."
 
 # 6. Close bead
 bd close by-6b7 --reason "Created PR #123"
-bd sync
 ```
 
 EOF


### PR DESCRIPTION
## What

Removes every instruction to run `bd sync` from the agent-facing docs.

## Why

`bd sync` no longer exists. The installed beads version (bd 1.2.2) responds:

```
$ bd sync
Error: unknown command "sync" for "bd"
```

The instructions told agents to run it before *and* after every `git commit`,
after `bd close`, and as a final session-close step — so every agent workflow
ended up issuing a command that just errors. Export to `.beads/issues.jsonl`
happens automatically after `bd create`/`bd close`, so nothing needs to replace it.

## Changed

- `.claude/startup-hook.sh` — dropped the three `bd sync` steps from the session-close
  checklist (renumbered 2–7) and the two from the example workflow.
- `.claude/rules/git-workflow.md` — dropped it from the commit snippet (step 3), the
  bead-close snippet (step 6), and the pre-commit checklist item.
- `.claude/rules/beads-tracking.md` — dropped it from workflow step 6 and the key-rules list.

Docs only; no application code touched. `bash -n .claude/startup-hook.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
