### PR TITLE
Refresh the verification view when a new citation is added

### DIFF
--- a/app/views/lexicon/citations/create.js
+++ b/app/views/lexicon/citations/create.js
@@ -1,1 +1,7 @@
-reloadContent($('#citations'));
+if ($('#citations').length) {
+  // Entry-edit view: lazy-reload just the citations section
+  reloadContent($('#citations'));
+} else {
+  // Verification view: the new card belongs in the migrated pane, so reload the page
+  reloadPage();
+}

--- a/spec/system/lexicon/verification_citation_create_spec.rb
+++ b/spec/system/lexicon/verification_citation_create_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Adding a citation from the verification page', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+  let!(:existing_citation) { create(:lex_citation, person: person, title: 'מראה מקום קיים') }
+
+  it 'reloads the verification view so the new citation shows' do
+    visit lexicon_verification_path(entry)
+    expect(page).to have_css("#citation-#{existing_citation.id}")
+
+    click_on I18n.t('lexicon.verification.migrated.add_citation')
+
+    within('#generalDlg') do
+      fill_in 'lex_citation_title', with: 'מראה מקום חדש'
+      fill_in 'lex_citation_from_publication', with: 'כתב עת כלשהו'
+      click_on I18n.t(:save)
+    end
+
+    # The page reloads, so the new card appears in the migrated pane without any manual refresh
+    expect(page).to have_css('.citation-card', text: 'מראה מקום חדש', wait: 10)
+
+    new_citation = person.citations.reload.find_by!(title: 'מראה מקום חדש')
+    expect(page).to have_css("#citation-#{new_citation.id}")
+    expect(page).to have_css("#citation-#{existing_citation.id}")
+  end
+end


### PR DESCRIPTION
## Problem

On the lexicon verification workbench, adding a completely new `LexCitation` via the "add citation" modal saved the record but left the page untouched — the new citation only appeared after a manual refresh.

`app/views/lexicon/citations/create.js` was a single line:

```js
reloadContent($('#citations'));
```

`#citations` is the tab pane on the entry-edit page. The verification view has no such element, and `reloadContent` returns early when the selector matches nothing, so the create response did nothing there.

## Fix

Mirror the branching that `destroy.js` and `update.js.erb` already use: refresh the tab pane when it exists, otherwise reload the page (which preserves both panes' scroll positions via `reloadPage`).

## Tests

- New regression spec `spec/system/lexicon/verification_citation_create_spec.rb`: adds a citation from the verification page and asserts the new card shows up without a manual refresh. Verified it fails against the old `create.js` and passes with the fix.
- Ran `bundle exec rspec spec/system/lexicon/verification_citation_create_spec.rb spec/system/lexicon/verification_citation_delete_spec.rb` → 3 examples, 0 failures.
- The full suite was **not** run (40+ min; needs approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)