### PR TITLE
Allow deleting a citation from the lexicon verification workbench

### DIFF
--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -63,7 +63,9 @@ module Lexicon
     end
 
     def destroy
+      citation_id = @citation.id
       @citation.destroy!
+      @person.entry&.remove_citation_from_checklist!(citation_id)
     end
 
     def text_links; end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -270,37 +270,21 @@ class LexEntry < ApplicationRecord
   def remove_work_from_checklist!(work_id)
     return unless lex_item_type == 'LexPerson'
 
-    with_lock do
-      return if verification_progress.blank?
-
-      progress = verification_progress.deep_dup
-      checklist = progress['checklist']
-      return unless checklist&.dig('works', 'items')&.key?(work_id.to_s)
-
-      checklist['works']['items'].delete(work_id.to_s)
-      auto_verify_collections!(checklist)
-      progress['last_updated_at'] = Time.current.iso8601
-      update!(verification_progress: progress)
-    end
+    remove_collection_item_from_checklist!('works', work_id, auto_verify_when_empty: true)
   end
 
   # Remove a single link from the verification checklist (called synchronously when a link is destroyed),
   # so the deleted link stops counting towards the section's verified/total tally.
   def remove_link_from_checklist!(link_id)
-    with_lock do
-      return if verification_progress.blank?
+    remove_collection_item_from_checklist!('links', link_id)
+  end
 
-      progress = verification_progress.deep_dup
-      checklist = progress['checklist']
-      return unless checklist&.dig('links', 'items')&.key?(link_id.to_s)
+  # Remove a single citation from the verification checklist (called synchronously when a citation is
+  # destroyed), so the deleted citation stops counting towards the section's verified/total tally.
+  def remove_citation_from_checklist!(citation_id)
+    return unless lex_item_type == 'LexPerson'
 
-      checklist['links']['items'].delete(link_id.to_s)
-      # When the last link is deleted, keep whatever verified state the section had:
-      # a zero-link section can legitimately be marked verified by hand.
-      auto_verify_collections!(checklist) if checklist['links']['items'].any?
-      progress['last_updated_at'] = Time.current.iso8601
-      update!(verification_progress: progress)
-    end
+    remove_collection_item_from_checklist!('citations', citation_id)
   end
 
   # Mark all works as verified (called when marking entire works section as verified)
@@ -334,6 +318,25 @@ class LexEntry < ApplicationRecord
   end
 
   private
+
+  # Drop one item from a collection section of the checklist. `auto_verify_when_empty` controls what
+  # happens once the section runs dry: works re-derive their verified flag from the database (so an
+  # emptied works section correctly becomes unverified), while citations and links keep whatever
+  # verified state they had — an empty section can legitimately be marked verified by hand.
+  def remove_collection_item_from_checklist!(collection, item_id, auto_verify_when_empty: false)
+    with_lock do
+      return if verification_progress.blank?
+
+      progress = verification_progress.deep_dup
+      checklist = progress['checklist']
+      return unless checklist&.dig(collection, 'items')&.key?(item_id.to_s)
+
+      checklist[collection]['items'].delete(item_id.to_s)
+      auto_verify_collections!(checklist) if auto_verify_when_empty || checklist[collection]['items'].any?
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
+    end
+  end
 
   # Auto-verify collection sections when all items are verified
   def auto_verify_collections!(checklist)

--- a/app/views/lexicon/citations/destroy.js
+++ b/app/views/lexicon/citations/destroy.js
@@ -1,1 +1,7 @@
-reloadContent($('#citations'));
+if ($('#citations').length) {
+  // Entry-edit view: lazy-reload just the citations section
+  reloadContent($('#citations'));
+} else {
+  // Verification view: the deleted card lives in the migrated pane, so reload the page
+  reloadPage();
+}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -254,6 +254,8 @@
                 %button.btn.btn-sm{class: checklist['citations']&.dig('items', citation.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "citations.items.#{citation.id}"}}
                   ✓
                   = t('lexicon.verification.migrated.mark_verified')
+                -# Legacy PHP parsing sometimes mistakes a few lines of external links for citations, so verifiers need a way to throw the bogus ones away.
+                = link_to t('lexicon.verification.migrated.delete_citation'), lexicon_citation_path(citation), remote: true, method: :delete, class: 'btn btn-sm btn-outline-danger delete-citation', data: { confirm: t('lexicon.verification.migrated.delete_citation_confirm') }
     - else
       %p.text-muted= t('lexicon.verification.sections.no_citations')
   .section-actions

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -244,6 +244,8 @@ en:
         jump_to: "Jump to:"
         edit: Edit
         add_citation: Add Citation
+        delete_citation: Delete Citation
+        delete_citation_confirm: Permanently delete this citation?
         add_link: Add Link
         delete_link: Delete Link
         delete_link_confirm: Permanently delete this link?

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -245,6 +245,8 @@ he:
         jump_to: "קפיצה אל:"
         edit: ערוך
         add_citation: הוסף מראה מקום
+        delete_citation: מחק מראה מקום
+        delete_citation_confirm: למחוק את מראה המקום לצמיתות?
         add_link: הוסף קישור
         delete_link: מחק קישור
         delete_link_confirm: למחוק את הקישורית לצמיתות?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         ENV['GIT_SHA'] = original_sha
         ENV['GIT_COMMITTED_AT'] = original_committed_at
       end
+    end
   end
 
   # #show_deployment_version? is covered end-to-end, against the real current_user, in

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -186,6 +186,52 @@ RSpec.describe LexEntry, type: :model do
       end
     end
 
+    describe '#remove_citation_from_checklist!' do
+      let!(:citation1) { create(:lex_citation, person: person) }
+      let!(:citation2) { create(:lex_citation, person: person) }
+
+      before do
+        person.reload
+        entry.start_verification!('test@example.com')
+      end
+
+      it 'removes the citation ID from checklist items' do
+        citation1.destroy!
+        entry.remove_citation_from_checklist!(citation1.id)
+
+        items = entry.reload.verification_progress.dig('checklist', 'citations', 'items')
+        expect(items[citation1.id.to_s]).to be_nil
+        expect(items[citation2.id.to_s]).to be_present
+      end
+
+      it 'does nothing when the citation ID is not in the checklist' do
+        expect { entry.remove_citation_from_checklist!(999_999) }.not_to raise_error
+      end
+
+      it 'auto-verifies the section when all remaining citations are verified' do
+        entry.update_checklist_item("citations.items.#{citation2.id}", true)
+
+        citation1.destroy!
+        entry.remove_citation_from_checklist!(citation1.id)
+
+        expect(entry.reload.verification_progress.dig('checklist', 'citations', 'verified')).to be true
+      end
+
+      it 'keeps the citations section verified when the last verified citation goes' do
+        entry.update_checklist_item("citations.items.#{citation1.id}", true)
+        entry.update_checklist_item("citations.items.#{citation2.id}", true)
+
+        [citation1, citation2].each do |citation|
+          citation.destroy!
+          entry.remove_citation_from_checklist!(citation.id)
+        end
+
+        progress = entry.reload.verification_progress
+        expect(progress.dig('checklist', 'citations', 'items')).to be_empty
+        expect(progress.dig('checklist', 'citations', 'verified')).to be true
+      end
+    end
+
     describe '#verification_percentage' do
       let!(:work1) { create(:lex_person_work, person: person, title: 'Work 1') }
       let!(:work2) { create(:lex_person_work, person: person, title: 'Work 2') }

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -370,6 +370,31 @@ describe '/lexicon/citations' do
       expect { call }.to change { person.citations.count }.by(-1)
       expect(call).to eq(200)
     end
+
+    it 'reloads the whole page when not in the entry-edit view' do
+      call
+      expect(response.body).to include('reloadPage()')
+    end
+
+    context 'when the entry is under verification' do
+      let(:entry) { person.entry }
+
+      before { entry.start_verification!('editor@example.com') }
+
+      it 'drops the deleted citation from the verification checklist' do
+        expect { call }
+          .to change { entry.reload.verification_progress.dig('checklist', 'citations', 'items').keys }
+          .from(match_array(citations.map { |c| c.id.to_s }))
+          .to(match_array(citations.drop(1).map { |c| c.id.to_s }))
+      end
+
+      it 'verifies the citations section once only verified citations remain' do
+        citations.drop(1).each { |c| entry.update_checklist_item("citations.items.#{c.id}", true) }
+        expect { call }
+          .to change { entry.reload.verification_progress.dig('checklist', 'citations', 'verified') }
+          .from(false).to(true)
+      end
+    end
   end
 
   describe 'GET /lex/citations/:id/text_links' do

--- a/spec/system/lexicon/verification_citation_delete_spec.rb
+++ b/spec/system/lexicon/verification_citation_delete_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Deleting a citation from the verification page', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+  let!(:citation) { create(:lex_citation, person: person, title: 'מראה מקום שגוי') }
+  let!(:other_citation) { create(:lex_citation, person: person, title: 'מראה מקום תקין') }
+
+  def delete_button_for(target)
+    within("#citation-#{target.id}") do
+      find('a.delete-citation')
+    end
+  end
+
+  it 'asks for confirmation and keeps the citation when the confirmation is dismissed' do
+    visit lexicon_verification_path(entry)
+
+    dismiss_confirm(I18n.t('lexicon.verification.migrated.delete_citation_confirm')) do
+      delete_button_for(citation).click
+    end
+
+    expect(page).to have_css("#citation-#{citation.id}")
+    expect(person.citations.reload).to include(citation)
+  end
+
+  it 'deletes the citation and reloads the page when the confirmation is accepted' do
+    visit lexicon_verification_path(entry)
+
+    accept_confirm(I18n.t('lexicon.verification.migrated.delete_citation_confirm')) do
+      delete_button_for(citation).click
+    end
+
+    expect(page).to have_no_css("#citation-#{citation.id}", wait: 8)
+    expect(page).to have_css("#citation-#{other_citation.id}")
+    expect(person.citations.reload).to contain_exactly(other_citation)
+  end
+end


### PR DESCRIPTION
## Problem

In production, the legacy PHP parser sometimes misidentifies a few lines of external links and stores them as `LexCitation`s. The verification workbench let editors edit and verify citations, but not delete them — the only way to remove a bogus one was the Rails console.

## Changes

- **`app/views/lexicon/verification/_person_sections.html.haml`**: added a "מחק מראה מקום" button to each citation card's actions, mirroring the existing per-link delete. Uses rails-ujs `data-confirm`, so it asks for confirmation before deleting.
- **`app/controllers/lexicon/citations_controller.rb`**: `destroy` now calls `remove_citation_from_checklist!` on the entry, so a deleted citation stops counting towards the section's verified/total tally (works and links already did this).
- **`app/models/lex_entry.rb`**: added `remove_citation_from_checklist!`. The three near-identical `remove_*_from_checklist!` methods now delegate to one private helper. Behaviour is preserved on both sides of the existing split: `works` re-derives its section flag from the database once emptied, while `citations`/`links` keep a hand-set verified flag on an empty section.
- **`app/views/lexicon/citations/destroy.js`**: reloads the whole page when `#citations` is absent (i.e. the verification view), same as `links/destroy.js`. Previously it unconditionally called `reloadContent($('#citations'))`, which is a no-op outside the entry-edit view.
- **Locales**: `delete_citation` / `delete_citation_confirm` added to `lexicon.en.yml` and `lexicon.he.yml`.

No new route or endpoint — this reuses the existing `DELETE /lex/citations/:id`. `LexCitationAuthor` rows and the attached backup file are already cleaned up by `dependent: :destroy` / `has_one_attached`.

Publications have no citations, so `_publication_sections` is untouched.

## Drive-by fix: `spec/helpers/application_helper_spec.rb` syntax error

Unrelated to the feature, but folded into this PR by request. The `'with no baked-in build stamp'` shared_context added in a783060f7 (#1601) was missing the `end` for its `around` block, so the `shared_context` ran to end-of-file and the whole file failed to parse. **None of its 39 examples were running** — including the `#deployment_sha` / `#deployment_time` / `#deployment_version` coverage that commit introduced. All 39 pass once the file parses.

## Test plan

- `spec/system/lexicon/verification_citation_delete_spec.rb` (new): confirms the dialog appears, that dismissing it keeps the citation, and that accepting it deletes the citation and reloads the page.
- `spec/requests/lexicon/citations_spec.rb`: `DELETE` now also asserts the page-reload response and that the citation is dropped from the checklist / the section auto-verifies once only verified citations remain.
- `spec/models/lex_entry_spec.rb`: `#remove_citation_from_checklist!`, matching the existing `#remove_link_from_checklist!` coverage (including the "last verified citation goes" case).

Ran green:
- `spec/models/lex_entry_spec.rb spec/requests/lexicon/citations_spec.rb spec/requests/lexicon/links_spec.rb spec/requests/lexicon/person_works_spec.rb` — 168 examples, 0 failures
- `spec/requests/lexicon/ spec/system/lexicon/` — 498 examples, 0 failures (11m55s)
- `spec/helpers/ spec/requests/version_indicator_spec.rb` — 162 examples, 0 failures

RuboCop clean on all changed Ruby files; haml-lint on `_person_sections.html.haml` is unchanged at its pre-existing baseline of 90 lints.

**The full suite was not run** (40+ minutes) — it needs your go-ahead.

Closes by-cwt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
