### PR TITLE
Fix lexicon ingestion crash when the links section can't be located (by-w5m)

### DIFF
--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -8,6 +8,15 @@ module Lexicon
     WORKS_HEADER = 'Books'
     CITATIONS_HEADER = 'Bib.'
 
+    # The links section is normally introduced by an <a name="links"> anchor, but a handful of
+    # legacy files spell the anchor differently (e.g. `name="links."`) or omit it entirely and
+    # carry only the Hebrew "קישורים:" heading. Patterns are tried in order, so the anchor always
+    # wins when present.
+    LINKS_SECTION_PATTERNS = [
+      %r{a name="links[^"]*".*?</ul}m,
+      %r{<font[^>]*>\s*קישורים\s*:?\s*</font>.*?</ul}m
+    ].freeze
+
     # Maps 00000_files logo filenames to Hebrew site names for img tags that lack alt text.
     IMG_LOGO_TEXT = {
       'Ben-Yehuda-s.jpg' => 'פרויקט בן יהודה',
@@ -105,8 +114,7 @@ module Lexicon
 
       # Links are parsed only after the authority is known, so that links pointing at this entry's
       # own authority page on benyehuda.org can be skipped (see #redundant_authority_link?).
-      buf = html_doc.to_html
-      parse_person_links(lex_person, buf[%r{a name="links".*?</ul}m])
+      parse_person_links(lex_person, links_section_html(html_doc.to_html))
       lex_person.save!
 
       link_citations_to_works(lex_person)
@@ -153,7 +161,19 @@ module Lexicon
       end
     end
 
+    # Returns the markup of the links section, or nil when the entry has no links section at all.
+    def links_section_html(buf)
+      LINKS_SECTION_PATTERNS.each do |pattern|
+        section = buf[pattern]
+        return section if section.present?
+      end
+      nil
+    end
+
     def parse_person_links(person, buf)
+      # Entries without a links section at all are legitimate; there is simply nothing to migrate.
+      return if buf.blank?
+
       html_entities_coder = HTMLEntities.new
 
       buf.scan(%r{<li>(.*?)</li>}m).map do |x|

--- a/spec/fixtures/files/lexicon/links_anchor_with_dot.php
+++ b/spec/fixtures/files/lexicon/links_anchor_with_dot.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person whose links anchor has a trailing dot</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul>
+  <li>ספר לדוגמה (תל אביב : הוצאה לדוגמה, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links.">קישורים:</a></font>
+<ul>
+  <li><a href="http://www.example.com/story">"סיפור לדוגמה"</a> - סיפור מאת ישראל ישראלי</li>
+  <hr><font size="2">[עודכן לאחרונה: 26VIII2016]</font>
+</ul>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/links_heading_without_anchor.php
+++ b/spec/fixtures/files/lexicon/links_heading_without_anchor.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person whose links section has no anchor</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul>
+  <li>ספר לדוגמה (תל אביב : הוצאה לדוגמה, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF">קישורים:</font><br>
+<ul style="MARGIN-TOP: 0in" type="circle">
+  <li><i><a target="_blank" href="http://www.example.com/blog">הבלוג של ישראל ישראלי</a></i></li>
+  <li><a target="_blank" href="http://www.example.com/articles">מאמרים בספריה הוירטואלית</a></li>
+</ul>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/no_links_section.php
+++ b/spec/fixtures/files/lexicon/no_links_section.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person with no links section at all</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul>
+  <li>ספר לדוגמה (תל אביב : הוצאה לדוגמה, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -192,6 +192,77 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when the links anchor has a trailing dot (name="links.")' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Test Person',
+          fname: 'links_anchor_with_dot.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/links_anchor_with_dot.php')
+        }
+      )
+    end
+
+    it 'still locates the links section and migrates its links' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.links.map(&:url)).to contain_exactly('http://www.example.com/story')
+    end
+  end
+
+  context 'when the links section carries only a Hebrew heading and no anchor' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Test Person',
+          fname: 'links_heading_without_anchor.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/links_heading_without_anchor.php')
+        }
+      )
+    end
+
+    it 'falls back to the heading and migrates its links' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.links.map(&:url)).to contain_exactly(
+        'http://www.example.com/blog',
+        'http://www.example.com/articles'
+      )
+    end
+  end
+
+  context 'when the entry has no links section at all' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Test Person',
+          fname: 'no_links_section.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/no_links_section.php')
+        }
+      )
+    end
+
+    it 'ingests the entry without links instead of raising' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      expect(file.reload).to be_status_ingested
+      person = file.lex_entry.lex_item
+      expect(person.links).to be_empty
+      expect(person.works.count).to eq(1)
+    end
+  end
+
   context 'when both birthdate and deathdate provided', vcr: { cassette_name: 'lexicon/ingest_person/00024' } do
     let(:file) do
       create(


### PR DESCRIPTION
## Problem

Ingesting `lexicon/00429.php` failed completely with:

```
NoMethodError: undefined method `scan' for nil
  app/services/lexicon/ingest_person.rb:159:in `parse_person_links'
  app/services/lexicon/ingest_person.rb:109:in `create_lex_item'
```

`Lexicon::IngestPerson#create_lex_item` located the links section with a single regex and
passed the result straight into `parse_person_links`, which called `.scan` on it:

```ruby
buf = html_doc.to_html
parse_person_links(lex_person, buf[%r{a name="links".*?</ul}m])
```

When the regex matched nothing, the argument was `nil` and the whole entry was lost.

`00429.php` spells its anchor `<a name="links.">` — with a trailing dot. It is the **only**
file in the 4,950-file corpus that does (4,061 use the plain `a name="links"`), so it was
the only one to trip on that particular spelling.

## Fix

* **`parse_person_links` returns early when there is no links section.** Entries that
  genuinely have none are legitimate and should ingest with zero links, not raise.
* **The section is located by an ordered list of patterns** — the anchor first (tolerating
  any suffix after `links`), then the Hebrew `קישורים:` heading as a fallback. The anchor is
  tried first, so the 4,061 files that carry it behave exactly as before.

The heading fallback is included because without it, two more files would ingest *silently
losing their links* once the nil guard is in place.

## Verified against the real corpus

Ran `Lexicon::IngestPerson` (in a rolled-back transaction) over every person entry whose
file lacks a plain `a name="links"` anchor, plus a control that has one:

| file | before | after |
| --- | --- | --- |
| `00429.php` | `nil.scan` crash | ✅ ingests, **1 link** (anchor-with-dot) |
| `03083.php` | crash | ✅ ingests, **3 links** (heading fallback) |
| `00292.php` | crash | ✅ ingests, 0 links (genuinely has none) |
| `00400.php` | crash | ✅ ingests, 0 links (genuinely has none) |
| `00002.php` (control) | ✅ 1 link | ✅ 1 link — unchanged |

Two files still fail, but at **earlier** points in `create_lex_item`, before the links
parsing — pre-existing bugs unrelated to this one, filed separately:

* `01928.php` — `nil.to_html` at `ingest_person.rb:47` (no heading table) → **by-0x4**
* `00457.php` — `RecordInvalid: Citations` at `ingest_person.rb:107` → **by-tdj**
  (its links section *is* now found correctly — 2 links — it just never gets that far)

## Tests

Three new contexts in `spec/services/lexicon/ingest_person_spec.rb`, each with a fixture:

* `links_anchor_with_dot.php` — regression test for `00429.php`; asserts the link is migrated
* `links_heading_without_anchor.php` — asserts the Hebrew-heading fallback migrates both links
* `no_links_section.php` — asserts an entry with no links section ingests instead of raising

```
bundle exec rspec spec/services/lexicon/   →  257 examples, 0 failures
```

RuboCop clean on both changed Ruby files. The full suite was **not** run (40+ min, needs
your approval).

Closes by-w5m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
