### PR TITLE
Fix lexicon citations lost when no <font> wrapper follows the Bib. header (by-5su)

### DIFF
--- a/app/services/lexicon/extract_citations.rb
+++ b/app/services/lexicon/extract_citations.rb
@@ -5,20 +5,24 @@ module Lexicon
   class ExtractCitations < ApplicationService
     include HtmlUtils
 
+    # Elements that can open the citations section. Older exports always wrapped the bibliography
+    # in a <font> tag, but the newest ones drop that wrapper and put the first <ul> (or a bare
+    # <li>) directly after the header.
+    CITATIONS_START_TAGS = %w(font ul li).freeze
+
     def call(html_doc)
       header = header_element(html_doc)
       return [] if header.nil?
 
-      # The next element should be a 'font' tag containing all citations. Sometimes there could be one or more blank
-      # paragraphs before it, so we skip blank non-font elements. Font elements are always potential
-      # citations-section markers even when their content is empty (e.g. <font color="#FF0000"></font>),
-      # so we must not skip them.
+      # The next element should open the citations section. Sometimes there could be one or more
+      # blank paragraphs before it, so we skip blank elements that cannot open the section. Section
+      # openers are never skipped even when their content is empty (e.g. <font color="#FF0000"></font>).
       citations_node = header.next_element
-      while citations_node.present? && citations_node.name != 'font' && citations_node.text.blank?
+      while citations_node.present? && !citations_start?(citations_node) && citations_node.text.blank?
         citations_node = citations_node.next_element
       end
 
-      return [] if citations_node&.name != 'font'
+      return [] if citations_node.nil? || !citations_start?(citations_node)
 
       html_nodes = [citations_node]
 
@@ -63,6 +67,10 @@ module Lexicon
     end
 
     private
+
+    def citations_start?(elem)
+      CITATIONS_START_TAGS.include?(elem.name)
+    end
 
     def header_element(html_doc)
       header = html_doc.at_css('a[name="Bib."]')

--- a/spec/fixtures/files/lexicon/ul_directly_after_citations_header.php
+++ b/spec/fixtures/files/lexicon/ul_directly_after_citations_header.php
@@ -1,0 +1,22 @@
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head>
+<body dir="rtl">
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul style="margin-top:0in" type=circle>
+  <li>ספר ראשון (תל אביב, 2012)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<ul style="margin-top:0in" type=circle>
+  <li><b>כהן, דוד.</b> ביקורת כללית. <u>הארץ</u>, 1 בינואר 2020, עמ׳ 5.</li>
+  <li><b>לוי, יוסף.</b> מאמר נוסף. <u>מעריב</u>, 10 בפברואר 2021, עמ׳ 8.</li>
+</ul>
+<font color="#FF0000">על ״ספר ראשון״</font>
+<ul style="margin-top:0in" type=circle>
+  <li><b>פלוני, ראובן.</b> ביקורת שנייה. <u>ידיעות אחרונות</u>, 5 במארס 2022, עמ׳ 3.</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="links">קישורים:</a></font></p>
+<ul style="margin-top:0in" type=circle>
+  <li><a href="https://example.com">אתר חיצוני שאינו ציטוט</a></li>
+</ul>
+</body>
+</html>

--- a/spec/services/lexicon/extract_citations_spec.rb
+++ b/spec/services/lexicon/extract_citations_spec.rb
@@ -72,6 +72,31 @@ describe Lexicon::ExtractCitations do
     end
   end
 
+  context 'when the citation lists follow the header directly, with no <font> wrapper at all' do
+    # Regression test for 00044.php: the current production export dropped the <font size="2">
+    # wrapper that older files placed right after the Bib. anchor, so the first <ul> is now the
+    # header's immediate sibling. The guard requiring the section to open with a <font> made the
+    # service return [], and not a single citation of the entry was migrated.
+    let(:filename) { Rails.root.join('spec/fixtures/files/lexicon/ul_directly_after_citations_header.php') }
+
+    it 'extracts all citations across every subject group' do
+      captured_html = nil
+      allow(Lexicon::ParseCitations).to receive(:call) do |html|
+        captured_html = html
+        []
+      end
+
+      result
+
+      expect(captured_html).not_to be_nil
+      expect(Nokogiri::HTML(captured_html).css('li').size).to eq(3)
+      expect(captured_html).to include('כהן, דוד')
+      expect(captured_html).to include('על ״ספר ראשון״')
+      # The walk must stop at the Links section header rather than swallowing its list.
+      expect(captured_html).not_to include('אתר חיצוני שאינו ציטוט')
+    end
+  end
+
   context 'when a stray </span> inside a <li> prematurely closes the parent span' do
     # Regression test for 00034.php: a stray </span> after </b> inside a citation <li>
     # caused Nokogiri to prematurely close the <span dir="rtl"> wrapping the citations section.


### PR DESCRIPTION
## Problem (by-5su)

Legacy lexicon file `00044.php` (אדמיאל קוסמן) migrated **zero** citations — silently, with no error recorded on the entry.

The copy of `00044.php` in the local `lexicon/` snapshot (dated 2019) migrates fine, which is what made this hard to see. The **current production** export of the same file differs: it dropped the `<font size="2">` wrapper that older files placed immediately after the `<a name="Bib.">` header, so the first `<ul>` is now the header's direct sibling.

`ExtractCitations` required the citations section to open with a `<font>`:

```ruby
return [] if citations_node&.name != 'font'
```

so it bailed out before parsing anything.

## Fix

Accept `<ul>` and `<li>` as citation-section openers alongside `<font>`. The existing sibling-walk already handles the flat "subject `<font color="#FF0000">` header + `<ul>`" layout that follows, and still stops at the Links section header.

## Verification

- On the production copy of `00044.php`: all 72 source `<li>` (73 after Nokogiri repairs one unclosed `<li>`) now reach `ParseCitations`, across all 14 subject groups, with the Links section correctly excluded. A full `IngestPerson` run yields 73 citations / 17 works / 14 subject groups.
- **Corpus regression check**: ran `ExtractCitations` (with `ParseCitations` stubbed) over all 4051 local lexicon files and diffed the `<li>` counts before vs. after. Six further files went from zero citations to a full extraction — 00040 (67), 00073 (27), 00379 (43), 00423 (7), 02444 (3), 99994 (1) — and **no other file changed in any direction**.

## Tests

- New fixture `spec/fixtures/files/lexicon/ul_directly_after_citations_header.php` reproducing the production layout.
- New regression example in `spec/services/lexicon/extract_citations_spec.rb`, asserting all 3 citations across both subject groups are captured and that the walk stops before the Links list.

## Test plan

```
bundle exec rspec spec/services/lexicon/        # 225 examples, 0 failures
bundle exec rspec spec/models/lex_person_spec.rb spec/models/lex_citation_spec.rb spec/requests/lexicon/
                                                # 343 examples, 0 failures
bundle exec rubocop app/services/lexicon/extract_citations.rb spec/services/lexicon/extract_citations_spec.rb
                                                # no offenses
```

The full suite (40+ min) was **not** run — needs your approval.

## Follow-up worth considering

Entries whose bibliography fails to parse migrate with zero citations and no error, so the failure is invisible in the migration queue. The seven files above were only found by diffing. A "person entry has a Bib. section but migrated zero citations" check would surface this class of bug automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
