### PR TITLE
Recover title-less lexicon citations instead of dropping them

### DIFF
--- a/app/services/lexicon/parse_citations.rb
+++ b/app/services/lexicon/parse_citations.rb
@@ -81,6 +81,18 @@ PROMPT
         subject = subject_works['subject']
         subject_works['works'].each.with_index do |work, index|
           title = sanitize_smart_quotes(work['title'])
+          authors = work['authors'] || []
+
+          # A legacy <li> whose only bold content is a bracketed placeholder standing in for a
+          # missing title (e.g. "<b>[ביקורת].</b> <u>ספרות ילדים ונוער</u>, ...") has nothing at
+          # all in its author slot, so the LLM reads the placeholder as the author and returns a
+          # null title. Promote it back to the title rather than discarding a record that still
+          # carries its subject, publication and pages.
+          if title.blank? && placeholder_author?(authors)
+            title = sanitize_smart_quotes(authors.first['name'])
+            authors = []
+          end
+
           if title.blank?
             Rails.logger.warn("ParseCitations: skipping citation with blank title (subject=#{subject.inspect})")
             next
@@ -97,7 +109,7 @@ PROMPT
             seqno: index + 1
           )
 
-          work['authors'].each do |author|
+          authors.each do |author|
             author = citation.authors.build(name: author['name'], link: author['link'])
             update_link(author)
           end
@@ -117,7 +129,22 @@ PROMPT
       result
     end
 
+    # A bracketed descriptor standing where a title belongs, e.g. "[ביקורת]" (review) or
+    # "[מחבר לא מזוהה]" (unidentified author). Kept with its brackets, matching how the same
+    # placeholder is already stored when the <li> does have an author to precede it.
+    PLACEHOLDER_TITLE = /\A\[.+\]\.?\z/m
+
     private
+
+    # True when the work's single author is a bracketed placeholder rather than a real name.
+    # Only consulted once the title is known to be blank, so a bracketed author accompanying a
+    # genuine title (e.g. "[יעוז, חנה]. שיחה עם...") is never disturbed. An author carrying a
+    # link is a real entry reference and is left alone, since promoting it would lose the link.
+    def placeholder_author?(authors)
+      return false unless authors.size == 1
+
+      authors.first['link'].blank? && authors.first['name'].to_s.strip.match?(PLACEHOLDER_TITLE)
+    end
 
     def update_link(author)
       return if author.link.blank?

--- a/spec/services/lexicon/parse_citations_spec.rb
+++ b/spec/services/lexicon/parse_citations_spec.rb
@@ -443,4 +443,88 @@ describe Lexicon::ParseCitations do
       expect(result.first.title).to eq('כותרת תקינה')
     end
   end
+
+  # Regression: in files such as 00072.php a citation of an untitled review is written with the
+  # placeholder "[ביקורת]" as the <li>'s only bold content and no author at all. The LLM reads
+  # that bold slot as the author and returns a null title, so the record — publication, pages,
+  # subject and all — used to be dropped silently by the blank-title guard.
+  context 'when the LLM reports a bracketed placeholder as the author of a title-less citation' do
+    let(:html) do
+      <<~HTML
+        <font color="#FF0000">על ״רק צרות״</font>
+        <ul style="margin-top:0in" type="circle">
+        <li> <b>[ביקורת].</b> <u>ספרות ילדים ונוער</u>, כרך י״ד, גל' ב' (1988), עמ' 63־64. </li>
+        </ul>
+      HTML
+    end
+
+    let(:works) do
+      [
+        { title: nil, authors: [{ name: '[ביקורת]', link: nil }],
+          from_publication: 'ספרות ילדים ונוער, כרך י״ד, גל\' ב\' (1988)', pages: '63־64',
+          link: nil, backup_url: nil, notes: nil }
+      ]
+    end
+
+    def stub_llm(works)
+      chat_double = instance_double(RubyLLM::Chat)
+      allow(RubyLLM).to receive(:chat).and_return(chat_double)
+      allow(chat_double).to receive_messages(with_instructions: chat_double, with_params: chat_double)
+      allow(chat_double).to receive(:ask).and_return(
+        instance_double(RubyLLM::Message, content: { result: [{ subject: 'רק צרות', works: works }] }.to_json)
+      )
+    end
+
+    it 'keeps the citation, promoting the placeholder to its title' do
+      stub_llm(works)
+
+      expect(result.size).to eq(1)
+      expect(result.first).to have_attributes(
+        subject: 'רק צרות',
+        title: '[ביקורת]',
+        pages: '63־64'
+      )
+    end
+
+    it 'does not leave the placeholder behind as an author' do
+      stub_llm(works)
+
+      expect(result.first.authors).to be_empty
+    end
+
+    it 'produces a citation that passes validation' do
+      stub_llm(works)
+
+      citation = result.first
+      citation.person = build(:lex_person)
+      expect(citation).to be_valid
+    end
+
+    it 'leaves a bracketed author accompanying a real title alone' do
+      stub_llm([works.first.merge(title: 'שיחה עם הסופרת', authors: [{ name: '[יעוז, חנה]', link: nil }])])
+
+      expect(result.first.title).to eq('שיחה עם הסופרת')
+      expect(result.first.authors.map(&:name)).to eq(['[יעוז, חנה]'])
+    end
+
+    it 'still skips a title-less citation whose sole author is a real name' do
+      stub_llm([works.first.merge(authors: [{ name: 'ברגסון, גרשון', link: nil }])])
+
+      expect(result).to be_empty
+    end
+
+    it 'still skips a title-less citation carrying more than one author' do
+      stub_llm([works.first.merge(authors: [{ name: '[ביקורת]', link: nil }, { name: 'ברגסון, גרשון', link: nil }])])
+
+      expect(result).to be_empty
+    end
+
+    # A bracketed author that links to a lexicon entry is a real entry reference, not a
+    # placeholder; promoting its name to the title would throw the link away.
+    it 'still skips a title-less citation whose bracketed author carries a link' do
+      stub_llm([works.first.merge(authors: [{ name: '[סדן, דב]', link: '02402.php' }])])
+
+      expect(result).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## The bug

A legacy `<li>` citing an *untitled* review is written with a bracketed placeholder as its only bold content and **no author at all**:

```html
<li> <b>[ביקורת].</b> <u>ספרות ילדים ונוער</u>, כרך י״ד, גל' ב' (1988), עמ' 63־64. </li>
```

`[ביקורת]` ("review") is a placeholder standing in for the missing *title*. But it sits in the leading `<b>` — the slot where an author name normally lives — so the LLM classifies it as the author and returns a null title. `ParseCitations` then discarded the entire record, subject/publication/pages included, leaving only a `Rails.logger.warn`.

Capturing the raw LLM JSON for `lexicon/00072.php` shows both "missing" citations were in fact returned, intact except for the title:

```
SUBJ "רק צרות" -> 1 works
    title=nil auth=[{"name"=>"[ביקורת]"}] pp="63־64"
SUBJ "אחותי הגדולה מכולם" -> 6 works
    ... title=nil auth=[{"name"=>"[ביקורת]"}] pp="70"
```

The contrast in the same file confirms the mechanism: line 60, `<b>ברגסון, גרשון.</b> [ביקורת]. <u>…`, *has* a real author, so the LLM correctly yields `author=ברגסון` / `title="[ביקורת]"` and migrates fine. Only the author-less form breaks.

## The fix

Recover the placeholder into the title before the blank-title guard runs. `placeholder_author?` requires a single, link-less, bracketed author, and is consulted **only** once the title is already known to be blank — so it structurally cannot disturb bracketed author names that accompany a genuine title (`[יעוז, חנה]. שיחה עם…`, ~25 in the corpus). An author carrying a link is left alone, since promoting its name would throw the link away.

The brackets are kept on the promoted title, matching how the same placeholder is already stored when the `<li>` does have an author to precede it.

## Scope

A scan of every bibliography section in `lexicon/` finds ~10 affected citations across 9 files: `00056`, `00072` (×2), `00308` (×2), `00309`, `00350`, `00372`, `00384`, `01177` — all `[ביקורת]`.

**This fixes the parser only.** Entries already migrated regain their lost citations when their files are re-ingested.

## Test plan

- 6 new examples in `spec/services/lexicon/parse_citations_spec.rb`, driven by the exact LLM JSON captured from `00072.php`: the citation survives with its subject/pages, the placeholder isn't left behind as an author, the result passes `LexCitation` validation (which requires a title), and the three non-triggering shapes — real-name author, multiple authors, bracketed author *with* a link — still skip as before.
- `spec/services/lexicon/` + `spec/models/lex_citation_spec.rb`: **273 examples, 0 failures**.
- RuboCop clean on both changed files.
- Real end-to-end run of `ExtractCitations` against `lexicon/00072.php` (live LLM call): **24 citations from 24 source bullets**, up from 22. Both previously-lost records now carry correct subject, publication and pages; the author-bearing `[ביקורת]` rows are unchanged.

Full suite not run (40+ min) — targeted specs only.

Closes by-0ex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
