### PR TITLE
Omit content-free layout tables from migrated lexicon bios

### DIFF
--- a/app/services/lexicon/html_utils.rb
+++ b/app/services/lexicon/html_utils.rb
@@ -8,6 +8,10 @@ module Lexicon
     # mojibake ('נ' -> '× ', 'ת' -> '×ª', ...) rather than failing loudly.
     FALLBACK_ENCODING = 'ISO-8859-1'
 
+    # Elements that render something of their own, so a table holding one is not empty
+    # even when it has no text.
+    VISIBLE_EMPTY_ELEMENTS = 'img, hr, iframe, embed, object, video, audio, input'
+
     # Parses a legacy lexicon PHP file, honouring the charset it declares (a handful of
     # the oldest files are genuinely windows-1255) but defaulting to UTF-8 instead of
     # libxml2's Latin-1 when no charset is declared.
@@ -29,6 +33,12 @@ module Lexicon
         # Otherwise we check for an anchor with any name specified
         return elem.at_css('a[name]').present?
       end
+    end
+
+    # Some legacy files carry layout-only tables: rows and cells, but nothing to show.
+    # Pandoc keeps them as raw HTML, so they survive migration as markup noise.
+    def content_free_table?(elem)
+      elem.name == 'table' && elem.text.blank? && elem.at_css(VISIBLE_EMPTY_ELEMENTS).nil?
     end
 
     def next_element_skipping_blank(elem)

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -71,7 +71,7 @@ module Lexicon
 
       bio = []
       while next_elem.present? && !header?(next_elem, WORKS_HEADER)
-        bio << next_elem.to_html
+        bio << bio_html(next_elem)
         next_elem = next_elem.next_element
       end
 
@@ -80,12 +80,12 @@ module Lexicon
       if next_elem.nil? && !at_span_level && heading_table.parent.name == 'span'
         next_elem = heading_table.parent.next_element
         while next_elem.present? && !header?(next_elem, WORKS_HEADER)
-          bio << next_elem.to_html
+          bio << bio_html(next_elem)
           next_elem = next_elem.next_element
         end
       end
 
-      lex_person.bio = HtmlToMarkdown.call(bio.join("\n"))
+      lex_person.bio = HtmlToMarkdown.call(bio.compact.join("\n"))
 
       if next_elem.present? && header?(next_elem, WORKS_HEADER)
         Lexicon::ExtractPersonWorks.call(next_elem, lex_person)
@@ -118,6 +118,18 @@ module Lexicon
     end
 
     private
+
+    # HTML of a single bio element, with content-free tables dropped: nil when the element
+    # is itself such a table, otherwise its markup minus any it contains. The element is
+    # copied before pruning, so the document the rest of the ingestion reads stays intact.
+    def bio_html(elem)
+      return nil if content_free_table?(elem)
+      return elem.to_html if elem.css('table').none? { |table| content_free_table?(table) }
+
+      copy = elem.dup
+      copy.css('table').each { |table| table.remove if content_free_table?(table) }
+      copy.to_html
+    end
 
     def link_citations_to_works(lex_person)
       lex_person.citations.each do |citation|

--- a/spec/fixtures/files/lexicon/empty_table_in_bio.php
+++ b/spec/fixtures/files/lexicon/empty_table_in_bio.php
@@ -1,0 +1,62 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>סופרת לדוגמה</title>
+</head>
+<!-- page header --><?php
+include "header.php";
+?>
+<body dir="rtl">
+
+<table border="0" width="100%" id="table4">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">סופרת לדוגמה</font><font size="4" color="#FF0000"> (1972)</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Example Author</font></td>
+  </tr>
+</table>
+<p class="margin" align="justify">
+ביוגרפיה קצרה של הסופרת לדוגמה. היא נולדה בשנת 1972 וכתבה ספרים רבים.
+</p>
+<table border="0" width="25%" align="left" id="table6">
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+<div>
+  <p>המשך הביוגרפיה אחרי הטבלה הריקה.</p>
+  <table border="0" width="20%" id="table7">
+    <tr>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+</div>
+<table border="1" id="table8">
+  <tr>
+    <td>שנת פרסום</td>
+    <td>1980</td>
+  </tr>
+</table>
+<table border="0" id="table9">
+  <tr>
+    <td><img src="00000_files/portrait.jpg" alt="דיוקן הסופרת"></td>
+  </tr>
+</table>
+<font size="4" color="#0000FF">
+<a name="Books">ספריה:</a></font></p>
+<ul style="MARGIN-TOP: 0in" type="circle">
+  <li>ספר ראשון : שירים (תל אביב : הוצאה לדוגמה, 1980)</li>
+</ul>
+<font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<!-- page footer --><?php
+include "footer.php";
+?>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -138,6 +138,41 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when the bio contains tables with rows and cells but no visible content' do
+    # Regression test for 00458.php and friends: a layout-only <table id="table6"> sits between
+    # the bio paragraphs. Pandoc has no Markdown representation for it, so it used to be emitted
+    # as raw HTML in the middle of the migrated bio.
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'סופרת לדוגמה',
+          fname: 'empty_table_in_bio.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/empty_table_in_bio.php')
+        }
+      )
+    end
+
+    it 'omits the empty tables but keeps the surrounding bio and tables that do show something' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      bio = file.lex_entry.lex_item.bio
+      expect(bio).to include('ביוגרפיה קצרה של הסופרת לדוגמה')
+      expect(bio).to include('המשך הביוגרפיה אחרי הטבלה הריקה')
+
+      # Dropped: standalone empty table, and one nested inside a bio <div> whose cells hold
+      # only non-breaking spaces.
+      expect(bio).not_to include('table6')
+      expect(bio).not_to include('table7')
+
+      # Kept: a table with actual text, and one whose only content is an image.
+      expect(bio).to include('שנת פרסום')
+      expect(bio).to include('/lex/portrait.jpg')
+    end
+  end
+
   context 'when life years are split across font elements in the heading table' do
     # tsifroni.php has "(1915" and "─2011)" in separate <font> elements, so the
     # HTML-regex path fails. The fallback must parse years from the cell's text content.


### PR DESCRIPTION
## Problem

Some legacy PHP lexicon files place a layout-only table between the bio paragraphs — rows and cells, but no visible content. In the current corpus, `00458.php`, `00799.php`, `01982.php` and `03604.php` each carry a `<table id="table6">` whose `<td>`s are all empty.

Pandoc has no Markdown representation for such a table, so with `+raw_html` it emitted the whole thing verbatim into `LexPerson#bio`:

```
ביוגרפיה קצרה של הסופרת לדוגמה...

<table id="table6" data-border="0" width="25%" data-align="left">
<tbody>
<tr>
<td></td>
<td></td>
</tr>
</tbody>
</table>

...המשך הביוגרפיה
```

## Fix

`Lexicon::IngestPerson` now drops content-free tables while collecting the bio elements — both when the table is itself a bio-level sibling and when it is nested inside one.

A table counts as content-free (`Lexicon::HtmlUtils#content_free_table?`) only when it has **no text** *and* contains nothing that renders on its own (`img, hr, iframe, embed, object, video, audio, input`). So a table with actual text, or an image-only table, is left alone. `&nbsp;`-only cells count as empty, since `blank?` treats U+00A0 as whitespace.

The element is copied before pruning, so the parsed document the rest of the ingestion reads (link parsing, `FlagUnmigratedCitations`) is untouched.

## Test plan

- New fixture `spec/fixtures/files/lexicon/empty_table_in_bio.php` covering all four cases: a standalone empty table, an empty (`&nbsp;`-celled) table nested in a bio `<div>`, a table with real text, and an image-only table.
- New example in `spec/services/lexicon/ingest_person_spec.rb`; verified it **fails** on `master` (`expected "...<table id=\"table6\"..." not to include "table6"`) and passes with the fix.
- `bundle exec rspec spec/services/lexicon/ingest_person_spec.rb` → 23 examples, 0 failures.
- RuboCop clean on all changed files (the two remaining offenses in `html_utils.rb` are pre-existing, in `next_element_skipping_blank`, which this PR does not touch).

The full suite has **not** been run — it takes 40+ minutes and needs your go-ahead.

## Note

This only affects bios ingested from now on. The four already-migrated entries would need re-ingestion to be cleaned up; happy to add a backfill if you want one.

Closes by-y08

🤖 Generated with [Claude Code](https://claude.com/claude-code)
