### PR TITLE
Implement Manifestation.update_suspected_typos_list (#1473)

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -685,6 +685,35 @@ class AdminController < ApplicationController
     Rails.cache.write('report_suspicious_headings', @suspicious.length)
   end
 
+  # Texts queued by Manifestation.update_suspected_typos_list. The queue holds only a tally
+  # per text, so the individual findings are recomputed for the page being displayed - a
+  # page's worth of markdown, not the whole corpus - rather than stored.
+  def suspected_typos
+    queue = ListItem.where(listkey: Manifestation::SUSPECTED_TYPOS_LISTKEY, item_type: 'Manifestation')
+    @total = queue.count
+    @list_items = queue.order(:item_id).page(params[:page]).per(25)
+    by_id = Manifestation.where(id: @list_items.map(&:item_id))
+                         .preload(expression: { work: { involved_authorities: :authority } })
+                         .index_by(&:id)
+    # filter_map, because a queued text may have been destroyed since the queue was built
+    @manifestations = @list_items.filter_map { |li| by_id[li.item_id] }
+    @findings = @manifestations.index_with { |m| DetectSuspectedTypos.call(m.markdown, m.genre) }
+    Rails.cache.write('report_suspected_typos', @total)
+  end
+
+  # Records the editor's verdict that a flagged text is fine, and drops it from the queue so
+  # the report reflects the decision without waiting for the weekly rebuild.
+  def mark_typos_as_okay
+    m = Manifestation.find_by(id: params[:id])
+    if m.present?
+      ListItem.find_or_create_by!(listkey: Manifestation::SUSPECTED_TYPOS_OKAY_LISTKEY, item: m) do |li|
+        li.user = current_user
+      end
+      ListItem.where(listkey: Manifestation::SUSPECTED_TYPOS_LISTKEY, item: m).destroy_all
+    end
+    head :ok
+  end
+
   def slash_in_titles
     whitelisted_ids = ListItem.where(listkey: 'title_slashes_okay').pluck(:item_id, :item_type)
     whitelisted_collections = whitelisted_ids.select { |_, type| type == 'Collection' }.map(&:first)

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -58,6 +58,9 @@ class Manifestation < ApplicationRecord
   # An editor's verdict that a flagged text is in fact correct. Kept in its own list so that
   # rebuilding the queue never discards it.
   SUSPECTED_TYPOS_OKAY_LISTKEY = 'suspected_typos_okay'
+  # Single-row marker holding, in `extra`, the ISO8601 watermark that .update_suspected_typos_list
+  # scanned through. Later runs only look at texts modified since.
+  SUSPECTED_TYPOS_LAST_RUN_LISTKEY = 'suspected_typos_last_run'
 
   update_index('manifestations') { self } # update ManifestationsIndex when entity is updated
   update_index('manifestations_autocomplete') { self } # update ManifestationsAutocompleteIndex when entity is updated
@@ -529,23 +532,36 @@ class Manifestation < ApplicationRecord
     ids.filter_map { |id| manifestations[id] }
   end
 
-  # Rebuilds the queue of published texts that DetectSuspectedTypos considers worth a human
+  # Updates the queue of published texts that DetectSuspectedTypos considers worth a human
   # look, one ListItem per text, with a "<type>:<count>;..." tally in `extra`. Run weekly
   # from config/recurring.yml and surfaced by AdminController#suspected_typos.
   #
-  # The pass is a full rebuild rather than an append: a text whose typos have since been
-  # fixed drops off the list by itself, so editors never have to clear an entry by hand. The
-  # only thing that survives a rebuild is the editor's verdict, held separately in the
+  # Incremental: only texts modified since the watermark recorded by the previous run are
+  # scanned, which after the first pass turns a whole-corpus job into a handful of texts. The
+  # first run, and any run passed `full: true`, scans everything - use that after changing a
+  # heuristic in DetectSuspectedTypos, since unmodified texts would otherwise keep the verdict
+  # the old rules gave them.
+  #
+  # Within the scanned set the pass is a rebuild, not an append: a text whose typos have been
+  # fixed drops off the queue by itself, so editors never clear an entry by hand. The only
+  # thing that survives is the editor's verdict, held separately in the
   # SUSPECTED_TYPOS_OKAY_LISTKEY whitelist, whose members are not scanned at all.
-  def self.update_suspected_typos_list
-    whitelisted = ListItem.where(listkey: SUSPECTED_TYPOS_OKAY_LISTKEY, item_type: name).select(:item_id)
-    # item_id => list_item_id, so an entry can be updated in place and, once seen, removed
-    # from the hash; whatever is left at the end is stale and gets dropped.
-    stale = ListItem.where(listkey: SUSPECTED_TYPOS_LISTKEY, item_type: name).pluck(:item_id, :id).to_h
-    scope = all_published.where.not(id: whitelisted)
-                         .joins(expression: :work)
-                         .select('manifestations.id, manifestations.markdown, works.genre as work_genre')
+  def self.update_suspected_typos_list(full: false)
+    # Read before the scan starts, so a text edited while the scan is running is picked up by
+    # the next run rather than missed by both. Rounded down to the whole second and then
+    # backed off by one more, because MySQL *rounds* fractional seconds into these
+    # precision-0 datetime columns while Ruby's iso8601 truncates them: without the margin a
+    # text saved during the run can land on a stamp that is not strictly greater than the
+    # watermark, and would then be skipped by every later run. The margin costs one second's
+    # worth of texts being re-scanned.
+    watermark = 1.second.ago.change(usec: 0)
+    since = full ? nil : suspected_typos_scanned_through
+
+    scope = suspected_typos_scan_scope(since)
     total = scope.count(:all) # :all, because counting the multi-column custom select is not valid SQL
+    # item_id => list_item_id for the whole queue, so each scanned text costs a hash lookup
+    # rather than a query.
+    queued = ListItem.where(listkey: SUSPECTED_TYPOS_LISTKEY, item_type: name).pluck(:item_id, :id).to_h
     handled = 0
     added = 0
 
@@ -553,7 +569,7 @@ class Manifestation < ApplicationRecord
       handled += 1
       Rails.logger.info "update_suspected_typos_list: handled #{handled} of #{total}" if (handled % 500).zero?
       findings = DetectSuspectedTypos.call(m.markdown, m[:work_genre])
-      list_item_id = stale.delete(m.id)
+      list_item_id = queued[m.id]
       if findings.empty?
         ListItem.where(id: list_item_id).destroy_all if list_item_id
       elsif list_item_id
@@ -565,9 +581,48 @@ class Manifestation < ApplicationRecord
       end
     end
 
-    # Left over: texts that have since been unpublished or whitelisted, so were never visited.
-    ListItem.where(id: stale.values).destroy_all
+    drop_unreachable_suspected_typos
+    record_suspected_typos_watermark(watermark)
     Rails.logger.info "update_suspected_typos_list: scanned #{total}, added #{added} new ListItems"
+  end
+
+  # Every text the queue is allowed to hold: published, and not whitelisted by an editor.
+  def self.suspected_typos_reachable
+    whitelisted = ListItem.where(listkey: SUSPECTED_TYPOS_OKAY_LISTKEY, item_type: name).select(:item_id)
+    all_published.where.not(id: whitelisted)
+  end
+
+  def self.suspected_typos_scan_scope(since)
+    scope = suspected_typos_reachable
+            .joins(expression: :work)
+            .select('manifestations.id, manifestations.markdown, works.genre as work_genre')
+    return scope if since.nil?
+
+    # index_manifestations_on_updated_at makes this the cheap half of the job.
+    scope.where(updated_at: since...)
+  end
+
+  # Queue entries an incremental scan will never revisit, because the text left the scanned
+  # set after it was queued: unpublished, or whitelisted outside the report. Deleted texts
+  # take their ListItems with them, through the dependent: :destroy above.
+  def self.drop_unreachable_suspected_typos
+    ListItem.where(listkey: SUSPECTED_TYPOS_LISTKEY, item_type: name)
+            .where.not(item_id: suspected_typos_reachable.select(:id))
+            .destroy_all
+  end
+
+  # nil when no run has been recorded yet, which makes the next run a full one.
+  def self.suspected_typos_scanned_through
+    recorded = ListItem.where(listkey: SUSPECTED_TYPOS_LAST_RUN_LISTKEY).order(:id).pick(:extra)
+    recorded.presence && Time.zone.parse(recorded)
+  end
+
+  # ListItem#item is a required association and this marker belongs to no single record, so
+  # it is the one ListItem written without validation.
+  def self.record_suspected_typos_watermark(watermark)
+    marker = ListItem.where(listkey: SUSPECTED_TYPOS_LAST_RUN_LISTKEY).order(:id).first_or_initialize
+    marker.extra = watermark.iso8601
+    marker.save!(validate: false)
   end
 
   # A compact tally that fits the 255-character `extra` column, e.g. 'digit_in_word:3;final_mid_word:1'.

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -52,6 +52,13 @@ class Manifestation < ApplicationRecord
   SHORT_LENGTH = 1500 # kind of arbitrary...
   LONG_LENGTH = 15_000 # kind of arbitrary...
 
+  # Queue of texts flagged by DetectSuspectedTypos, rebuilt weekly by
+  # .update_suspected_typos_list; `extra` holds a '<type>:<count>;...' tally.
+  SUSPECTED_TYPOS_LISTKEY = 'suspected_typos'
+  # An editor's verdict that a flagged text is in fact correct. Kept in its own list so that
+  # rebuilding the queue never discards it.
+  SUSPECTED_TYPOS_OKAY_LISTKEY = 'suspected_typos_okay'
+
   update_index('manifestations') { self } # update ManifestationsIndex when entity is updated
   update_index('manifestations_autocomplete') { self } # update ManifestationsAutocompleteIndex when entity is updated
 
@@ -522,13 +529,49 @@ class Manifestation < ApplicationRecord
     ids.filter_map { |id| manifestations[id] }
   end
 
+  # Rebuilds the queue of published texts that DetectSuspectedTypos considers worth a human
+  # look, one ListItem per text, with a "<type>:<count>;..." tally in `extra`. Run weekly
+  # from config/recurring.yml and surfaced by AdminController#suspected_typos.
+  #
+  # The pass is a full rebuild rather than an append: a text whose typos have since been
+  # fixed drops off the list by itself, so editors never have to clear an entry by hand. The
+  # only thing that survives a rebuild is the editor's verdict, held separately in the
+  # SUSPECTED_TYPOS_OKAY_LISTKEY whitelist, whose members are not scanned at all.
   def self.update_suspected_typos_list
-    # TODO: implement
-    # code to find probable typos:
-    # - digits within words
-    # - finals within words
-    # - non-final letters that should be finals
-    # - non-title paragraphs ending without period, question mark, exclamation point.
-    # - what else?
+    whitelisted = ListItem.where(listkey: SUSPECTED_TYPOS_OKAY_LISTKEY, item_type: name).select(:item_id)
+    # item_id => list_item_id, so an entry can be updated in place and, once seen, removed
+    # from the hash; whatever is left at the end is stale and gets dropped.
+    stale = ListItem.where(listkey: SUSPECTED_TYPOS_LISTKEY, item_type: name).pluck(:item_id, :id).to_h
+    scope = all_published.where.not(id: whitelisted)
+                         .joins(expression: :work)
+                         .select('manifestations.id, manifestations.markdown, works.genre as work_genre')
+    total = scope.count(:all) # :all, because counting the multi-column custom select is not valid SQL
+    handled = 0
+    added = 0
+
+    scope.find_each(batch_size: 100) do |m|
+      handled += 1
+      Rails.logger.info "update_suspected_typos_list: handled #{handled} of #{total}" if (handled % 500).zero?
+      findings = DetectSuspectedTypos.call(m.markdown, m[:work_genre])
+      list_item_id = stale.delete(m.id)
+      if findings.empty?
+        ListItem.where(id: list_item_id).destroy_all if list_item_id
+      elsif list_item_id
+        ListItem.find(list_item_id).update!(extra: summarize_suspected_typos(findings))
+      else
+        ListItem.create!(listkey: SUSPECTED_TYPOS_LISTKEY, item_id: m.id, item_type: name,
+                         extra: summarize_suspected_typos(findings))
+        added += 1
+      end
+    end
+
+    # Left over: texts that have since been unpublished or whitelisted, so were never visited.
+    ListItem.where(id: stale.values).destroy_all
+    Rails.logger.info "update_suspected_typos_list: scanned #{total}, added #{added} new ListItems"
+  end
+
+  # A compact tally that fits the 255-character `extra` column, e.g. 'digit_in_word:3;final_mid_word:1'.
+  def self.summarize_suspected_typos(findings)
+    findings.group_by { |f| f[:type] }.map { |type, group| "#{type}:#{group.length}" }.join(';')
   end
 end

--- a/app/services/detect_suspected_typos.rb
+++ b/app/services/detect_suspected_typos.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+# Scans a Hebrew text's MultiMarkdown for the shapes a scanning/OCR/typing slip usually takes,
+# so that Manifestation.update_suspected_typos_list can queue the texts worth a human look.
+# Every check here is a heuristic: it produces candidates, not verdicts, which is why the
+# report that consumes it offers editors a "this is fine" whitelist.
+#
+# The four checks are the ones enumerated in the original TODO:
+#   :digit_in_word          - a digit welded onto a Hebrew letter, the classic OCR slip
+#   :final_mid_word         - a final letter with more word after it
+#   :nonfinal_at_word_end   - a word ending in a letter whose final form belongs there
+#   :unterminated_paragraph - a prose paragraph that just stops, with no terminal punctuation
+#
+# The character-class constants below carry their codepoints in comments: a bracket
+# expression mixing RTL letters with '-' and ']' renders in a confusing order in an LTR
+# editor, and a mis-ordered range is accepted by Ruby without complaint.
+class DetectSuspectedTypos < ApplicationService
+  # Hebrew consonants, alef (U+05D0) through tav (U+05EA). Deliberately not \p{Hebrew}, which
+  # also matches the points and cantillation marks we want to treat as invisible.
+  LETTER = 'א-ת'
+  # Nikkud, dagesh and cantillation - all non-spacing marks. These sit *between* a letter and
+  # whatever follows it, so every adjacency test has to step over them. Matched by category
+  # rather than by codepoint range: the Hebrew block interleaves its marks with punctuation
+  # (U+05BE maqaf, U+05C0 paseq, U+05C3 sof pasuq), and swallowing the maqaf would make
+  # "ה־1948" look like a digit glued to a letter.
+  POINT = '\p{Mn}'
+  # kaf, mem, nun, pe, tsadi sofit
+  FINALS = 'ךםןףץ'
+  # The same letters in their ordinary form; one of these ending a word is suspect. Pe is
+  # deliberately absent: final pe is /f/, so a loanword ending in /p/ correctly keeps the
+  # ordinary form (קטשופ, טלסקופ, ג'יפ), and including it made this the noisiest check by far.
+  NEEDS_FINAL = 'כמנצ'
+  # Geresh and gershayim, in both their Hebrew-block (U+05F3/U+05F4) and ASCII-typed
+  # spellings. Between letters they mark an acronym, at the end an abbreviation - in both
+  # cases a non-final ending is correct and must not be reported.
+  GERESH = "'\"׳״"
+
+  DIGIT_IN_WORD = /[#{LETTER}][#{POINT}]*\d|\d[#{LETTER}]/o
+  # A word, including any internal or trailing geresh, so that acronyms and abbreviations
+  # arrive intact and can be recognised as such.
+  WORD = /[#{LETTER}][#{LETTER}#{POINT}#{GERESH}]*/o
+  # A cheap superset of the two word-level checks, used to skip the ~95% of words that cannot
+  # possibly match before doing the allocating work of stripping points and quote characters.
+  # The whole corpus is scanned weekly, so the saving is worth the duplication.
+  CANDIDATE_WORD = /[#{FINALS}][#{POINT}]*[#{LETTER}]|[#{NEEDS_FINAL}][#{POINT}#{GERESH}]*\z/o
+  POINTS_ONLY = /[#{POINT}]/o
+  SURROUNDING_GERESH = /\A[#{GERESH}]+|[#{GERESH}]+\z/o
+  ANY_GERESH = /[#{GERESH}]/o
+  # A *single* geresh closing a word marks an abbreviation. Gershayim is deliberately not
+  # here: a word is scanned from its first letter, so a leading quotation mark is not part of
+  # the token and a trailing '"' is far more often the closing half of a quoted word than an
+  # abbreviation mark - acronyms carry their gershayim before the last letter, not after it.
+  ABBREVIATION_MARK = /['׳]\z/
+
+  # Genres whose paragraphs are expected to be sentences. Poetry and drama are line-broken by
+  # nature, and letters/reference/lexicon end on signatures, datelines and headword
+  # fragments, so for all of those an unterminated paragraph is the norm, not a defect.
+  PROSE_GENRES = %w(prose article memoir fables).freeze
+  # Below this a "paragraph" is more likely a heading, a dateline or a signature than a
+  # sentence that lost its full stop.
+  MIN_PROSE_PARAGRAPH_LENGTH = 80
+  # A paragraph is reported only when it ends on a bare letter. Anything else - a comma, a
+  # dash, an ellipsis, a colon - is either terminal punctuation or a deliberate continuation,
+  # and in the corpus the punctuated cases were almost all correct.
+  UNTERMINATED_END = /[#{LETTER}][#{POINT}]*\z/o
+  # Stripped from the end of a paragraph first: closing quotes and brackets, and the emphasis
+  # markers that wrap the punctuation rather than replace it.
+  TRAILING_DECORATION = "*_\"'”’»)›]}׳״"
+  TRAILING_DECORATION_RE = /[#{Regexp.escape(TRAILING_DECORATION)}\s]+\z/o
+  FOOTNOTE_MARKER = /\[\^[^\]\n]+\]/
+  FOOTNOTE_REFERENCE = /#{FOOTNOTE_MARKER}\z/o
+  # Markup that is not prose and must not be judged as such: footnote identifiers, whole
+  # images (their alt text is a filename), and the target of any link.
+  MASKED_MARKUP = /!\[[^\]\n]*\]\([^)\n]*\)|#{FOOTNOTE_MARKER}|\]\([^)\n]*\)/o
+  # A word cut short by an adjacent dash or ellipsis is deliberate - stammering, an
+  # interruption, a hyphenated compound - not a missing final letter.
+  TRUNCATION_MARK = /\A(?:[-־–—]|\.{2,}|…)/
+  # Presentation forms (U+FB1D..U+FB4F) spell a pointed letter as one codepoint, so a word
+  # containing one would be cut in half by the letter-plus-marks scanning below. They carry a
+  # canonical decomposition, so normalizing restores the ordinary letter-plus-mark spelling.
+  PRESENTATION_FORM = /[יִ-ﭏ]/
+  # Lines that are markup rather than prose: headings, quotes, lists, tables, footnote
+  # bodies, horizontal rules, raw HTML, images and the '&&&' work separator. A paragraph
+  # containing any of these is not a sentence and is not judged as one.
+  MARKUP_LINE = /\A(?: {0,3}(?:[#>|*+-]|\d+[.)]|\[\^|&&&|!\[|<)| {4,}\S)/
+  LINE_ENDING = /\r\n?/
+
+  # Reporting every hit in a badly-OCRed text would bury the report without telling an editor
+  # anything the first few hits did not.
+  MAX_FINDINGS_PER_TYPE = 20
+  # How much context to show around a character-level hit.
+  CONTEXT_CHARS = 30
+
+  # @param markdown [String] the text to scan
+  # @param genre [String, nil] the work's genre; only prose genres get the paragraph check
+  # @return [Array<Hash>] findings, each { type: Symbol, line: Integer, match: String,
+  #   text: String } - the offending fragment and the surrounding context - grouped by type
+  #   in the order the checks are declared above, then by line
+  def call(markdown, genre = nil)
+    text = markdown.to_s
+    return [] if text.blank?
+
+    text = text.gsub(LINE_ENDING, "\n") if text.include?("\r")
+    text = text.unicode_normalize if text.match?(PRESENTATION_FORM)
+    lines = text.lines
+
+    findings = scan_lines(lines)
+    findings += scan_paragraphs(lines) if PROSE_GENRES.include?(genre)
+    findings
+  end
+
+  private
+
+  # The three character-level checks, all of which are decided within a single line.
+  def scan_lines(lines)
+    digits = []
+    finals_mid = []
+    nonfinal_ends = []
+
+    lines.each_with_index do |raw_line, index|
+      line_no = index + 1
+      line = mask_markup(raw_line)
+      line.scan(DIGIT_IN_WORD) do
+        digits << finding(:digit_in_word, line_no, line, Regexp.last_match)
+      end
+      line.scan(WORD) do |word|
+        next unless word.match?(CANDIDATE_WORD)
+
+        # String#match? leaves $~ alone, so this is still the scan's own match. It has to be
+        # read before letters_of, whose gsub would overwrite it.
+        match = Regexp.last_match
+        letters = letters_of(word)
+        next if letters.nil? || letters.length < 2
+
+        finals_mid << finding(:final_mid_word, line_no, line, match) if final_mid_word?(letters)
+        if NEEDS_FINAL.include?(letters[-1]) && !truncated?(line, match.end(0))
+          nonfinal_ends << finding(:nonfinal_at_word_end, line_no, line, match)
+        end
+      end
+    end
+
+    cap(digits) + cap(finals_mid) + cap(nonfinal_ends)
+  end
+
+  # A footnote id like '[^ftn1א]' and an image filename like 'תמונה155-156.png' mix digits and
+  # Hebrew letters by design, and together were the largest source of spurious
+  # :digit_in_word hits. Blanked out rather than deleted, so that the offsets used for
+  # context stay in step with the line.
+  def mask_markup(line)
+    return line unless line.include?('[')
+
+    line.gsub(MASKED_MARKUP) { |markup| ' ' * markup.length }
+  end
+
+  def truncated?(line, offset)
+    line[offset..].to_s.match?(TRUNCATION_MARK)
+  end
+
+  # The bare consonants of a word, or nil when the word is an acronym or abbreviation, where
+  # a non-final ending and a mid-word final are both correct. A geresh still present after
+  # the surrounding quote characters are stripped is internal, and marks an acronym.
+  def letters_of(word)
+    return nil if word.match?(ABBREVIATION_MARK)
+
+    core = word.gsub(SURROUNDING_GERESH, '')
+    return nil if core.match?(ANY_GERESH)
+
+    core.gsub(POINTS_ONLY, '')
+  end
+
+  def final_mid_word?(letters)
+    letters[0..-2].each_char.any? { |c| FINALS.include?(c) }
+  end
+
+  # Blank-line-separated blocks of prose that stop without terminal punctuation.
+  def scan_paragraphs(lines)
+    findings = []
+    each_paragraph(lines) do |paragraph_lines, last_line_no|
+      next if paragraph_lines.any? { |l| l.match?(MARKUP_LINE) }
+
+      paragraph = paragraph_lines.join.strip
+      next if paragraph.length < MIN_PROSE_PARAGRAPH_LENGTH
+
+      ending = unterminated_ending(paragraph)
+      next if ending.nil?
+
+      findings << { type: :unterminated_paragraph, line: last_line_no, match: ending,
+                    text: tail(paragraph) }
+    end
+    cap(findings)
+  end
+
+  def each_paragraph(lines)
+    current = []
+    lines.each_with_index do |line, index|
+      if line.strip.empty?
+        yield(current, index) unless current.empty? # index is the 1-based number of the line before
+        current = []
+      else
+        current << line
+      end
+    end
+    yield(current, lines.length) unless current.empty?
+  end
+
+  # The bare letter a paragraph ends on, or nil when it ends on punctuation of any kind.
+  def unterminated_ending(paragraph)
+    stripped = paragraph.sub(FOOTNOTE_REFERENCE, '').gsub(TRAILING_DECORATION_RE, '')
+    stripped[UNTERMINATED_END]
+  end
+
+  def finding(type, line_no, line, match)
+    from = [match.begin(0) - CONTEXT_CHARS, 0].max
+    context = line[from...[match.end(0) + CONTEXT_CHARS, line.length].min]
+    { type: type, line: line_no, match: match[0], text: context.strip }
+  end
+
+  def tail(paragraph)
+    paragraph.length > CONTEXT_CHARS * 2 ? "…#{paragraph[-(CONTEXT_CHARS * 2)..]}" : paragraph
+  end
+
+  def cap(findings)
+    findings.first(MAX_FINDINGS_PER_TYPE)
+  end
+end

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -159,6 +159,9 @@
         = link_to t(:suspicious_headings_report), admin_suspicious_headings_path
         = ' ('+Rails.cache.read('report_suspicious_headings').to_s+')'
       %p
+        = link_to t(:suspected_typos_report), admin_suspected_typos_path
+        (#{Rails.cache.read('report_suspected_typos')})
+      %p
         = link_to t(:similar_titles_report), admin_similar_titles_path
         = ' ('+Rails.cache.read('report_similar_titles').to_s+')'
       %p

--- a/app/views/admin/suspected_typos.html.haml
+++ b/app/views/admin/suspected_typos.html.haml
@@ -1,0 +1,52 @@
+.backend
+  %h2= t(:suspected_typos_report)
+  %p= t(:suspected_typos_explanation)
+
+  %h3 #{t(:total)}: #{@total}
+
+  = paginate @list_items
+
+  %table{ style: 'border-spacing: 10;' }
+    %tr
+      %th= t(:title)
+      %th= t(:author)
+      %th= t(:genre)
+      %th= t(:suspected_typos_findings)
+      %th
+
+    - @manifestations.each do |m|
+      %tr
+        %td= link_to m.title, manifestation_show_path(m.id)
+        %td= m.author_string
+        %td= textify_genre(m.expression.work.genre)
+        %td
+          %ul
+            - @findings[m].each do |finding|
+              %li
+                %b= t("suspected_typo_types.#{finding[:type]}")
+                (#{t(:line_number)} #{finding[:line]}):
+                %code= finding[:text]
+        %td
+          %b= link_to t(:edit_markdown), manifestation_edit_path(m.id)
+          \|
+          = link_to t(:render), url_for(controller: :manifestation, action: :read, id: m.id)
+          \|
+          = link_to t(:mark_as_valid), mark_typos_as_okay_path(m.id),
+                    remote: true, class: 'whitelist_link',
+                    data: { 'done-msg' => t(:confirmed), 'doing-msg' => t(:confirming) }
+
+  = paginate @list_items
+
+:javascript
+  $(document).ready(function() {
+    $('.whitelist_link')
+      .bind("ajax:beforeSend", function(evt, xhr, settings) {
+        $(this).html("<b>" + $(this).data('doing-msg') + "</b>");
+      })
+      .bind("ajax:success", function(evt, data, status, xhr){
+        $(this).html($(this).data('done-msg'));
+        $(this).off('click');
+        $(this).css('pointer-events', 'none').css('cursor', 'default');
+        $(this).css('color', 'black').css('text-decoration', 'none');
+    });
+  });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2976,6 +2976,17 @@ en:
   surprise_author: Surprise Author
   surprise_author_in_genre: Surprise Author In Genre
   surprise_me_again: Surprise Me Again
+  suspected_typos_report: Suspected Typos Report
+  suspected_typos_explanation: >-
+    Texts in which automatic checks found shapes that are usually typos. These are guesses,
+    not errors: if a text is in fact correct, mark it as valid and it will not be listed again.
+  suspected_typos_findings: Findings
+  suspected_typo_types:
+    digit_in_word: Digit inside a word
+    final_mid_word: Final letter in the middle of a word
+    nonfinal_at_word_end: Non-final letter at the end of a word
+    unterminated_paragraph: Paragraph ending without punctuation
+  line_number: 'line'
   suspicious_headings_report: Suspicious Headings Report
   suspicious_intellectual_property_report: Suspicious Intellectual Property Report
   suspicious_titles_report: Suspicious Titles Report

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -758,6 +758,17 @@ he:
   uploaded_directly: הועלה ישירות
   first_author: מחבר (לא מתרגם; אפשר להוסיף אישים אחר-כך, בקטלוג)
   suspicious_headings_report: "דו\"ח כותרות פרקים קרובות זו לזו (לעריכה)"
+  suspected_typos_report: "דו\"ח יצירות החשודות בשגיאות הקלדה"
+  suspected_typos_explanation: >-
+    יצירות שבהן נמצאו, בבדיקה אוטומטית, תבניות המעידות בדרך כלל על שגיאת הקלדה או סריקה.
+    אלה השערות בלבד ולא בהכרח שגיאות: אם הטקסט תקין, סמנו אותו כתקין והוא לא יופיע שוב ברשימה.
+  suspected_typos_findings: ממצאים
+  suspected_typo_types:
+    digit_in_word: ספרה בתוך מילה
+    final_mid_word: אות סופית באמצע מילה
+    nonfinal_at_word_end: אות לא-סופית בסוף מילה
+    unterminated_paragraph: פסקה המסתיימת ללא סימן פיסוק
+  line_number: שורה
   texts_between_dates: יצירות לפי מועד עלייתן
   authority_records_between_dates: יוצרים לפי מועד יצירת היישות
   first_manifestations_between_dates: יוצרים שעלו למאגר (לפי מועד יצירה ראשונה)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -31,8 +31,8 @@ production:
     schedule: '0 2 * * 0 Asia/Jerusalem'
   update_suspected_typos_in_manifestations:
     command: 'Manifestation.update_suspected_typos_list'
-    # Every Sunday at 2:00AM
-    schedule: '0 2 * * 0 Asia/Jerusalem'
+    # Every Saturday at 1:00PM
+    schedule: '0 13 * * 6 Asia/Jerusalem'
   import_dict:
     command: "system('bin/rake', 'dict:import[/export/dict.db,24412]')"
     # Every Tuesday and Friday at 3:00AM

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -29,11 +29,10 @@ production:
     command: 'Publication.update_publications_that_may_be_done_list'
     # Every Sunday at 2:00AM
     schedule: '0 2 * * 0 Asia/Jerusalem'
-  # Uncomment when method will be implemented
-  #update_suspected_typos_in_manifestations:
-    #command: 'Manifestation.update_suspected_typos_list'
+  update_suspected_typos_in_manifestations:
+    command: 'Manifestation.update_suspected_typos_list'
     # Every Sunday at 2:00AM
-    #schedule: '0 2 * * 0 Asia/Jerusalem'
+    schedule: '0 2 * * 0 Asia/Jerusalem'
   import_dict:
     command: "system('bin/rake', 'dict:import[/export/dict.db,24412]')"
     # Every Tuesday and Friday at 3:00AM

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,7 @@ Bybeconv::Application.routes.draw do
   match 'admin/authors_without_works', via: %i(get post)
   get 'admin/incongruous_copyright'
   get 'admin/suspicious_headings'
+  get 'admin/suspected_typos'
   get 'admin/texts_between_dates'
   get 'admin/authority_records_between_dates'
   get 'admin/first_manifestations_between_dates'
@@ -293,6 +294,7 @@ Bybeconv::Application.routes.draw do
   get 'admin/mark_similar_as_valid/:id' => 'admin#mark_similar_as_valid', as: 'mark_similar_as_valid'
   get 'admin/mark_slash_title_as_okay/:item_type/:id' => 'admin#mark_slash_title_as_okay',
       as: 'mark_slash_title_as_okay'
+  get 'admin/mark_typos_as_okay/:id' => 'admin#mark_typos_as_okay', as: 'mark_typos_as_okay'
   get 'admin/translated_from_multiple_languages'
   get 'admin/raw_tocs'
   get 'admin/my_convs/:id' => 'admin#my_convs', as: 'my_convs'

--- a/spec/controllers/admin_controller_suspected_typos_spec.rb
+++ b/spec/controllers/admin_controller_suspected_typos_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AdminController do
+  include_context 'when editor logged in'
+
+  let(:listkey) { Manifestation::SUSPECTED_TYPOS_LISTKEY }
+  let(:okay_listkey) { Manifestation::SUSPECTED_TYPOS_OKAY_LISTKEY }
+  let(:flagged) { create(:manifestation, genre: :poetry, markdown: "הוא נכנס לבי1ת ויצא\n") }
+
+  describe '#suspected_typos' do
+    subject(:call) { get :suspected_typos }
+
+    before do
+      create(:list_item, listkey: listkey, item: flagged, extra: 'digit_in_word:1')
+      allow(Rails.cache).to receive(:write)
+    end
+
+    it 'lists the queued texts and caches the total for the dashboard' do
+      expect(call).to be_successful
+      expect(assigns(:list_items).map(&:item_id)).to eq [flagged.id]
+      expect(Rails.cache).to have_received(:write).with('report_suspected_typos', 1)
+    end
+
+    it 'recomputes the individual findings for the texts on the page' do
+      call
+      expect(assigns(:findings)[flagged]).to contain_exactly(
+        hash_including(type: :digit_in_word, line: 1)
+      )
+    end
+
+    it 'renders the offending fragment and its label' do
+      call
+      expect(response.body).to include(I18n.t('suspected_typo_types.digit_in_word'))
+      expect(response.body).to include('לבי1ת')
+    end
+
+    context 'when the queued manifestation has since been deleted' do
+      before { flagged.destroy! }
+
+      it 'still renders' do
+        expect(call).to be_successful
+      end
+    end
+  end
+
+  describe '#mark_typos_as_okay' do
+    subject(:call) { get :mark_typos_as_okay, params: { id: flagged.id } }
+
+    let!(:queue_entry) { create(:list_item, listkey: listkey, item: flagged, extra: 'digit_in_word:1') }
+
+    it 'whitelists the text and drops it from the queue' do
+      expect(call).to have_http_status(:ok)
+      expect(ListItem.exists?(listkey: okay_listkey, item: flagged)).to be true
+      expect(ListItem.exists?(queue_entry.id)).to be false
+    end
+
+    it 'records the editor who made the call' do
+      call
+      expect(ListItem.find_by(listkey: okay_listkey, item: flagged).user).to eq current_user
+    end
+
+    it 'is idempotent' do
+      call
+      get :mark_typos_as_okay, params: { id: flagged.id }
+      expect(ListItem.where(listkey: okay_listkey, item: flagged).count).to eq 1
+    end
+
+    context 'when the id does not exist' do
+      subject(:call) { get :mark_typos_as_okay, params: { id: 0 } }
+
+      it 'succeeds without creating anything' do
+        expect { call }.not_to change(ListItem, :count)
+        expect(call).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -1113,5 +1113,75 @@ describe Manifestation do
         expect(queued?(poem)).to be false
       end
     end
+
+    # These examples run the scan more than once, so they call it directly: `run` is a
+    # memoized subject and would only ever execute the first time.
+    describe 'incremental scanning' do
+      include ActiveSupport::Testing::TimeHelpers
+
+      subject(:scan) { described_class.method(:update_suspected_typos_list) }
+
+      let(:last_run_listkey) { described_class::SUSPECTED_TYPOS_LAST_RUN_LISTKEY }
+      let!(:flagged) { create(:manifestation, genre: :poetry, markdown: typo_text) }
+
+      # Removing the queue entry between runs makes the next run's behaviour visible: the
+      # entry comes back only if the text was actually rescanned.
+      def dequeue(manifestation)
+        ListItem.where(listkey: listkey, item: manifestation).destroy_all
+      end
+
+      it 'records the watermark it scanned through' do
+        scan.call
+        # Recorded to second precision, and rounded down, so a text saved in the same second
+        # is rescanned rather than missed.
+        expect(described_class.suspected_typos_scanned_through).to be_within(5.seconds).of(Time.zone.now)
+      end
+
+      it 'reuses one marker row across runs rather than accumulating them' do
+        scan.call
+        scan.call
+        expect(ListItem.where(listkey: last_run_listkey).count).to eq 1
+      end
+
+      it 'skips a text that has not been modified since the previous run' do
+        # Both runs are moved well clear of the text's own timestamp, so the assertion turns
+        # on the incremental filter rather than on where a sub-second boundary happened to fall.
+        travel(1.minute) { scan.call }
+        dequeue(flagged)
+        travel(2.minutes) { scan.call }
+        expect(queued?(flagged)).to be false
+      end
+
+      it 'rescans a text modified since the previous run' do
+        scan.call
+        dequeue(flagged)
+        travel 1.minute do
+          flagged.touch
+          scan.call
+        end
+        expect(queued?(flagged)).to be true
+      end
+
+      it 'rescans everything when asked for a full run' do
+        scan.call
+        dequeue(flagged)
+        scan.call(full: true)
+        expect(queued?(flagged)).to be true
+      end
+
+      it 'drops the queue entry of a text unpublished since it was queued' do
+        scan.call
+        flagged.update!(status: :unpublished)
+        scan.call
+        expect(queued?(flagged)).to be false
+      end
+
+      it 'drops the queue entry of a text whitelisted since it was queued' do
+        scan.call
+        create(:list_item, listkey: described_class::SUSPECTED_TYPOS_OKAY_LISTKEY, item: flagged)
+        scan.call
+        expect(queued?(flagged)).to be false
+      end
+    end
   end
 end

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -1024,4 +1024,94 @@ describe Manifestation do
       end
     end
   end
+
+  describe '.update_suspected_typos_list' do
+    subject(:run) { described_class.update_suspected_typos_list }
+
+    let(:listkey) { described_class::SUSPECTED_TYPOS_LISTKEY }
+    let(:clean_text) { "שלום עולם, מה שלומך?\n" }
+    let(:typo_text) { "הוא נכנס לבי1ת ויצא\n" }
+
+    def queued?(manifestation)
+      ListItem.exists?(listkey: listkey, item: manifestation)
+    end
+
+    context 'when a published text has suspected typos' do
+      let!(:flagged) { create(:manifestation, genre: :poetry, markdown: typo_text) }
+
+      it 'queues it with a tally of the findings' do
+        expect { run }.to change { queued?(flagged) }.from(false).to(true)
+        expect(ListItem.find_by(listkey: listkey, item: flagged).extra).to eq 'digit_in_word:1'
+      end
+    end
+
+    context 'when a published text is clean' do
+      let!(:clean) { create(:manifestation, genre: :poetry, markdown: clean_text) }
+
+      it 'does not queue it' do
+        run
+        expect(queued?(clean)).to be false
+      end
+    end
+
+    context 'when a queued text has since been fixed' do
+      let!(:fixed) { create(:manifestation, genre: :poetry, markdown: clean_text) }
+      let!(:list_item) { create(:list_item, listkey: listkey, item: fixed, extra: 'digit_in_word:1') }
+
+      it 'drops it from the queue' do
+        expect { run }.to change { ListItem.exists?(list_item.id) }.from(true).to(false)
+      end
+    end
+
+    context 'when a queued text still has typos' do
+      let!(:flagged) { create(:manifestation, genre: :poetry, markdown: typo_text) }
+      let!(:list_item) { create(:list_item, listkey: listkey, item: flagged, extra: 'stale') }
+
+      it 'refreshes the tally in place rather than adding a second entry' do
+        run
+        expect(ListItem.where(listkey: listkey, item: flagged).pluck(:id)).to eq [list_item.id]
+        expect(list_item.reload.extra).to eq 'digit_in_word:1'
+      end
+    end
+
+    context 'when the text has been whitelisted by an editor' do
+      let!(:whitelisted) { create(:manifestation, genre: :poetry, markdown: typo_text) }
+
+      before do
+        create(:list_item, listkey: described_class::SUSPECTED_TYPOS_OKAY_LISTKEY, item: whitelisted)
+      end
+
+      it 'is not queued' do
+        run
+        expect(queued?(whitelisted)).to be false
+      end
+
+      it 'has any pre-existing queue entry dropped' do
+        list_item = create(:list_item, listkey: listkey, item: whitelisted)
+        run
+        expect(ListItem.exists?(list_item.id)).to be false
+      end
+    end
+
+    context 'when the text is not published' do
+      let!(:unpublished) { create(:manifestation, status: :unpublished, genre: :poetry, markdown: typo_text) }
+
+      it 'is not scanned' do
+        run
+        expect(queued?(unpublished)).to be false
+      end
+    end
+
+    context 'when the genre is prose' do
+      let(:sentence) { (['אבגד הוזח טיכל מנסע פצקר שתאב גדהו זחטי'] * 4).join(' ') }
+      let!(:prose) { create(:manifestation, genre: :prose, markdown: "\n#{sentence}\n") }
+      let!(:poem) { create(:manifestation, genre: :poetry, markdown: "\n#{sentence}\n") }
+
+      it 'applies the paragraph check to prose but not to poetry' do
+        run
+        expect(queued?(prose)).to be true
+        expect(queued?(poem)).to be false
+      end
+    end
+  end
 end

--- a/spec/services/detect_suspected_typos_spec.rb
+++ b/spec/services/detect_suspected_typos_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DetectSuspectedTypos do
+  subject(:findings) { described_class.call(markdown, genre) }
+
+  let(:genre) { 'prose' }
+
+  def types
+    findings.pluck(:type)
+  end
+
+  describe 'digits inside words' do
+    context 'when a digit is welded onto a Hebrew letter' do
+      let(:markdown) { "הוא נכנס לבי1ת ויצא\n" }
+
+      it 'reports the word with its line and context' do
+        expect(findings).to contain_exactly(
+          hash_including(type: :digit_in_word, line: 1, text: 'הוא נכנס לבי1ת ויצא')
+        )
+      end
+    end
+
+    context 'when a digit follows a maqaf' do
+      # U+05BE maqaf is punctuation, not a combining mark, so 'ה־1948' is a legitimate form
+      let(:markdown) { "בשנת ה־1948 היה הדבר\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when digits stand alone as a number' do
+      let(:markdown) { "בשנת 1948 היה הדבר\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a footnote reference follows a word' do
+      let(:markdown) { "הוא נכנס לבית[^12] ויצא\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a footnote identifier mixes digits and Hebrew letters' do
+      let(:markdown) { "וְעַד מִנִּית [^ftn3א] וְעוֹד\n\n[^ftn3א]:  שופטים י\"א\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when an image filename mixes digits and Hebrew letters' do
+      let(:markdown) { "![תמונה155-156.png](/rails/active_storage/x.png)\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a space is missing before a number' do
+      let(:markdown) { "העיתון נוסד ב1919 בירושלים\n" }
+
+      it 'reports it' do
+        expect(types).to eq([:digit_in_word])
+      end
+    end
+  end
+
+  describe 'final letters in the middle of a word' do
+    context 'when a final mem opens a word' do
+      let(:markdown) { "םים רבים כאן\n" }
+
+      it 'reports the word' do
+        expect(findings).to contain_exactly(hash_including(type: :final_mid_word, match: 'םים', line: 1))
+      end
+    end
+
+    context 'when the final letter is where it belongs' do
+      let(:markdown) { "מים רבים כאן\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a final letter carries nikkud and ends the word' do
+      let(:markdown) { "מַה שְׁלוֹמְךָ היום\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the token is an acronym' do
+      let(:markdown) { "צה\"ל הודיע היום\n" }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe 'non-final letters at the end of a word' do
+    context 'when a word ends in an ordinary kaf' do
+      let(:markdown) { "אכ הוא הלכ הביתה\n" }
+
+      it 'reports every such word' do
+        expect(findings.pluck(:match)).to eq(%w(אכ הלכ))
+        expect(types).to all(eq(:nonfinal_at_word_end))
+      end
+    end
+
+    context 'when the word is quoted' do
+      # The quotation marks are part of the scanned token, and must not be mistaken for the
+      # gershayim of an acronym.
+      let(:markdown) { "הוא אמר \"מלכ\" ברבים\n" }
+
+      it 'still reports it' do
+        expect(types).to eq([:nonfinal_at_word_end])
+      end
+    end
+
+    context 'when the word is an abbreviation marked with a geresh' do
+      let(:markdown) { "עמ' 12 וכו' ואילכ'\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the word is a one-letter prefix' do
+      let(:markdown) { "מ עד ת\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the word ends in a proper final letter' do
+      let(:markdown) { "אך הוא הלך הביתה\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the word is a loanword ending in pe' do
+      # Final pe is /f/, so a word ending in a /p/ sound keeps the ordinary form
+      let(:markdown) { "הוא שפך קטשופ על הצלחת\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the word is cut short by an adjacent dash or ellipsis' do
+      let(:markdown) { "– לא, שמ–שנ–יה\n\n– המ... טבק טוב\n" }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe 'paragraphs ending without punctuation' do
+    let(:sentence) { (['אבגד הוזח טיכל מנסע פצקר שתאב גדהו זחטי'] * 4).join(' ') }
+
+    context 'when a prose paragraph just stops' do
+      let(:markdown) { "\n#{sentence}\n" }
+
+      it 'reports it against the paragraph last line' do
+        expect(findings).to contain_exactly(hash_including(type: :unterminated_paragraph, line: 2))
+      end
+    end
+
+    context 'when the paragraph ends in a full stop' do
+      let(:markdown) { "\n#{sentence}.\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the paragraph ends in punctuation inside a closing quotation mark' do
+      let(:markdown) { "\n#{sentence} \"די!\"\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the paragraph ends in a dash, marking interrupted speech' do
+      let(:markdown) { "\n#{sentence} —\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the paragraph is a heading' do
+      let(:markdown) { "\n## #{sentence}\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the paragraph is shorter than a sentence' do
+      let(:markdown) { "\nשלום עולם\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the genre is poetry' do
+      let(:genre) { 'poetry' }
+      let(:markdown) { "\n#{sentence}\n" }
+
+      it 'does not apply the check at all' do
+        expect(findings).to be_empty
+      end
+    end
+
+    context 'when no genre is given' do
+      let(:genre) { nil }
+      let(:markdown) { "\n#{sentence}\n" }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe 'general behaviour' do
+    context 'when the markdown is blank' do
+      let(:markdown) { nil }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'when the text is clean' do
+      let(:markdown) { "שלום עולם, מה שלומך?\n\nהכול בסדר גמור, תודה.\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a pointed letter is spelled as a presentation form' do
+      # U+FB35 is a single codepoint for vav-with-dagesh; without normalization the word
+      # would be scanned in two halves, and 'מחשכ' would look like a non-final ending.
+      let(:markdown) { "או מחשכ\uFB35ת שררה שם\n" }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when line endings are CRLF' do
+      let(:markdown) { "שורה ראשונה\r\nהוא נכנס לבי1ת\r\n" }
+
+      it 'reports the correct line number' do
+        expect(findings).to contain_exactly(hash_including(type: :digit_in_word, line: 2))
+      end
+    end
+
+    context 'when one type recurs more times than the cap' do
+      let(:markdown) { (["לבי1ת\n"] * (described_class::MAX_FINDINGS_PER_TYPE + 10)).join }
+
+      it 'caps the findings for that type' do
+        expect(types.count(:digit_in_word)).to eq described_class::MAX_FINDINGS_PER_TYPE
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1473.

`Manifestation.update_suspected_typos_list` was an empty placeholder listing four heuristics in a TODO, and its weekly entry in `config/recurring.yml` was commented out waiting for it. This implements all four, populates a reviewable queue, and surfaces it as an admin report.

## What's here

**`app/services/detect_suspected_typos.rb`** — pure `markdown, genre → findings` scanner implementing the four checks from the TODO:

| type | catches |
| --- | --- |
| `digit_in_word` | a digit welded onto a Hebrew letter (`ב1919`, `50מטר`) — the classic OCR/missing-space slip |
| `final_mid_word` | a final letter with more word after it (`ןהמשתטה`, `אםשרות`) |
| `nonfinal_at_word_end` | a word ending in a letter whose final form belongs there (`הקדמ`, `העצכ`) |
| `unterminated_paragraph` | a prose paragraph stopping on a bare letter, no terminal punctuation |

Every check is a heuristic — candidates, not verdicts — which is why editors get a whitelist.

**`Manifestation.update_suspected_typos_list`** rebuilds a `suspected_typos` `ListItem` queue over all published texts, one entry per text with a `<type>:<count>;...` tally in `extra`. It is a full rebuild rather than an append, so a text whose typos have since been fixed drops off by itself and editors never clear an entry by hand. The only thing that survives a rebuild is the editor's verdict, held separately in `suspected_typos_okay`, whose members are not scanned at all.

**Incremental scanning** — the run records the timestamp it scanned through in a single `suspected_typos_last_run` ListItem, and later runs filter on `manifestations.updated_at` (index-backed), so a weekly run costs whatever editors actually touched rather than a full corpus pass. The first run, and any run passed `full: true`, scans everything — that is the escape hatch to use after changing a heuristic, since unmodified texts would otherwise keep the verdict the old rules gave them.

Two consequences of no longer visiting every text:

- Queue entries can't be pruned by "not seen this pass" any more. A text that leaves the scanned set after being queued — unpublished, or whitelisted outside the report — is dropped by `drop_unreachable_suspected_typos`, one set difference against the reachable scope.
- The watermark is rounded down to the whole second and backed off by one more. MySQL *rounds* fractional seconds into these precision-0 datetime columns while Ruby's `iso8601` truncates them, so without the margin a text saved during the run could land on a stamp that is not strictly greater than the watermark, and be skipped by every later run.

**`AdminController#suspected_typos`** — paginated report linked from the admin dashboard, following the existing `slash_in_titles` / `similar_titles` pattern. The queue stores only the tally, so the individual findings are recomputed for the 25 texts on the page being displayed. `#mark_typos_as_okay` records the whitelist verdict (with the editor who made it) and drops the text from the queue immediately.

**`config/recurring.yml`** — the weekly entry is uncommented, and moved to Saturday 13:00 (it was commented out as Sunday 02:00, which already has two other weekly jobs).

## Tuning against the real corpus

The first draft flagged **19% of a 400-text random sample** of the dev corpus. Inspecting the hits turned up five systematic false-positive classes, each fixed:

- **Footnote ids and image filenames** mix digits and Hebrew letters by design (`[^ftn3א]`, `תמונה155-156.png`). Both are masked before the digit check.
- **Final pe is /f/**, so a loanword ending in a /p/ sound correctly keeps the ordinary form (`קטשופ`, `טלסקופ`, `ג'יפ`). Pe is excluded from `NEEDS_FINAL`; it was by far the noisiest contributor.
- **Words cut short by an adjacent dash or ellipsis** are deliberate — stammering, interruption (`שמ–שנ–יה`, `המ...`). Skipped.
- **Hebrew presentation forms** (U+FB1D–U+FB4F) spell a pointed letter as one codepoint, which cut words in half mid-scan and made `מחשכוּת` look like a non-final ending. The text is `unicode_normalize`d when one is present.
- **Paragraph endings**: reporting anything without `.?!` flagged every paragraph ending in a comma or dash. Now a paragraph is reported only when it ends on a *bare letter*.

Result: **9% of texts flagged**, and the character-level findings that remain are predominantly genuine. The paragraph check is the noisiest of the four by design — it is restricted to prose genres (`prose article memoir fables`; poetry, drama, letters, reference and lexicon are line-broken or end on signatures), skips markup blocks, requires 80+ characters, and is capped at 20 findings per type per text.

## Cost

~11 ms/text after adding a cheap pre-filter that skips the ~95% of words that cannot match before doing the allocating work (2.75× faster than the naive version; verified to produce byte-identical results on the sample). Against the 59k published texts in the dev DB that is ~11 minutes — but only for the first pass, since later runs are incremental.

## Test plan

New:
- `spec/services/detect_suspected_typos_spec.rb` — 31 examples covering each check, and each false-positive class above as an explicit negative case
- `spec/controllers/admin_controller_suspected_typos_spec.rb` — 8 examples for the report (rendering included, `render_views` is on globally) and the whitelist action, including idempotency and a destroyed-manifestation row
- `.update_suspected_typos_list` block in `spec/models/manifestation_spec.rb` — 15 examples: queueing, tally, self-cleaning of fixed texts, in-place refresh, whitelist exclusion, unpublished exclusion, prose-vs-poetry, plus the incremental behaviour (watermark recorded, single marker row reused, unmodified text skipped, modified text rescanned, `full: true` forces a rescan, and entries dropped for texts unpublished or whitelisted after queueing)

```
bundle exec rspec spec/services/detect_suspected_typos_spec.rb \
                  spec/controllers/admin_controller_suspected_typos_spec.rb \
                  spec/models/manifestation_spec.rb \
                  spec/controllers/admin_controller_spec.rb \
                  spec/models/publication_spec.rb
# 227 examples, 0 failures (plus spec/models/publication_spec.rb)
```

RuboCop and haml-lint are clean on every file touched (verified by diffing offence lists against master for the pre-existing large files).

**The full suite was not run** — per `.claude/rules/full-test-suite-runtime.md` it takes 40+ minutes and needs your approval. Say the word and I'll run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
