### PR TITLE
Flag bot-challenged links as 'verify manually' instead of broken (by-9jz)

### DIFF
--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -394,7 +394,15 @@ body:has(.verification-container) {
     background: #fff5f5;
   }
 
-  .broken-link-badge {
+  // Links we could not get a verdict on (bot challenge) are not failures, so they get a
+  // neutral slate treatment rather than the red of a genuinely broken link.
+  &.unverifiable-link {
+    border-color: #6c757d;
+    background: #f8f9fa;
+  }
+
+  .broken-link-badge,
+  .unverifiable-link-badge {
     display: inline-block;
     font-size: 0.8rem;
     font-weight: 600;
@@ -404,6 +412,13 @@ body:has(.verification-container) {
     border-radius: 4px;
     padding: 0.1rem 0.4rem;
     margin-inline-end: 0.4rem;
+  }
+
+  .unverifiable-link-badge {
+    color: #495057;
+    background: #e9ecef;
+    border-color: #6c757d;
+    cursor: help;
   }
 
   &:hover {

--- a/app/controllers/concerns/link_checking_concern.rb
+++ b/app/controllers/concerns/link_checking_concern.rb
@@ -6,8 +6,10 @@
 # Also reports corrections of previously-broken links to Monday (see #report_broken_link_fix).
 #
 # Records differ in their column names, so the caller passes them in:
-#   - LexLink:     status_column: :http_status,      checked_at_column: :checked_at
-#   - LexCitation: status_column: :link_http_status, checked_at_column: :link_checked_at
+#   - LexLink:     status_column: :http_status,      checked_at_column: :checked_at,
+#                  unverifiable_column: :unverifiable
+#   - LexCitation: status_column: :link_http_status, checked_at_column: :link_checked_at,
+#                  unverifiable_column: :link_unverifiable
 module LinkCheckingConcern
   extend ActiveSupport::Concern
 
@@ -16,16 +18,17 @@ module LinkCheckingConcern
   # Re-checks +url+ synchronously and stores the resulting HTTP status on +record+.
   # A blank URL clears the stored status without making a network request.
   # Sets @link_check_performed / @link_toast_type / @link_toast_message for the JS view.
-  def check_link_synchronously(record, url, status_column:, checked_at_column:)
+  def check_link_synchronously(record, url, status_column:, checked_at_column:, unverifiable_column:)
     if url.blank?
-      record.update_columns(status_column => nil, checked_at_column => nil)
+      record.update_columns(status_column => nil, checked_at_column => nil, unverifiable_column => false)
       return
     end
 
-    status = Lexicon::CheckExternalLinks.new.check_url(url)
-    record.update_columns(status_column => status, checked_at_column => Time.current)
+    result = Lexicon::CheckExternalLinks.new.check_url(url)
+    record.update_columns(status_column => result.status, checked_at_column => Time.current,
+                          unverifiable_column => result.unverifiable?)
     @link_check_performed = true
-    @link_toast_type, @link_toast_message = link_toast_for(status)
+    @link_toast_type, @link_toast_message = link_toast_for(result)
     # flash (not flash.now) is intentional: the JS response triggers a full page reload in the
     # verification view, and the toast must survive into the reloaded request.
     flash[:link_check_toast_type] = @link_toast_type
@@ -54,8 +57,11 @@ module LinkCheckingConcern
     @monday_toast_message = t('lexicon.verification.monday.report_error')
   end
 
-  def link_toast_for(status)
-    if status.nil?
+  def link_toast_for(result)
+    status = result.status
+    if result.unverifiable?
+      ['warning', t('lexicon.verification.broken_link.unverifiable_toast')]
+    elsif status.nil?
       ['error', t('lexicon.verification.broken_link.inaccessible')]
     elsif status < 400
       ['success', t('lexicon.verification.broken_link.now_accessible')]

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -53,7 +53,8 @@ module Lexicon
       if @citation.save
         if @citation.saved_change_to_link?
           check_link_synchronously(@citation, @citation.link,
-                                   status_column: :link_http_status, checked_at_column: :link_checked_at)
+                                   status_column: :link_http_status, checked_at_column: :link_checked_at,
+                                   unverifiable_column: :link_unverifiable)
           report_broken_link_fix(@citation, @person.entry, old_link) if link_was_broken
         end
         return

--- a/app/controllers/lexicon/links_controller.rb
+++ b/app/controllers/lexicon/links_controller.rb
@@ -42,7 +42,9 @@ module Lexicon
         # Re-check the link only when its URL actually changed, so a previously-broken
         # link (e.g. HTTP 403) is re-evaluated instead of keeping its stale status.
         if @link.saved_change_to_url?
-          check_link_synchronously(@link, @link.url, status_column: :http_status, checked_at_column: :checked_at)
+          check_link_synchronously(@link, @link.url, status_column: :http_status,
+                                                     checked_at_column: :checked_at,
+                                                     unverifiable_column: :unverifiable)
           report_broken_link_fix(@link, @item.entry, old_url) if link_was_broken
         end
         return

--- a/app/helpers/lexicon/verification_helper.rb
+++ b/app/helpers/lexicon/verification_helper.rb
@@ -15,19 +15,23 @@ module Lexicon
       (hebrew_count.to_f / total) < LTR_HEBREW_RATIO_THRESHOLD ? 'ltr' : nil
     end
 
-    # Returns the CSS classes for a citation card, including broken-link if needed.
+    # Returns the CSS classes for a citation card, including broken-link (or the neutral
+    # unverifiable-link, when the check reached no verdict) if needed.
     def citation_card_css(citation, checklist)
       verified = checklist['citations']&.dig('items', citation.id.to_s, 'verified')
       css = verified ? 'verified' : 'not-verified'
       css += ' broken-link' if citation.link_broken?
+      css += ' unverifiable-link' if citation.link_unverifiable?
       css
     end
 
-    # Returns the CSS classes for a link card, including broken-link if needed.
+    # Returns the CSS classes for a link card, including broken-link (or the neutral
+    # unverifiable-link, when the check reached no verdict) if needed.
     def link_card_css(link, links_checklist)
       verified = links_checklist&.dig('items', link.id.to_s, 'verified')
       css = verified ? 'verified' : 'not-verified'
       css += ' broken-link' if link.broken?
+      css += ' unverifiable-link' if link.unverifiable?
       css
     end
 

--- a/app/models/lex_citation.rb
+++ b/app/models/lex_citation.rb
@@ -50,8 +50,11 @@ class LexCitation < ApplicationRecord
   # check). link_checked_at distinguishes "checked and dead" from "never checked".
   # Local/relative URLs (e.g. /files/lex/...) are never considered broken — they
   # are served by our own application and cannot be checked via HTTP HEAD.
+  # A link the checker could not get a verdict on (see #link_unverifiable?) is not
+  # broken: we simply do not know, and an editor has to look at it.
   def link_broken?
     return false if link.blank? || !link.start_with?('http://', 'https://')
+    return false if link_unverifiable?
 
     link_checked_at.present? && (link_http_status.nil? || link_http_status >= 400)
   end

--- a/app/models/lex_link.rb
+++ b/app/models/lex_link.rb
@@ -11,8 +11,11 @@ class LexLink < ApplicationRecord
   # checked_at distinguishes "checked and dead" from "never checked".
   # Local/relative URLs are never considered broken — they are served by our
   # own application and cannot be checked via HTTP HEAD.
+  # A link the checker could not get a verdict on (see #unverifiable?) is not broken:
+  # we simply do not know, and an editor has to look at it.
   def broken?
     return false unless url.to_s.start_with?('http://', 'https://')
+    return false if unverifiable?
 
     checked_at.present? && (http_status.nil? || http_status >= 400)
   end

--- a/app/services/lexicon/check_external_links.rb
+++ b/app/services/lexicon/check_external_links.rb
@@ -14,9 +14,28 @@ module Lexicon
   # - Follows up to MAX_REDIRECTS redirects
   # - Stores the final HTTP status code on the record (nil = check failed)
   # - 4xx/5xx codes indicate a broken link
+  # - Unless the refusal is a bot challenge, in which case the link is flagged unverifiable
+  #   rather than broken (see #challenge_response?)
   #
   # Invoked asynchronously via Lexicon::CheckExternalLinksJob after ingestion.
   class CheckExternalLinks < ApplicationService
+    # Outcome of checking one URL. +unverifiable+ means the host refused us with a bot challenge
+    # we cannot solve, so +status+ says nothing about whether the link actually works.
+    Result = Data.define(:status, :unverifiable) do
+      def self.checked(status, unverifiable: false)
+        new(status: status, unverifiable: unverifiable)
+      end
+
+      # No verdict at all: unreachable host, invalid URL, blocked address, redirect loop.
+      def self.unreachable
+        checked(nil)
+      end
+
+      def unverifiable?
+        unverifiable
+      end
+    end
+
     MAX_REDIRECTS = 5
     TIMEOUT_SECONDS = 15
     REDIRECT_STATUSES = [301, 302, 303, 307, 308].freeze
@@ -31,6 +50,11 @@ module Lexicon
     # does exactly this -- `Project-Ben-Yehuda/1.0 (link-checker; +...)` gets a blanket 403 there
     # while `Project-Ben-Yehuda/1.0 (+...)` gets 200. Keep us identifiable, just not by that token.
     USER_AGENT = 'Project-Ben-Yehuda/1.0 (+https://benyehuda.org)'
+
+    # Cloudflare sets cf-mitigated on a request it blocked (value "challenge" for a managed
+    # challenge). Older/other configurations only give us a 403 with a cloudflare Server header.
+    # Keyed off headers rather than a hostname allowlist so the next gated site is handled too.
+    CHALLENGE_STATUS = 403
 
     # RFC1918, loopback, link-local, and IPv6 private ranges to block (SSRF guard)
     PRIVATE_IP_RANGES = [
@@ -52,9 +76,9 @@ module Lexicon
       check_citation_links(item) if item.is_a?(LexPerson)
     end
 
-    # Check a single URL and return its HTTP status code (or nil on error).
+    # Check a single URL and return a Result.
     def check_url(url)
-      fetch_status(url)
+      fetch_result(url)
     end
 
     private
@@ -63,8 +87,9 @@ module Lexicon
       item.links.find_each do |lex_link|
         next unless external_url?(lex_link.url)
 
-        status = fetch_status(lex_link.url)
-        lex_link.update_columns(http_status: status, checked_at: Time.current)
+        result = fetch_result(lex_link.url)
+        lex_link.update_columns(http_status: result.status, unverifiable: result.unverifiable?,
+                                checked_at: Time.current)
       end
     end
 
@@ -72,8 +97,9 @@ module Lexicon
       person.citations.where.not(link: [nil, '']).find_each do |citation|
         next unless external_url?(citation.link)
 
-        status = fetch_status(citation.link)
-        citation.update_columns(link_http_status: status, link_checked_at: Time.current)
+        result = fetch_result(citation.link)
+        citation.update_columns(link_http_status: result.status, link_unverifiable: result.unverifiable?,
+                                link_checked_at: Time.current)
       end
     end
 
@@ -81,26 +107,26 @@ module Lexicon
       url.to_s.start_with?('http://', 'https://')
     end
 
-    # Returns the final HTTP status code after following redirects, or nil on error.
-    def fetch_status(url)
-      return nil if url.blank?
+    # Returns the Result of the check after following redirects.
+    def fetch_result(url)
+      return Result.unreachable if url.blank?
 
       uri = parse_uri(url)
-      return nil unless uri
-      return nil unless ssrf_safe?(uri)
+      return Result.unreachable unless uri
+      return Result.unreachable unless ssrf_safe?(uri)
 
       follow_redirects(uri, MAX_REDIRECTS)
     rescue StandardError => e
       Rails.logger.warn("Lexicon::CheckExternalLinks: failed to check #{url}: #{e.message}")
-      nil
+      Result.unreachable
     end
 
-    # Errors propagate to fetch_status where they are logged.
+    # Errors propagate to fetch_result where they are logged.
     def follow_redirects(uri, remaining_hops)
-      return nil if remaining_hops <= 0
+      return Result.unreachable if remaining_hops <= 0
 
       response = make_request(uri)
-      return nil unless response
+      return Result.unreachable unless response
 
       status = response.code.to_i
 
@@ -109,7 +135,16 @@ module Lexicon
         return follow_redirects(new_uri, remaining_hops - 1) if new_uri
       end
 
-      status
+      Result.checked(status, unverifiable: challenge_response?(response))
+    end
+
+    # True when the response is a bot challenge rather than a verdict about the URL. We cannot
+    # execute a JS challenge from Net::HTTP (and our datacenter IP scores badly), so "we cannot
+    # tell" is the honest reading of such a refusal -- not "the link is dead".
+    def challenge_response?(response)
+      return true if response['cf-mitigated'].present?
+
+      response.code.to_i == CHALLENGE_STATUS && response['server'].to_s.casecmp?('cloudflare')
     end
 
     def make_request(uri)

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -240,6 +240,9 @@
                   - if citation.link_broken?
                     %span.broken-link-badge= broken_link_badge(citation.link_http_status)
                     = link_to t('lexicon.verification.broken_link.internet_archive'), "https://web.archive.org/web/*/#{citation.link}", target: '_blank', rel: 'noopener', class: 'btn btn-sm btn-outline-secondary ms-1'
+                  - elsif citation.link_unverifiable?
+                    %span.unverifiable-link-badge{ title: t('lexicon.verification.broken_link.unverifiable_tooltip') }
+                      = t('lexicon.verification.broken_link.unverifiable_badge')
                   %span.text-muted= t('lexicon.verification.sections.citation_link')
                   = link_to citation.link, citation.link, target: '_blank', class: 'citation-link'
                 - if citation.backup_url.present?
@@ -304,6 +307,9 @@
             - if link.broken?
               %span.broken-link-badge= broken_link_badge(link.http_status)
               = link_to t('lexicon.verification.broken_link.internet_archive'), "https://web.archive.org/web/*/#{link.url}", target: '_blank', rel: 'noopener', class: 'btn btn-sm btn-outline-secondary ms-1'
+            - elsif link.unverifiable?
+              %span.unverifiable-link-badge{ title: t('lexicon.verification.broken_link.unverifiable_tooltip') }
+                = t('lexicon.verification.broken_link.unverifiable_badge')
             = link_to link.url, link.url, target: '_blank'
             - if link.description.present?
               %br

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -122,6 +122,9 @@
           .link-content{dir: text_dir(link.description.to_s)}
             - if link.broken?
               %span.broken-link-badge= broken_link_badge(link.http_status)
+            - elsif link.unverifiable?
+              %span.unverifiable-link-badge{ title: t('lexicon.verification.broken_link.unverifiable_tooltip') }
+                = t('lexicon.verification.broken_link.unverifiable_badge')
             = link_to link.url, link.url, target: '_blank'
             - if link.description.present?
               %br

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -308,6 +308,9 @@ en:
         still_broken: "Link is still broken (HTTP %{status})"
         inaccessible: "Inaccessible link (could not be retrieved)"
         internet_archive: "Internet Archive"
+        unverifiable_badge: "Verify manually"
+        unverifiable_tooltip: "This site blocks automated link checking (Cloudflare challenge), so we cannot tell whether the link works. Open it in a browser and check it yourself."
+        unverifiable_toast: "The link could not be checked automatically — open it in a browser and check it yourself"
       messages:
         progress_saved: Progress saved successfully
         entry_verified: Entry verified successfully

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -309,6 +309,9 @@ he:
         still_broken: "הקישור עדיין שבור (HTTP %{status})"
         inaccessible: "קישור לא נגיש (לא ניתן לאחזר אותו)"
         internet_archive: "ארכיון האינטרנט"
+        unverifiable_badge: "יש לבדוק ידנית"
+        unverifiable_tooltip: "האתר חוסם בדיקה אוטומטית של קישורים (אתגר Cloudflare), ולכן לא ניתן לדעת אם הקישור תקין. פתחו אותו בדפדפן ובדקו ידנית."
+        unverifiable_toast: "לא ניתן לבדוק את הקישור אוטומטית — פתחו אותו בדפדפן ובדקו ידנית"
       messages:
         progress_saved: ההתקדמות נשמרה בהצלחה
         entry_verified: הערך אומת בהצלחה

--- a/db/migrate/20260823120000_add_unverifiable_to_lex_links_and_citations.rb
+++ b/db/migrate/20260823120000_add_unverifiable_to_lex_links_and_citations.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Link checking runs from a datacenter IP and cannot execute a bot challenge (Cloudflare and
+# friends), so the 403 such a host answers with is a false negative, not a broken link. This flag
+# records that third state -- checked, but no verdict reached -- so the verification UI can tell
+# the editor to open the URL in a browser instead of showing a red broken-link warning.
+# Named link_unverifiable on lex_citations to match its sibling link_http_status/link_checked_at.
+class AddUnverifiableToLexLinksAndCitations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :lex_links, :unverifiable, :boolean, default: false, null: false
+    add_column :lex_citations, :link_unverifiable, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -657,6 +657,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_090000) do
     t.string "link", limit: 1024
     t.datetime "link_checked_at"
     t.integer "link_http_status"
+    t.boolean "link_unverifiable", default: false, null: false
     t.integer "manifestation_id"
     t.text "notes"
     t.string "pages"
@@ -758,6 +759,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_090000) do
     t.bigint "item_id"
     t.string "item_type"
     t.integer "status"
+    t.boolean "unverifiable", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "url"
     t.index ["item_type", "item_id"], name: "index_lex_links_on_item_type_and_item_id"

--- a/lib/tasks/ingest_lexicon.rake
+++ b/lib/tasks/ingest_lexicon.rake
@@ -252,11 +252,18 @@ task recheck_broken_lexicon_links: :environment do
   # would only spend a timeout on. Records already flagged unverifiable need no second look.
   links = LexLink.where(unverifiable: false).where(http_status: 400..)
   citations = LexCitation.where(link_unverifiable: false).where(link_http_status: 400..)
+
+  # Tallied as we go rather than by counting the relations afterwards: rechecking moves rows out
+  # of these scopes (a link that now answers 200, or one we have just flagged unverifiable), so a
+  # trailing relation.count would re-run the query against the mutated rows and under-report.
+  checked_links = 0
+  checked_citations = 0
   reclassified = 0
 
   links.find_each do |link|
     result = checker.check_url(link.url)
     link.update_columns(http_status: result.status, unverifiable: result.unverifiable?, checked_at: Time.current)
+    checked_links += 1
     next unless result.unverifiable?
 
     reclassified += 1
@@ -267,13 +274,15 @@ task recheck_broken_lexicon_links: :environment do
     result = checker.check_url(citation.link)
     citation.update_columns(link_http_status: result.status, link_unverifiable: result.unverifiable?,
                             link_checked_at: Time.current)
+    checked_citations += 1
     next unless result.unverifiable?
 
     reclassified += 1
     puts "LexCitation #{citation.id}: #{citation.link} -> unverifiable (HTTP #{result.status})"
   end
 
-  puts "Rechecked #{links.count} links and #{citations.count} citation links; #{reclassified} now unverifiable"
+  puts "Rechecked #{checked_links} links and #{checked_citations} citation links; " \
+       "#{reclassified} now unverifiable"
 end
 
 task reset_lexicon_ingestion: :environment do

--- a/lib/tasks/ingest_lexicon.rake
+++ b/lib/tasks/ingest_lexicon.rake
@@ -243,6 +243,39 @@ task flag_unmigrated_citations: :environment do
   puts "Could not be checked: #{failed.sort.join(', ')}" if failed.any?
 end
 
+desc 'recheck lexicon links already recorded as broken, so bot-challenged ones become unverifiable'
+task recheck_broken_lexicon_links: :environment do
+  checker = Lexicon::CheckExternalLinks.new
+
+  # Only records with an HTTP status >= 400 are candidates: a bot challenge always comes back as a
+  # real response (hence a status), so a nil status means an unreachable host, which re-checking
+  # would only spend a timeout on. Records already flagged unverifiable need no second look.
+  links = LexLink.where(unverifiable: false).where(http_status: 400..)
+  citations = LexCitation.where(link_unverifiable: false).where(link_http_status: 400..)
+  reclassified = 0
+
+  links.find_each do |link|
+    result = checker.check_url(link.url)
+    link.update_columns(http_status: result.status, unverifiable: result.unverifiable?, checked_at: Time.current)
+    next unless result.unverifiable?
+
+    reclassified += 1
+    puts "LexLink #{link.id}: #{link.url} -> unverifiable (HTTP #{result.status})"
+  end
+
+  citations.find_each do |citation|
+    result = checker.check_url(citation.link)
+    citation.update_columns(link_http_status: result.status, link_unverifiable: result.unverifiable?,
+                            link_checked_at: Time.current)
+    next unless result.unverifiable?
+
+    reclassified += 1
+    puts "LexCitation #{citation.id}: #{citation.link} -> unverifiable (HTTP #{result.status})"
+  end
+
+  puts "Rechecked #{links.count} links and #{citations.count} citation links; #{reclassified} now unverifiable"
+end
+
 task reset_lexicon_ingestion: :environment do
   puts 'Wiping Ingested Lexicon Entries...'
   Chewy.strategy(:atomic) do

--- a/spec/lib/tasks/ingest_lexicon_rake_spec.rb
+++ b/spec/lib/tasks/ingest_lexicon_rake_spec.rb
@@ -108,6 +108,89 @@ RSpec.describe 'ingest_lexicon rake task' do # rubocop:disable RSpec/DescribeCla
     end
   end
 
+  describe 'recheck_broken_lexicon_links' do
+    let(:recheck_task) { Rake::Task['recheck_broken_lexicon_links'] }
+    let(:checker) { instance_double(Lexicon::CheckExternalLinks) }
+
+    before do
+      recheck_task.reenable
+      allow(Lexicon::CheckExternalLinks).to receive(:new).and_return(checker)
+      allow(checker).to receive(:check_url).and_return(link_check_result(200))
+    end
+
+    def broken_link(url)
+      create(:lex_link, url: url, http_status: 403, checked_at: 1.day.ago)
+    end
+
+    def broken_citation_link(url)
+      create(:lex_citation, person: create(:lex_person), link: url,
+                            link_http_status: 403, link_checked_at: 1.day.ago)
+    end
+
+    it 'flags a link whose host now answers with a bot challenge' do
+      link = broken_link('https://www.nli.org.il/he/archives/NNL_ALEPH000000001')
+      allow(checker).to receive(:check_url).and_return(link_check_result(403, unverifiable: true))
+
+      recheck_task.invoke
+
+      expect(link.reload.unverifiable).to be true
+    end
+
+    it 'flags a citation link whose host now answers with a bot challenge' do
+      citation = broken_citation_link('https://www.nli.org.il/he/newspapers/example')
+      allow(checker).to receive(:check_url).and_return(link_check_result(403, unverifiable: true))
+
+      recheck_task.invoke
+
+      expect(citation.reload.link_unverifiable).to be true
+    end
+
+    # Regression: the summary line used to call .count on the two relations after the loops had
+    # already moved rows out of their scopes, so it re-queried the mutated rows and reported far
+    # fewer records than it had actually rechecked -- here, zero of each.
+    it 'reports what it rechecked, not what still matches the scope afterwards' do
+      broken_link('https://recovered.example.com/a')
+      broken_citation_link('https://recovered.example.com/b')
+
+      expect { recheck_task.invoke }
+        .to output(/Rechecked 1 links and 1 citation links; 0 now unverifiable/).to_stdout
+    end
+
+    it 'counts records it reclassified, which have also left the scope' do
+      broken_link('https://www.nli.org.il/he/archives/a')
+      broken_citation_link('https://www.nli.org.il/he/newspapers/b')
+      allow(checker).to receive(:check_url).and_return(link_check_result(403, unverifiable: true))
+
+      expect { recheck_task.invoke }
+        .to output(/Rechecked 1 links and 1 citation links; 2 now unverifiable/).to_stdout
+    end
+
+    it 'skips an unreachable link (nil status) rather than spending a timeout on it' do
+      create(:lex_link, url: 'https://dead.example.com/x', http_status: nil, checked_at: 1.day.ago)
+
+      recheck_task.invoke
+
+      expect(checker).not_to have_received(:check_url)
+    end
+
+    it 'skips links already flagged unverifiable' do
+      create(:lex_link, url: 'https://www.nli.org.il/he/archives/x', http_status: 403,
+                        unverifiable: true, checked_at: 1.day.ago)
+
+      recheck_task.invoke
+
+      expect(checker).not_to have_received(:check_url)
+    end
+
+    it 'clears the flag on a link that now answers normally' do
+      link = broken_link('https://recovered.example.com/a')
+
+      recheck_task.invoke
+
+      expect(link.reload).to have_attributes(http_status: 200, unverifiable: false)
+    end
+  end
+
   describe 'fix_lexicon_titles' do
     let(:fix_task) { Rake::Task['fix_lexicon_titles'] }
     let(:source_file) { fixtures_dir.join('00020.php') }

--- a/spec/models/lex_citation_spec.rb
+++ b/spec/models/lex_citation_spec.rb
@@ -91,5 +91,16 @@ describe LexCitation do
 
       it { is_expected.to be false }
     end
+
+    # A bot challenge (Cloudflare) tells us nothing about the link, so "we cannot tell" must not
+    # be shown to editors as "broken". See by-9jz.
+    context 'when the check hit a bot challenge (link_unverifiable)' do
+      subject do
+        build(:lex_citation, link_checked_at: Time.current, link_http_status: 403,
+                             link_unverifiable: true).link_broken?
+      end
+
+      it { is_expected.to be false }
+    end
   end
 end

--- a/spec/models/lex_link_spec.rb
+++ b/spec/models/lex_link_spec.rb
@@ -46,5 +46,15 @@ describe LexLink do
 
       it { is_expected.to be false }
     end
+
+    # A bot challenge (Cloudflare) tells us nothing about the link, so "we cannot tell" must not
+    # be shown to editors as "broken". See by-9jz.
+    context 'when the check hit a bot challenge (unverifiable)' do
+      subject do
+        build(:lex_link, checked_at: Time.current, http_status: 403, unverifiable: true).broken?
+      end
+
+      it { is_expected.to be false }
+    end
   end
 end

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -147,7 +147,7 @@ describe '/lexicon/citations' do
       end
 
       context 'when the new link is accessible' do
-        before { allow(checker).to receive(:check_url).and_return(200) }
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(200)) }
 
         it 'updates link_http_status synchronously' do
           call
@@ -162,7 +162,7 @@ describe '/lexicon/citations' do
       end
 
       context 'when the new link is still broken' do
-        before { allow(checker).to receive(:check_url).and_return(404) }
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(404)) }
 
         it 'stores the new broken status' do
           call
@@ -177,7 +177,7 @@ describe '/lexicon/citations' do
       end
 
       context 'when the link is unreachable (host defunct)' do
-        before { allow(checker).to receive(:check_url).and_return(nil) }
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(nil)) }
 
         it 'stores nil status but records the check time and flags it broken' do
           call
@@ -196,7 +196,7 @@ describe '/lexicon/citations' do
     end
 
     context 'when a broken link is replaced' do
-      let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 200) }
+      let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: link_check_result(200)) }
       let(:entry) { create(:lex_entry, :person, status: :verifying) }
       let(:person) { entry.lex_item }
       let(:old_link) { 'https://dead.example.com/page' }
@@ -235,7 +235,7 @@ describe '/lexicon/citations' do
       end
 
       context 'when the replacement link is also broken' do
-        let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 404) }
+        let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: link_check_result(404)) }
 
         it 'still reports the change' do
           call

--- a/spec/requests/lexicon/links_spec.rb
+++ b/spec/requests/lexicon/links_spec.rb
@@ -68,7 +68,7 @@ describe '/lexicon/links' do
         # attributes_for changes the URL, which now triggers a synchronous re-check.
         # Stub the network call so this example stays offline.
         allow(Lexicon::CheckExternalLinks).to receive(:new)
-          .and_return(instance_double(Lexicon::CheckExternalLinks, check_url: 200))
+          .and_return(instance_double(Lexicon::CheckExternalLinks, check_url: link_check_result(200)))
       end
 
       it 'updates record' do
@@ -99,7 +99,7 @@ describe '/lexicon/links' do
       end
 
       context 'when the new link is accessible' do
-        before { allow(checker).to receive(:check_url).and_return(200) }
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(200)) }
 
         it 'launches a fresh check and stores the new status' do
           call
@@ -116,7 +116,7 @@ describe '/lexicon/links' do
       end
 
       context 'when the new link is still broken' do
-        before { allow(checker).to receive(:check_url).and_return(404) }
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(404)) }
 
         it 'stores the new broken status' do
           call
@@ -126,7 +126,7 @@ describe '/lexicon/links' do
       end
 
       context 'when the link is unreachable (host defunct)' do
-        before { allow(checker).to receive(:check_url).and_return(nil) }
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(nil)) }
 
         it 'stores nil status but records the check time and flags it broken' do
           call
@@ -136,10 +136,42 @@ describe '/lexicon/links' do
           expect(link).to be_broken
         end
       end
+
+      # A bot challenge is not a verdict, so the editor gets a neutral warning rather than
+      # a red "still broken" toast. See by-9jz.
+      context 'when the new host answers with a bot challenge' do
+        before { allow(checker).to receive(:check_url).and_return(link_check_result(403, unverifiable: true)) }
+
+        it 'flags the link unverifiable instead of broken' do
+          call
+          link.reload
+          expect(link.unverifiable).to be true
+          expect(link.http_status).to eq(403)
+          expect(link).not_to be_broken
+        end
+
+        it 'includes a neutral warning toast in the response' do
+          call
+          expect(response.body).to include('warning')
+          expect(response.body).to include(I18n.t('lexicon.verification.broken_link.unverifiable_toast'))
+        end
+      end
+
+      context 'when a link previously flagged unverifiable is replaced with a working one' do
+        before do
+          link.update_columns(unverifiable: true)
+          allow(checker).to receive(:check_url).and_return(link_check_result(200))
+        end
+
+        it 'clears the unverifiable flag' do
+          call
+          expect(link.reload.unverifiable).to be false
+        end
+      end
     end
 
     context 'when a broken URL is replaced' do
-      let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 200) }
+      let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: link_check_result(200)) }
       let(:entry) { create(:lex_entry, :person, status: :verifying) }
       let(:old_url) { 'https://dead.example.com/page' }
       let(:link) { create(:lex_link, item: person, description: 'אתר הזיכרון', url: old_url) }
@@ -175,7 +207,7 @@ describe '/lexicon/links' do
       end
 
       context 'when the replacement URL is also broken' do
-        let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 404) }
+        let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: link_check_result(404)) }
 
         it 'still reports the change' do
           call

--- a/spec/services/lexicon/check_external_links_spec.rb
+++ b/spec/services/lexicon/check_external_links_spec.rb
@@ -158,6 +158,135 @@ describe Lexicon::CheckExternalLinks do
     end
   end
 
+  # Link checking runs from a datacenter IP and cannot execute a JS challenge, so a Cloudflare
+  # challenge is a false negative, not a dead link. See by-9jz (www.nli.org.il).
+  describe 'links behind a bot challenge' do
+    let!(:link) { create(:lex_link, item: person, url: url) }
+
+    context 'when the host answers with a Cloudflare managed challenge' do
+      let(:url) { 'http://challenged.example.com/record' }
+      let(:cf_headers) { { 'cf-mitigated' => 'challenge', 'Server' => 'cloudflare' } }
+
+      before do
+        stub_request(:head, url).to_return(status: 403, headers: cf_headers)
+        stub_request(:get, url).to_return(status: 403, headers: cf_headers)
+      end
+
+      it 'flags the link unverifiable and keeps the raw status for diagnostics' do
+        call
+        link.reload
+        expect(link.unverifiable).to be true
+        expect(link.http_status).to eq(403)
+      end
+
+      it 'does not report the link as broken' do
+        call
+        expect(link.reload).not_to be_broken
+      end
+    end
+
+    context 'when Cloudflare 403s without the cf-mitigated header' do
+      let(:url) { 'http://cf-plain-403.example.com/record' }
+
+      before do
+        stub_request(:head, url).to_return(status: 403, headers: { 'Server' => 'cloudflare' })
+        stub_request(:get, url).to_return(status: 403, headers: { 'Server' => 'cloudflare' })
+      end
+
+      it 'still flags the link unverifiable' do
+        call
+        expect(link.reload.unverifiable).to be true
+      end
+    end
+
+    # The point of keying off headers rather than a hostname list is that ordinary refusals from
+    # ordinary servers must keep counting as broken.
+    context 'when a plain 403 arrives without any challenge headers' do
+      let(:url) { 'http://plain-403.example.com/denied' }
+
+      before do
+        stub_request(:head, url).to_return(status: 403)
+        stub_request(:get, url).to_return(status: 403)
+      end
+
+      it 'leaves the link broken and not unverifiable' do
+        call
+        link.reload
+        expect(link.unverifiable).to be false
+        expect(link).to be_broken
+      end
+    end
+
+    context 'when a Cloudflare-fronted host returns an honest 404' do
+      let(:url) { 'http://cf-404.example.com/missing' }
+
+      before do
+        stub_request(:head, url).to_return(status: 404, headers: { 'Server' => 'cloudflare' })
+      end
+
+      it 'is broken, not unverifiable' do
+        call
+        link.reload
+        expect(link.unverifiable).to be false
+        expect(link).to be_broken
+      end
+    end
+
+    context 'when a previously challenged link now answers normally' do
+      let(:url) { 'http://was-challenged.example.com/record' }
+
+      before do
+        link.update_columns(http_status: 403, unverifiable: true, checked_at: 1.day.ago)
+        stub_request(:head, url).to_return(status: 200)
+      end
+
+      it 'clears the unverifiable flag' do
+        call
+        link.reload
+        expect(link.unverifiable).to be false
+        expect(link.http_status).to eq(200)
+      end
+    end
+  end
+
+  describe 'citation links behind a bot challenge' do
+    let(:citation) { create(:lex_citation, person: person, link: 'http://challenged.example.com/cit') }
+
+    before do
+      citation
+      headers = { 'cf-mitigated' => 'challenge', 'Server' => 'cloudflare' }
+      stub_request(:head, 'http://challenged.example.com/cit').to_return(status: 403, headers: headers)
+      stub_request(:get, 'http://challenged.example.com/cit').to_return(status: 403, headers: headers)
+    end
+
+    it 'flags the citation link unverifiable rather than broken' do
+      call
+      citation.reload
+      expect(citation.link_unverifiable).to be true
+      expect(citation).not_to be_link_broken
+    end
+  end
+
+  describe '#check_url' do
+    it 'returns the status and the unverifiable verdict for a challenged URL' do
+      headers = { 'cf-mitigated' => 'challenge', 'Server' => 'cloudflare' }
+      stub_request(:head, 'http://challenged.example.com/one').to_return(status: 403, headers: headers)
+      stub_request(:get, 'http://challenged.example.com/one').to_return(status: 403, headers: headers)
+
+      result = described_class.new.check_url('http://challenged.example.com/one')
+      expect(result.status).to eq(403)
+      expect(result).to be_unverifiable
+    end
+
+    it 'returns a nil status and no verdict for an unreachable URL' do
+      stub_request(:head, 'http://dead.example.com/one').to_raise(Errno::ECONNREFUSED)
+
+      result = described_class.new.check_url('http://dead.example.com/one')
+      expect(result.status).to be_nil
+      expect(result).not_to be_unverifiable
+    end
+  end
+
   # Regression: www.text.org.il's mod_security rules 403 any User-Agent containing "link"
   # (matching "linkchecker"), which made every link on that host look broken. See #1594.
   describe 'the User-Agent sent to external servers' do

--- a/spec/support/link_check_helpers.rb
+++ b/spec/support/link_check_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Shared factory for the value Lexicon::CheckExternalLinks#check_url returns, so the specs that
+# stub the checker (request, system and service specs) don't each spell out the Result constructor.
+module LinkCheckHelpers
+  # +unverifiable+ marks a host that answered with a bot challenge: the status says nothing about
+  # whether the link works, and an editor has to check it in a browser.
+  def link_check_result(status, unverifiable: false)
+    Lexicon::CheckExternalLinks::Result.checked(status, unverifiable: unverifiable)
+  end
+end
+
+RSpec.configure do |config|
+  config.include LinkCheckHelpers
+end

--- a/spec/system/lexicon/verification_citation_link_check_spec.rb
+++ b/spec/system/lexicon/verification_citation_link_check_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Citation link check feedback on verification page', type: :syste
   end
 
   context 'when the new link is accessible (HTTP 200)' do
-    let(:check_url_result) { 200 }
+    let(:check_url_result) { link_check_result(200) }
 
     it 'reloads the page and shows a green success toast' do
       visit_verification_page
@@ -66,7 +66,7 @@ RSpec.describe 'Citation link check feedback on verification page', type: :syste
   end
 
   context 'when the new link is still broken (HTTP 404)' do
-    let(:check_url_result) { 404 }
+    let(:check_url_result) { link_check_result(404) }
 
     it 'reloads the page and shows a red error toast' do
       visit_verification_page
@@ -87,7 +87,7 @@ RSpec.describe 'Citation link check feedback on verification page', type: :syste
   end
 
   context 'when the new link could not be retrieved (nil status)' do
-    let(:check_url_result) { nil }
+    let(:check_url_result) { link_check_result(nil) }
 
     it 'reloads the page and shows a red error toast' do
       visit_verification_page
@@ -108,7 +108,7 @@ RSpec.describe 'Citation link check feedback on verification page', type: :syste
   end
 
   context 'when the link is not changed' do
-    let(:check_url_result) { nil }
+    let(:check_url_result) { link_check_result(nil) }
 
     it 'reloads the page without a toast' do
       visit_verification_page

--- a/spec/system/lexicon/verification_link_check_spec.rb
+++ b/spec/system/lexicon/verification_link_check_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'External link check feedback on verification page', :js, type: :
   end
 
   context 'when the new link is accessible (HTTP 200)' do
-    let(:check_url_result) { 200 }
+    let(:check_url_result) { link_check_result(200) }
 
     it 'reloads the page and shows a green success toast' do
       visit_verification_page
@@ -64,7 +64,7 @@ RSpec.describe 'External link check feedback on verification page', :js, type: :
   end
 
   context 'when the new link is still broken (HTTP 404)' do
-    let(:check_url_result) { 404 }
+    let(:check_url_result) { link_check_result(404) }
 
     it 'reloads the page and shows a red error toast' do
       visit_verification_page
@@ -85,7 +85,7 @@ RSpec.describe 'External link check feedback on verification page', :js, type: :
   end
 
   context 'when the link is not changed' do
-    let(:check_url_result) { nil }
+    let(:check_url_result) { link_check_result(nil) }
 
     it 'reloads the page without a toast' do
       visit_verification_page

--- a/spec/system/lexicon/verification_unverifiable_link_spec.rb
+++ b/spec/system/lexicon/verification_unverifiable_link_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Links behind a bot challenge (e.g. www.nli.org.il behind Cloudflare) cannot be checked from our
+# datacenter IP. The verification workbench must say so neutrally instead of crying "broken link".
+# See by-9jz.
+RSpec.describe 'Unverifiable link badge on verification page', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+
+  let(:badge_text) { I18n.t('lexicon.verification.broken_link.unverifiable_badge') }
+  let(:broken_badge_text) { I18n.t('lexicon.verification.broken_link.badge', status: 403) }
+
+  context 'with a link that was challenged by the host' do
+    let!(:link) do
+      create(:lex_link,
+             item: person,
+             url: 'https://www.nli.org.il/he/archives/NNL_ALEPH000000001',
+             http_status: 403,
+             unverifiable: true,
+             checked_at: Time.current)
+    end
+
+    it 'shows the neutral verify-manually badge instead of the broken-link badge' do
+      visit lexicon_verification_path(entry)
+
+      within("#link-#{link.id}") do
+        expect(page).to have_css('.unverifiable-link-badge', text: badge_text)
+        expect(page).to have_no_css('.broken-link-badge')
+      end
+    end
+
+    it 'does not style the card as a broken link' do
+      visit lexicon_verification_path(entry)
+
+      expect(page).to have_css("#link-#{link.id}.unverifiable-link")
+      expect(page).to have_no_css("#link-#{link.id}.broken-link")
+    end
+
+    it 'explains in the tooltip that the URL must be opened in a browser' do
+      visit lexicon_verification_path(entry)
+
+      expect(page).to have_css("#link-#{link.id} .unverifiable-link-badge")
+      badge = find("#link-#{link.id} .unverifiable-link-badge")
+      expect(badge[:title]).to eq(I18n.t('lexicon.verification.broken_link.unverifiable_tooltip'))
+    end
+  end
+
+  context 'with a link that is genuinely broken' do
+    let!(:link) do
+      create(:lex_link,
+             item: person,
+             url: 'https://broken.example.com/gone',
+             http_status: 403,
+             unverifiable: false,
+             checked_at: Time.current)
+    end
+
+    it 'still shows the red broken-link badge' do
+      visit lexicon_verification_path(entry)
+
+      within("#link-#{link.id}") do
+        expect(page).to have_css('.broken-link-badge', text: broken_badge_text)
+        expect(page).to have_no_css('.unverifiable-link-badge')
+      end
+    end
+  end
+
+  context 'with a citation whose link was challenged by the host' do
+    let!(:citation) do
+      create(:lex_citation,
+             person: person,
+             title: 'Test Article',
+             link: 'https://www.nli.org.il/he/newspapers/example',
+             link_http_status: 403,
+             link_unverifiable: true,
+             link_checked_at: Time.current)
+    end
+
+    it 'shows the neutral verify-manually badge on the citation' do
+      visit lexicon_verification_path(entry)
+
+      within("#citation-#{citation.id}") do
+        expect(page).to have_css('.unverifiable-link-badge', text: badge_text)
+        expect(page).to have_no_css('.broken-link-badge')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Link checking runs from a datacenter IP (AWS us-east-1b) and cannot pass a Cloudflare
managed challenge, so **every** link on `http://www.nli.org.il` was recorded as HTTP 403 and
shown to verifying editors as a **BROKEN LINK**. Those are false negatives: the links are
fine, we simply cannot verify them programmatically. Zone-wide — even `/robots.txt` 403s —
and it fails identically with HEAD, GET, our checker UA and a full Chrome UA, so the UA and
HEAD-fallback fixes in #1594 cannot help here.

This adds an honest third state between "works" and "broken": *we cannot tell, look at it
yourself*.

## Changes

- **Migration** `20260823120000`: `lex_links.unverifiable` and `lex_citations.link_unverifiable`
  (boolean, default false, not null).
- **`Lexicon::CheckExternalLinks`**: detects the challenge from **response headers** —
  `cf-mitigated` present, or a 403 with `Server: cloudflare` — rather than a hardcoded
  hostname allowlist, so the next gated site is covered too. `#check_url` now returns a
  `Result` value carrying both the raw HTTP status (kept for diagnostics) and the verdict.
- **Models**: `LexLink#broken?` and `LexCitation#link_broken?` return `false` for unverifiable
  records, which previously had only the two states nil/`>= 400`.
- **Verification UI**: a neutral grey *"יש לבדוק ידנית"* badge with a tooltip explaining that
  the site blocks automated checking and the editor should open the URL in a browser —
  instead of the red broken-link badge and its Internet Archive button. Cards get a slate
  `.unverifiable-link` style rather than the red `.broken-link` one.
- **Editing a link**: re-checking on URL change now sets *or clears* the flag, and raises a
  neutral `toast-warning` rather than a red "still broken" error.
- **I18n**: `unverifiable_badge` / `unverifiable_tooltip` / `unverifiable_toast` in both
  `lexicon.he.yml` and `lexicon.en.yml`.
- **Backfill**: `rake recheck_broken_lexicon_links` re-checks records already recorded as
  `>= 400` so existing NLI entries stop displaying as broken. It deliberately skips nil-status
  records: a challenge always produces a real response, so a nil status means an unreachable
  host and re-checking it would only spend a timeout.

## Deliberately not done

- No blanket hostname whitelist that assumes such links never break. "We cannot tell" is the
  honest state, and it is what the editor is shown.
- Validating NLI records via `api.nli.org.il` was rejected: it needs an API key and only covers
  catalogue-style permalinks.

## Deviation from the bead

The bead specified a column named `unverifiable` on **both** tables. On `lex_citations` I named
it `link_unverifiable` to match its siblings `link_http_status` / `link_checked_at` /
`link_broken?` — on that model `unverifiable?` would read as a property of the citation rather
than of its link. `LinkCheckingConcern` already takes column names as parameters, so differing
names cost nothing. Say the word if you'd rather have it renamed.

## Tests

Run and passing:

- `spec/services/lexicon/check_external_links_spec.rb` — 45 examples. New: challenge headers ⇒
  unverifiable; Cloudflare 403 without `cf-mitigated` ⇒ still unverifiable; **plain 403 with no
  challenge headers ⇒ still broken**; Cloudflare-fronted honest 404 ⇒ broken, not unverifiable;
  a previously-challenged link that now answers 200 ⇒ flag cleared; citation links; `#check_url`
  return value.
- `spec/models/lex_link_spec.rb`, `spec/models/lex_citation_spec.rb` — unverifiable ⇒ not broken.
- `spec/requests/lexicon/links_spec.rb`, `spec/requests/lexicon/citations_spec.rb` — the neutral
  warning toast, and clearing a stale flag on re-check.
- `spec/system/lexicon/verification_unverifiable_link_spec.rb` (new) — the badge, the tooltip,
  the card styling, and that a genuinely broken link still gets the red badge.
- `spec/system/lexicon/verification_link_check_spec.rb`,
  `verification_citation_link_check_spec.rb` — updated for the new `check_url` return type.

Totals: 136 model/service/request/job examples and 17 system examples, 0 failures.
RuboCop and haml-lint clean on every file touched.

**The full suite was not run** — per `.claude/rules/full-test-suite-runtime.md` it takes 40+
minutes and needs your approval.

## Unrelated breakage found

`spec/helpers/application_helper_spec.rb:314` has a **syntax error on master** (at a783060f7,
the build-stamp commit), which aborts loading the whole `spec/helpers` directory. Filed as
`by-3lt`; not touched here.

Closes by-9jz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
