### PR TITLE
Give the readmode mobile alignment example a page to measure (by-b9y)

### DIFF
--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module SystemSpecHelpers
+  # Resize the browser window. Note that the :narrow_viewport tag only picks the Chrome driver
+  # (headless Firefox will not go below 500px wide) -- it does NOT resize anything, and the
+  # before hook in spec/support/capybara.rb sizes every `:js, type: :system` spec to 1400x900.
+  # A spec asserting mobile layout therefore has to call this itself.
+  def resize_window(width, height)
+    page.driver.browser.manage.window.resize_to(width, height)
+  end
+
   # Check if WebDriver is available and configured for system specs with JavaScript
   def webdriver_available?
     return false unless defined?(Capybara::Selenium)

--- a/spec/system/readmode_icon_alignment_spec.rb
+++ b/spec/system/readmode_icon_alignment_spec.rb
@@ -35,14 +35,20 @@ describe 'Reading mode icon alignment', :js do
   end
 
   it 'centres the glyph in the desktop reading-mode button' do
-    page.driver.browser.manage.window.resize_to(1400, 900)
+    resize_window(1400, 900)
     visit manifestation_path(manifestation)
 
     expect(page).to have_css('.reading-mode-btn-v02')
     expect(icon_offset_from_button_centre('.reading-mode-btn-v02').abs).to be < 1.5
   end
 
-it 'centres the glyph in the mobile reading-mode icon button', :narrow_viewport do
+  # The mobile button only exists below the 991px breakpoint -- above it the whole
+  # .chapters-and-icons-mobile container is display:none, so this has to narrow the window
+  # before visiting. :narrow_viewport buys the Chrome driver, which is the only one that will
+  # size below 500px; it does not do the resizing.
+  it 'centres the glyph in the mobile reading-mode icon button', :narrow_viewport do
+    resize_window(390, 844)
+    visit manifestation_path(manifestation)
 
     expect(page).to have_css('.reading-mode-icon-btn-v02')
     expect(icon_offset_from_button_centre('.reading-mode-icon-btn-v02').abs).to be < 1.5

--- a/spec/system/tag_proposal_mobile_spec.rb
+++ b/spec/system/tag_proposal_mobile_spec.rb
@@ -45,10 +45,6 @@ RSpec.describe 'Tag proposal popup on mobile', :js, :narrow_viewport, type: :sys
     resize_window(1400, 1400)
   end
 
-  def resize_window(width, height)
-    page.driver.browser.manage.window.resize_to(width, height)
-  end
-
   def open_tag_popup
     find('#initiate-add-tag').click
     expect(page).to have_css('#add_tagging_tabs > ul > li', count: 2, wait: 5)


### PR DESCRIPTION
## What's wrong

`spec/system/readmode_icon_alignment_spec.rb:45` fails locally:

```
1) Reading mode icon alignment centres the glyph in the mobile reading-mode icon button
   Failure/Error: expect(page).to have_css('.reading-mode-icon-btn-v02')
     expected to find css ".reading-mode-icon-btn-v02" but there were no matches
```

The example had no `visit` and no resize — it was measuring `about:blank`:

```ruby
it 'centres the glyph in the mobile reading-mode icon button', :narrow_viewport do

    expect(page).to have_css('.reading-mode-icon-btn-v02')
```

Two things went wrong at once:

1. **No `visit`.** The blank line where the setup should be, and the example's odd indentation (it starts at column 0), suggest the body was lost rather than never written.
2. **`:narrow_viewport` does less than the example assumed.** It only selects the Chrome driver, because headless Firefox refuses to size below 500px (`spec/support/capybara.rb:14`). It does **not** resize. Meanwhile the global `before` hook sizes every `:js` system spec to 1400×900 — so even with a `visit`, the assertion would still have failed: `.chapters-and-icons-mobile` is `display: none` above the 991px breakpoint (`BY_styles_Max991.css:703`).

## Why nobody noticed

Not an app regression — this has been broken since it was merged in e216e13a0 (#1582). CI never ran it: `.github/workflows/rspec.yml:49` excludes system specs wholesale.

```
bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"
```

So the file only fails for people running system specs locally.

## The fix

Resize to 390×844 (the phone viewport `tag_proposal_mobile_spec` already uses) and visit the work page. Fixed the indentation and documented what `:narrow_viewport` does and doesn't do, so the next spec doesn't repeat the assumption.

Also promotes the file-local `resize_window` helper out of `tag_proposal_mobile_spec.rb` into `spec/support/system_spec_helpers.rb`, per `.claude/rules/reuse-existing-helpers.md`, now that a second spec needs it. The desktop example's inline `page.driver.browser.manage.window.resize_to(...)` now goes through it too.

## Verification

The restored example is load-bearing, not vacuously green. With the `line-height: 26px` rule from `application.scss:1345` removed, it fails the way it should:

```
2) ...centres the glyph in the mobile reading-mode icon button
   expected: < 1.5
        got:   4
```

(4px low — exactly the "glyph rides to the top of the purple background" symptom the by-l0f fix addressed.) CSS restored afterwards; `git diff` on `application.scss` is empty.

| Suite | Result |
| --- | --- |
| `spec/system/readmode_icon_alignment_spec.rb` | 2 examples, 0 failures |
| `spec/system/tag_proposal_mobile_spec.rb` (refactored helper) | 26 examples, 0 failures |

RuboCop: no new offenses (the 3 in `system_spec_helpers.rb` are pre-existing in `webdriver_available?`, confirmed against master).

## Scope

This PR touches only `spec/system/readmode_icon_alignment_spec.rb`, `spec/system/tag_proposal_mobile_spec.rb` and `spec/support/system_spec_helpers.rb`. It was briefly mis-based off the `fix/lexlink-description-html-entities` branch, which pulled an unrelated `html2txt` commit into the diff; that has been rebased away and lives in #1612. The two PRs are independent.

## Worth a separate decision

System specs are excluded from CI entirely, which is how a spec that never ran got merged. That's outside this fix, but it means any `spec/system/` regression is invisible until someone runs it by hand. Happy to open a bead if you want that looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

