### PR TITLE
Fix spacing of angled-bracket comments on lexicon entry pages

### DIFF
--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -55,20 +55,29 @@ module LexiconHelper
   end
 
   def render_person_work(work)
-    result = String.new(render_person_work_title(work))
+    parts = [
+      render_person_work_title(work),
+      "(#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
+    ]
 
-    result += " (#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
+    parts += work.linked_people
+                 .sort_by(&:sort_value)
+                 .map { |person| angle_bracketed(render_linked_person(person)) }
 
-    result += work.linked_people
-                  .sort_by(&:sort_value)
-                  .map { |person| "<  #{render_linked_person(person)}  >" }.join(' ')
+    parts += work.comment.to_s.split("\n").compact_blank
+                 .map { |comment| angle_bracketed(render_person_work_comment(comment, work.comment_links)) }
 
-    if work.comment.present?
-      work.comment.split("\n").each do |comment|
-        result += " < #{render_person_work_comment(comment, work.comment_links)} >"
-      end
-    end
-    raw result
+    # every part is separated from the next by exactly one space, so the brackets below never
+    # need one of their own
+    raw parts.join(' ')
+  end
+
+  # Wraps a work comment in angled brackets, with NO space between a bracket and the content it
+  # encloses (the space belongs outside the brackets — see render_person_work).
+  # The brackets are emitted as entities so that a comment beginning or ending with a link can't
+  # produce a "<<a href=" / "</a>>" sequence for the HTML parser to trip over.
+  def angle_bracketed(content)
+    "&lt;#{content.to_s.strip}&gt;"
   end
 
   # Renders a work comment, hyperlinking any text listed in comment_links.

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -72,9 +72,9 @@ module LexiconHelper
     raw parts.join(' ')
   end
 
-  # Wraps a work comment in angled brackets, with NO space between a bracket and the content it
+  # Wraps content in angled brackets, with NO space between a bracket and the content it
   # encloses (the space belongs outside the brackets — see render_person_work).
-  # The brackets are emitted as entities so that a comment beginning or ending with a link can't
+  # The brackets are emitted as entities so that content beginning or ending with a link can't
   # produce a "<<a href=" / "</a>>" sequence for the HTML parser to trip over.
   def angle_bracketed(content)
     "&lt;#{content.to_s.strip}&gt;"

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -176,6 +176,42 @@ RSpec.describe LexiconHelper, type: :helper do
     end
   end
 
+  describe '#render_person_work' do
+    let(:work) do
+      create(:lex_person_work, title: 'ספר הזכרונות', publication_place: 'תל אביב', publisher: 'עם עובד',
+                               publication_date: '1975', title_links: nil)
+    end
+
+    # the rendered text minus the markup, which is what the spacing rule is about
+    def rendered_text(work)
+      Nokogiri::HTML.fragment(helper.render_person_work(work)).text
+    end
+
+    it 'puts no space inside the angled brackets, and one space around them' do
+      create(:lex_linked_person, person_work: work, name: 'דן פגיס', link_type: :editor, person_entry: nil)
+      work.update!(comment: 'כולל אחרית דבר')
+
+      expect(rendered_text(work.reload))
+        .to eq('ספר הזכרונות (תל אביב : עם עובד, 1975) <עריכה דן פגיס> <כולל אחרית דבר>')
+    end
+
+    it 'strips whitespace surrounding the content of the brackets' do
+      work.update!(comment: "  כולל אחרית דבר  \n\n  ובו תצלומים  ")
+
+      expect(rendered_text(work.reload))
+        .to eq('ספר הזכרונות (תל אביב : עם עובד, 1975) <כולל אחרית דבר> <ובו תצלומים>')
+    end
+
+    it 'keeps the brackets outside a link that spans the whole comment' do
+      target = create(:lex_entry, :person, title: 'יגאל שוורץ')
+      work.update!(comment: 'יגאל שוורץ', comment_links: [{ 'text' => 'יגאל שוורץ', 'entry_id' => target.id }])
+
+      result = helper.render_person_work(work.reload)
+      expect(result).to include("&lt;<a href=\"#{lexicon_entry_path(target)}\">יגאל שוורץ</a>&gt;")
+      expect(rendered_text(work)).to end_with(') <יגאל שוורץ>')
+    end
+  end
+
   describe '#render_person_work_comment' do
     let!(:target_entry) { create(:lex_entry, :person, title: 'יגאל שוורץ') }
     let(:comment) { 'כולל אחרית דבר מאת יגאל שוורץ' }


### PR DESCRIPTION
## What

On a lexicon entry page (`LexEntry#show`), a person's works can carry comments shown in angled brackets — linked people (`עריכה פלוני`) and the work's own comment lines. The spacing was wrong on both sides:

- linked people rendered as `<  content  >` — two spaces inside each bracket;
- work comments rendered as ` < content > ` — one space inside each bracket;
- the first linked person's `<` was appended directly to the publication details, with no space before it.

The required form (logical order — the page is RTL) is:

```
טקסט קודם <הערה בסוגריים זוויתיים> טקסט אחר כך
```

i.e. **no** space between a bracket and the content it encloses, and **one** space between a bracket and the neighbouring word.

## How

`render_person_work` now builds the line as a list of parts joined by a single space, and `angle_bracketed` wraps each comment with no padding. Its content is stripped, so a comment line with trailing whitespace in the database can't reintroduce a gap; blank comment lines are dropped rather than rendering empty brackets (they previously rendered as `<  >`).

The brackets are emitted as `&lt;`/`&gt;` entities. Without the padding spaces, a comment that is entirely a hyperlink would put a literal `<` immediately before `<a href=`; browsers do recover from that, but there is no reason to hand it to the parser.

## Test plan

New examples in `spec/helpers/lexicon_helper_spec.rb` under `#render_person_work` assert the exact rendered text for a work with a linked person and a comment, that surrounding whitespace is stripped, and that the brackets stay outside a link spanning the whole comment.

Ran:
- `bundle exec rspec spec/helpers/lexicon_helper_spec.rb` — 51 examples, 0 failures
- `bundle exec rspec spec/requests/lexicon/{linked_people,person_works,entries}_spec.rb spec/system/lexicon/person_work_{comment,title}_links_spec.rb` — 71 examples, 0 failures

The full suite (40+ min) was not run; it needs your go-ahead.

Closes by-52l

🤖 Generated with [Claude Code](https://claude.com/claude-code)