### PR TITLE
Link a lexicon work's title to its associated Collection

### DIFF
--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -39,12 +39,15 @@ module LexiconHelper
   end
 
   # Renders a work title, applying hyperlinks from title_links if present.
-  # When the work has a lex_publication, the whole title links to that publication and
-  # title_links are not applied (nested anchors are invalid HTML).
+  # When the work has a BY Collection or a lex_publication, the whole title links there and
+  # title_links are not applied (nested anchors are invalid HTML). A Collection takes
+  # precedence: it is the actual text on the main site.
   # Returns a plain String (possibly containing HTML) so that render_person_work can
   # safely concatenate further HTML before calling raw() at the end.
   def render_person_work_title(work)
-    if work.lex_publication.present?
+    if work.collection.present?
+      link_to(work.title, collection_path(work.collection))
+    elsif work.lex_publication.present?
       entry = work.lex_publication.entry
       link_to(entry.title, lexicon_entry_path(entry))
     elsif work.title_links.is_a?(Array) && work.title_links.present?

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -174,6 +174,32 @@ RSpec.describe LexiconHelper, type: :helper do
         expect(result).to include('כותרת הפרסום')
       end
     end
+
+    context 'when a collection is present' do
+      let(:collection) { create(:collection, title: 'כרך מקוון') }
+
+      before { work.collection = collection }
+
+      it 'links the work title to the collection' do
+        result = helper.render_person_work_title(work)
+        expect(result).to include(collection_path(collection))
+        expect(result).to include('ספר זכרון לאפרת דנון')
+      end
+
+      it 'takes precedence over title_links' do
+        work.title_links = [{ 'text' => 'אפרת דנון', 'entry_id' => 999 }]
+        result = helper.render_person_work_title(work)
+        expect(result).to include(collection_path(collection))
+        expect(Nokogiri::HTML.fragment(result).css('a').size).to eq(1)
+      end
+
+      it 'takes precedence over lex_publication' do
+        work.lex_publication = create(:lex_entry, :publication, title: 'כותרת הפרסום').lex_item
+        result = helper.render_person_work_title(work)
+        expect(result).to include(collection_path(collection))
+        expect(result).not_to include('כותרת הפרסום')
+      end
+    end
   end
 
   describe '#render_person_work' do

--- a/spec/requests/lexicon/entries_spec.rb
+++ b/spec/requests/lexicon/entries_spec.rb
@@ -137,6 +137,18 @@ describe '/lexicon/entries' do
 
         it { is_expected.to eq(200) }
       end
+
+      context 'when a work is associated with a collection' do
+        let(:collection) { create(:collection, title: 'כרך מקוון') }
+        let!(:work) do
+          create(:lex_person_work, person: entry.lex_item, title: 'ספר הזכרונות', collection: collection)
+        end
+
+        it 'links the work title to the collection' do
+          expect(call).to eq(200)
+          expect(response.body).to include(%(<a href="#{collection_path(collection)}">ספר הזכרונות</a>))
+        end
+      end
     end
 
     context 'when entry is a Publication' do


### PR DESCRIPTION
## What

In the works section of `LexEntry#show`, a work that is associated with a BY `Collection` now renders its title as a link to that collection's page.

Implemented in `render_person_work_title` (app/helpers/lexicon_helper.rb), so the same linking also applies wherever that helper is used: the verification workbench works section, the author page's generated ToC, and the person-works index.

## Precedence assumption

A `Collection` wins over both `lex_publication` and `title_links` — it points at the actual digitized text on the main site, and nested anchors would be invalid HTML. If you'd rather the lexicon publication entry win when both are set, say so and I'll flip the order.

## Tests

- `spec/helpers/lexicon_helper_spec.rb` — collection link, precedence over `title_links` (single anchor), precedence over `lex_publication`
- `spec/requests/lexicon/entries_spec.rb` — end-to-end: the entry show page emits `<a href="/collections/:id">work title</a>`

Ran: `spec/helpers/lexicon_helper_spec.rb`, `spec/requests/lexicon/entries_spec.rb`, `spec/requests/lexicon/person_works_spec.rb`, `spec/system/lexicon/person_work_title_links_spec.rb`, `spec/system/lexicon/verification_works_modal_spec.rb` — all green (72 examples, 0 failures). RuboCop clean on changed files (only pre-existing offenses elsewhere in the entries spec). The full suite was **not** run.

Closes by-9z1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
