### PR TITLE
Extract the English name from all legacy lexicon header variants

### DIFF
--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -5,6 +5,11 @@ module Lexicon
   class IngestBase < ApplicationService
     LAST_UPDATE_LABEL = 'עודכן לאחרונה'
     LAST_UPDATE_RE = /#{LAST_UPDATE_LABEL}:?\s*([^\]\r\n]*)/
+    LATIN_SCRIPT_RE = /\p{Latin}/
+    # Letters only: the Hebrew block also holds geresh and gershayim, which the legacy files use as
+    # apostrophes inside transliterated English names ("Ya׳akov Rabinowitz").
+    HEBREW_LETTER_RE = /[\p{Hebrew}&&\p{L}]/
+    BOM = "\uFEFF"
 
     def call(lex_file)
       @lex_file = lex_file
@@ -63,12 +68,32 @@ module Lexicon
       date.match?(/\d/) ? date : nil
     end
 
-    # Extract English title from the header table
+    # Extract English title from the header table.
+    #
+    # The name lives in a cell of the very first table, next to the Hebrew one, but the legacy
+    # files are wildly inconsistent about how they mark it: font size 4 or 5, red or blue, the
+    # dir="ltr" attribute on the <p>, on the <td> or missing altogether, and the name itself often
+    # broken across nested <span lang="en-us"> elements or an early-closing <font>. So we take the
+    # whole cell's text instead of matching one specific font tag.
+    #
+    # Choosing the cell: prefer the ones explicitly marked ltr, and fall back to every cell when
+    # none is. Among those we take the first written in Latin script and free of Hebrew letters,
+    # which skips the Hebrew title cell and, in the handful of entries that also show the name in
+    # its original script, the Cyrillic/Hungarian cell that precedes the English one.
     def extract_english_title(html_doc)
-      # Look for table cell with dir="ltr" containing the English title
-      # The pattern is: <td><p align="center" dir="ltr"><font size="5" color="#FF0000">English Name</font></td>
-      english_cell = html_doc.at_css('table td p[dir="ltr"] font[size="5"][color="#FF0000"]')
-      english_cell&.text&.squish
+      header_table = html_doc.at_css('table')
+      return nil if header_table.nil?
+
+      cells = header_table.css('td')
+      ltr_cells = cells.select { |cell| cell['dir'] == 'ltr' || cell.at_css('[dir="ltr"]') }
+      english_cell = (ltr_cells.presence || cells).find do |cell|
+        text = cell.text
+        text.match?(LATIN_SCRIPT_RE) && !text.match?(HEBREW_LETTER_RE)
+      end
+      return nil if english_cell.nil?
+
+      # A few files start the cell with a byte order mark, which squish does not consider space.
+      english_cell.text.delete(BOM).squish.presence
     end
 
     # Extract external identifiers from the footer table

--- a/spec/fixtures/files/lexicon/english_title_absent.php
+++ b/spec/fixtures/files/lexicon/english_title_absent.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="4" color="#FF0000">סביונה מאנה</td>
+    <td><p align="center" dir="ltr"><font size="4" color="#FF0000">&nbsp;</font></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_after_cyrillic.php
+++ b/spec/fixtures/files/lexicon/english_title_after_cyrillic.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">שמעון שמואל פרוג</font></td>
+    <td><p align="center" dir="ltr"><font size="4" color="#FF0000">Семён Григорьевич Фруг</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Shimen Shmuel Frug</font></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_after_unmarked_original.php
+++ b/spec/fixtures/files/lexicon/english_title_after_unmarked_original.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">חנה סנש</font></td>
+    <td><p align="center"><font size="4" color="#FF0000">Szenes Anikó</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Hannah Senesh</font></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_dir_on_cell.php
+++ b/spec/fixtures/files/lexicon/english_title_dir_on_cell.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td align="center"><font size="5" color="#FF0000">אילנה אביאל</font><font size="4" color="#FF0000"> (1925)</td>
+    <td align="center" dir="ltr"><font size="5" color="#FF0000">Ilana Aviel</font><font size="4" color="#FF0000"> </font></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_font_size_4.php
+++ b/spec/fixtures/files/lexicon/english_title_font_size_4.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="4" color="#FF0000">צבי ארזי (1915–1994)</font></td>
+    <td><p align="center" dir="ltr"><font size="4" color="#FF0000">Zvi Arzi</font></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_split_across_spans.php
+++ b/spec/fixtures/files/lexicon/english_title_split_across_spans.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">יוחנן טברסקי</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">J</font><span lang="en-us">ochanan
+      Twersky</span></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_with_geresh.php
+++ b/spec/fixtures/files/lexicon/english_title_with_geresh.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">יעקב רבינוביץ</font></td>
+    <td><p align="center" dir="ltr"><font size="4" color="#FF0000">Ya׳akov Rabinowitz</font></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/english_title_without_dir.php
+++ b/spec/fixtures/files/lexicon/english_title_without_dir.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person english title</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">מלכה שקד</font><font size="4" color="#FF0000"> (1933)</font></p></td>
+    <td><p align="center"><span lang="en-us"><font size="5" color="#FF0000">Malka Shaked</font></span></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -621,6 +621,85 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  describe 'English title extraction' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'ישראלי, ישראל',
+          fname: fixture,
+          full_path: Rails.root.join('spec/fixtures/files/lexicon', fixture)
+        }
+      )
+    end
+
+    context 'when the header uses font size 4 rather than 5' do
+      let(:fixture) { 'english_title_font_size_4.php' }
+
+      it 'extracts the English name' do
+        expect(call.english_title).to eq('Zvi Arzi')
+      end
+    end
+
+    context 'when the name is split across a nested span' do
+      let(:fixture) { 'english_title_split_across_spans.php' }
+
+      it 'extracts the whole name rather than the first fragment' do
+        expect(call.english_title).to eq('Jochanan Twersky')
+      end
+    end
+
+    context 'when dir="ltr" sits on the cell rather than the paragraph' do
+      let(:fixture) { 'english_title_dir_on_cell.php' }
+
+      it 'extracts the English name' do
+        expect(call.english_title).to eq('Ilana Aviel')
+      end
+    end
+
+    context 'when the header carries no dir attribute at all' do
+      let(:fixture) { 'english_title_without_dir.php' }
+
+      it 'falls back to the cell written in Latin script' do
+        expect(call.english_title).to eq('Malka Shaked')
+      end
+    end
+
+    context 'when the name also appears in its original, non-Latin script' do
+      let(:fixture) { 'english_title_after_cyrillic.php' }
+
+      it 'skips the Cyrillic cell and takes the Latin one' do
+        expect(call.english_title).to eq('Shimen Shmuel Frug')
+      end
+    end
+
+    context 'when an unmarked Latin-script original name precedes the English one' do
+      let(:fixture) { 'english_title_after_unmarked_original.php' }
+
+      it 'prefers the cell explicitly marked ltr' do
+        expect(call.english_title).to eq('Hannah Senesh')
+      end
+    end
+
+    context 'when the transliteration uses a geresh as an apostrophe' do
+      let(:fixture) { 'english_title_with_geresh.php' }
+
+      it 'does not mistake the geresh for a Hebrew letter' do
+        expect(call.english_title).to eq('Ya׳akov Rabinowitz')
+      end
+    end
+
+    context 'when the header cell holds no English name' do
+      let(:fixture) { 'english_title_absent.php' }
+
+      it 'leaves the English title blank' do
+        expect(call.english_title).to be_nil
+      end
+    end
+  end
+
   describe 'flagging a bibliography that produced no citations' do
     let!(:file) do
       create(


### PR DESCRIPTION
## Problem

`Lexicon::IngestBase#extract_english_title` matched exactly one markup shape:

```ruby
html_doc.at_css('table td p[dir="ltr"] font[size="5"][color="#FF0000"]')
```

The legacy files are much less consistent than that. Measured across all 4,950 files in `lexicon/`, **767 entries lost their English name entirely** and another **26 kept only a truncated fragment** — e.g. `"J"` instead of `"Jochanan Twersky"`, `"Katzetnik"` instead of `"Katzetnik 135633"`, because the `<font>` tag closes before the name ends.

The reported case, `lexicon/00062.php` (Zvi Arzi), is the most common variant: `size="4"` instead of `size="5"` (459 files).

Variants found in the corpus:

| Variant | Example | Count |
| --- | --- | --- |
| `font size="4"` | `00062.php` | 459 |
| `dir="ltr"` on the `<td>`, not the `<p>` | `00213.php` | — |
| no `dir` attribute anywhere in the header | `00093.php` | — |
| name split across `<span lang="en-us">` / early-closing `<font>` | `01277.php` | — |
| name also given in its original script (Cyrillic/Hungarian) | `02530.php`, `01385.php` | 6 |

## Fix

Take the whole header cell's text rather than matching one specific font tag, and choose the cell by direction and script:

1. Prefer cells explicitly marked `ltr` (on the `td` or anything inside it); fall back to all cells in the header table when none is marked.
2. Among those, take the first written in Latin script and free of Hebrew letters.

Step 2 skips the Hebrew title cell, and for the handful of entries that also show the name in its original script, skips the Cyrillic/Hungarian cell preceding the English one. Step 1 is what keeps `01385.php` on `Hannah Senesh` rather than `Szenes Anikó`.

Hebrew letters are tested with `[\p{Hebrew}&&\p{L}]` rather than `\p{Hebrew}`: the Hebrew block also contains geresh (`׳`) and gershayim (`״`), which these files use as apostrophes inside transliterated English names (`Ya׳akov Rabinowitz`). Using the bare block dropped 24 such names.

## Impact, measured over all 4,950 legacy files

Ran the committed method against every file and diffed against the old selector:

```
GAINED=767   LOST=0   CHANGED=26   still nil=37
```

- **767** names recovered.
- **0** lost — the new rule is a strict superset on everything the old one handled.
- **26** changed, all repairs of truncation or original-script cells:
  - `"J"` → `"Jochanan Twersky"`, `"Y"` → `"Yehiel Haggis"`, `"Judah"` → `"Judah Marschak"`
  - `"Katzetnik"` → `"Katzetnik 135633"`, `"Ephraim Tabor"` → `"Ephraim Tabory"`
  - `"Цви Прейгерзон"` → `"Zvi Preigerzon"`, `"Элишева"` → `"Elisheva"`
  - `"ha-"` → `"ha-Levanon"`, `"Ot"` → `"Ot : a journal of literary criticism and theory"`
- **37** still yield nothing; I checked these individually and they have no English name in the source — an empty cell, a bare `&nbsp;`, a `<בהכנה>` placeholder, or a header that is entirely commented out.

## Test plan

Eight new fixtures under `spec/fixtures/files/lexicon/`, one per markup variant found in the corpus, driven through `Lexicon::IngestPerson` following the existing `bracketed_date.php` pattern:

- `english_title_font_size_4.php` — the reported bug
- `english_title_split_across_spans.php` — truncation at an early `</font>`
- `english_title_dir_on_cell.php` — `dir` on the `<td>`
- `english_title_without_dir.php` — no `dir` at all
- `english_title_after_cyrillic.php` — Cyrillic cell also marked ltr
- `english_title_after_unmarked_original.php` — ltr preference over an unmarked Latin cell
- `english_title_with_geresh.php` — geresh-as-apostrophe regression guard
- `english_title_absent.php` — genuinely empty header cell yields `nil`

Ran:

```
bundle exec rspec spec/services/lexicon/     # 266 examples, 0 failures
bundle exec rubocop app/services/lexicon/ingest_base.rb spec/services/lexicon/ingest_person_spec.rb  # no offenses
```

`spec/services/lexicon/` covers both callers of the changed method (`ingest_person_spec.rb`, `ingest_publication_spec.rb`); they are the only specs in the repo that touch ingestion or `english_title`. **The full suite was not run** — it takes over 40 minutes and needs your go-ahead.

## Note

Existing entries already ingested with a missing or truncated `english_title` are not corrected by this change; they would need re-ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
