### PR TITLE
Open attached PDFs in a new tab instead of downloading them

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -48,7 +48,10 @@ class FilesController < ApplicationController
       result = {}
       record&.downloadable_attachments&.each do |attachment|
         blob = attachment.blob
-        disposition = blob.image? ? 'inline' : 'attachment'
+        # PDFs are linked from lexicon entries as documents to read (sometimes with a #page
+        # anchor), so like images they are served inline and open in the browser's viewer
+        # rather than downloading. Everything else is still offered as a download.
+        disposition = blob.image? || blob.content_type == 'application/pdf' ? 'inline' : 'attachment'
         result[attachment.filename.to_s] = blob.url(
           disposition: disposition,
           expires_in: CACHE_EXPIRATION_TIME + 1.minute

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -26,6 +26,11 @@ describe '/files' do
         create(:lex_entry).tap do |entry|
           entry.attachments.attach(io: StringIO.new('First'), filename: 'file_1.txt', content_type: 'text/plain')
           entry.attachments.attach(io: StringIO.new('Second'), filename: 'file_2', content_type: 'text/plain')
+          entry.attachments.attach(
+            io: StringIO.new("%PDF-1.4\nfake pdf\n"),
+            filename: 'scan.pdf',
+            content_type: 'application/pdf'
+          )
         end
       end
       let(:record_id) { record.id }
@@ -52,9 +57,23 @@ describe '/files' do
       context 'when correct file is requested' do
         let(:filename) { 'file_1.txt' }
 
-        it 'redirects to the file URL' do
+        it 'redirects to the file URL, served as a download' do
           expect(call).to eq(302)
           expect(response.location).to include('file_1.txt')
+          follow_redirect!
+          expect(response.headers['Content-Disposition']).to start_with('attachment')
+        end
+      end
+
+      context 'when a PDF file is requested' do
+        let(:filename) { 'scan.pdf' }
+
+        # PDFs linked from a lexicon entry should open in the browser's viewer in the new
+        # tab the link targets, not download
+        it 'redirects to the file URL, served inline' do
+          expect(call).to eq(302)
+          follow_redirect!
+          expect(response.headers['Content-Disposition']).to start_with('inline')
         end
       end
 


### PR DESCRIPTION
## Problem

On `LexEntry#show`, clicking an internal link to an attached PDF downloads the file instead of opening it in a new tab.

The `target="_blank"` half was never the problem — every path that renders an internal file link on that page already sets it (`MarkdownToHtml` injects it into bio/description/TOC links, and `render_citation`, `text_link_anchor` and `_links.html.haml` pass it explicitly). The cause is `FilesController#download`, which served **every** non-image blob with `Content-Disposition: attachment`. The browser opened the blank tab, got an attachment response, downloaded the file and closed the tab.

## Change

`app/controllers/files_controller.rb`: serve `application/pdf` blobs inline, like images. Everything else is still offered as a download.

This also makes the `#page=N` anchors that migrated legacy links carry (see `Lexicon::MigrateAttachment`) actually work — the browser's PDF viewer honours them.

## Tests

`spec/requests/files_spec.rb`:
- new example: a PDF attached to a `LexEntry` is redirected to with `Content-Disposition: inline` (verified to fail against the old controller: `expected "attachment; filename=\"scan.pdf\"..." to start with "inline"`)
- extended the existing `.txt` example to assert the disposition is still `attachment`, so the non-PDF behaviour is pinned

Ran: `spec/requests/files_spec.rb`, `spec/requests/lexicon/entries_spec.rb`, `spec/requests/lexicon/attachments_spec.rb`, `spec/helpers/lexicon_helper_spec.rb`, `spec/services/markdown_to_html_spec.rb` — 109 examples, 0 failures. RuboCop clean on both changed files. **The full suite was not run** (40+ min; needs your approval).

## Note for deploy

`FilesController` caches the signed blob URLs — disposition included — for 2 hours per record (`CACHE_EXPIRATION_TIME`). Entries whose URLs were cached before the deploy keep downloading PDFs until their cache entry expires. I left the cache key alone rather than adding a version bump for a 2-hour transient; say the word if you'd rather force it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
