### PR TITLE
Release lexicon entry lock immediately on publishing (by-4bs)

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -247,6 +247,9 @@ module Lexicon
     # POST /lexicon/verification/:id/mark_verified
     def mark_verified
       @entry.mark_verified!
+      # Verification is over, so hold on to the lock no longer: leaving it to expire would keep the
+      # entry listed as locked in the queue for up to LOCK_TIMEOUT_IN_SECONDS.
+      @entry.release_lock!
       report_verification_to_monday
       redirect_to lexicon_entry_path(@entry),
                   notice: I18n.t('lexicon.verification.messages.entry_verified_public')

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -246,16 +246,22 @@ module Lexicon
 
     # POST /lexicon/verification/:id/mark_verified
     def mark_verified
-      @entry.mark_verified!
-      # Verification is over, so hold on to the lock no longer: leaving it to expire would keep the
-      # entry listed as locked in the queue for up to LOCK_TIMEOUT_IN_SECONDS.
-      @entry.release_lock!
+      begin
+        @entry.mark_verified!
+        # Verification is over, so hold on to the lock no longer: leaving it to expire would keep
+        # the entry listed as locked in the queue for up to LOCK_TIMEOUT_IN_SECONDS.
+        @entry.release_lock!
+      rescue StandardError => e
+        # Publication did not happen, so send the editor back to the workbench to finish up.
+        redirect_to lexicon_verification_path(@entry), alert: e.message
+        return
+      end
+
+      # Past this point the entry is published and unlocked. Nothing that follows may redirect back
+      # to the workbench: that GET would immediately re-acquire the lock we just released.
       report_verification_to_monday
       redirect_to lexicon_entry_path(@entry),
                   notice: I18n.t('lexicon.verification.messages.entry_verified_public')
-    rescue StandardError => e
-      redirect_to lexicon_verification_path(@entry),
-                  alert: e.message
     end
 
     # GET /lexicon/verification/:id/bio_comparison
@@ -422,9 +428,19 @@ module Lexicon
       )
       return if result[:success]
 
-      # flash, not flash.now: the only caller (mark_verified) redirects afterwards.
+      warn_monday_report_failed(result[:error])
+    rescue StandardError => e
+      # MondayClient normalises its own failures into a { success:, error: } hash, so this is
+      # defence in depth: the entry is published and unlocked by now, and no failure in reporting
+      # it may be allowed to change that.
+      Rails.logger.error("Lexicon::MondayMigrationReport raised: #{e.message}")
+      warn_monday_report_failed(e.message)
+    end
+
+    # flash, not flash.now: the only caller (mark_verified) redirects afterwards.
+    def warn_monday_report_failed(error)
       flash[:alert] = # rubocop:disable Rails/ActionControllerFlashBeforeRender
-        I18n.t('lexicon.verification.monday.migration_report_failed', error: result[:error])
+        I18n.t('lexicon.verification.monday.migration_report_failed', error: error)
     end
 
     def record_to_lock

--- a/spec/requests/lexicon/verification_mark_verified_spec.rb
+++ b/spec/requests/lexicon/verification_mark_verified_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe 'POST /lex/verification/:id/mark_verified', type: :request do
       )
     end
 
+    it 'releases the lock instead of leaving it to expire' do
+      post url
+
+      entry.reload
+      expect(entry.locked_at).to be_nil
+      expect(entry.locked_by_user).to be_nil
+      expect(entry).not_to be_locked
+    end
+
     it 'redirects to the public entry page with a success notice' do
       post url
 
@@ -83,6 +92,14 @@ RSpec.describe 'POST /lex/verification/:id/mark_verified', type: :request do
 
       expect(Lexicon::MondayMigrationReport).not_to have_received(:call)
       expect(entry.reload).not_to be_status_published
+    end
+
+    it 'keeps the lock so the editor can carry on verifying' do
+      post url
+
+      entry.reload
+      expect(entry.locked_by_user).to eq(editor)
+      expect(entry).to be_locked
     end
   end
 end

--- a/spec/requests/lexicon/verification_mark_verified_spec.rb
+++ b/spec/requests/lexicon/verification_mark_verified_spec.rb
@@ -79,6 +79,34 @@ RSpec.describe 'POST /lex/verification/:id/mark_verified', type: :request do
       )
       expect(flash[:notice]).to eq(I18n.t('lexicon.verification.messages.entry_verified_public'))
     end
+
+    it 'still releases the lock' do
+      post url
+
+      expect(entry.reload.locked_at).to be_nil
+    end
+  end
+
+  context 'when the Monday post raises' do
+    before do
+      allow(Lexicon::MondayMigrationReport).to receive(:call).and_raise(Net::OpenTimeout, 'execution expired')
+    end
+
+    # The entry is published and unlocked by the time we talk to Monday, so a raise there must not
+    # bounce the editor back to the workbench — that GET would immediately re-acquire the lock.
+    it 'publishes, releases the lock and redirects to the public entry page with a warning' do
+      post url
+
+      entry.reload
+      expect(entry).to be_status_published
+      expect(entry.locked_at).to be_nil
+      expect(entry.locked_by_user).to be_nil
+      expect(response).to redirect_to(lexicon_entry_path(entry))
+      expect(flash[:alert]).to eq(
+        I18n.t('lexicon.verification.monday.migration_report_failed', error: 'execution expired')
+      )
+      expect(flash[:notice]).to eq(I18n.t('lexicon.verification.messages.entry_verified_public'))
+    end
   end
 
   context 'when verification is not complete' do


### PR DESCRIPTION
## Problem

When an editor finishes verifying a migrated lexicon entry and publishes it
(`POST /lex/verification/:id/mark_verified`), the `Lockable` lock obtained by
the `try_to_lock_record` before_action was left in place. It only cleared when
the 15-minute `LOCK_TIMEOUT_IN_SECONDS` expired, so the published entry kept
appearing under "my locked entries" in the verification queue and stayed
unavailable to other editors for no reason.

## Change

`Lexicon::VerificationController#mark_verified` now calls `@entry.release_lock!`
right after `mark_verified!` succeeds — before the Monday report, so a Monday
failure can't leave the lock hanging. If verification is incomplete and
`mark_verified!` raises, the lock is kept so the editor can carry on.

## Tests

`spec/requests/lexicon/verification_mark_verified_spec.rb`:
- publishing releases the lock (`locked_at`/`locked_by_user` nil, not `locked?`)
- an incomplete verification keeps the lock held by the editor

```
bundle exec rspec spec/requests/lexicon/verification_mark_verified_spec.rb   # 9 examples, 0 failures
bundle exec rspec spec/requests/lexicon/verification_spec.rb \
                  spec/requests/lexicon/verification_unlock_spec.rb          # 69 examples, 0 failures
```

RuboCop clean on both changed files. The full suite (40+ min) was not run —
it needs your go-ahead.

Closes by-4bs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
