### PR TITLE
Promote a deleted sub-collection's items into its containing collections

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -585,13 +585,6 @@ class Collection < ApplicationRecord
     end
   end
 
-  def before_destroy
-    collection_items.each do |ci|
-      ci.destroy!
-    end
-    CollectionItem.where(item: self).each { |ci| ci.destroy! } # destroy all references to this collection
-  end
-
   def collection_items_by_role(role, authority_id)
     collection_items.select do |ci|
       ci.item.present? && ci.item.involved_authorities_by_role(role).any? do |a|

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -16,6 +16,12 @@ class Collection < ApplicationRecord
   before_save :update_alternate_titles, if: :title_changed?
   before_save :clear_cached_credits, if: :credits_changed?
 
+  # A collection contained in other collections is not simply deleted out from under them: its items are first
+  # promoted into each containing collection, in their original order, starting at the position the deleted
+  # collection occupied there. `prepend: true` is essential -- this has to run before the `dependent: :destroy`
+  # on :collection_items (registered when that association is declared, below) destroys those items.
+  before_destroy :promote_items_to_parent_collections, prepend: true
+
   validates :collection_type, presence: true
 
   belongs_to :publication, optional: true
@@ -720,6 +726,40 @@ class Collection < ApplicationRecord
   end
 
   protected
+
+  # see the `before_destroy :promote_items_to_parent_collections` declaration at the top of this class
+  def promote_items_to_parent_collections
+    items = collection_items.to_a
+    return if items.empty?
+
+    links = parent_collection_items.includes(:collection).to_a
+    return if links.empty?
+
+    # this collection may be included in several collections; the original items are moved into the first of
+    # those, and each of the others gets copies, so every containing collection goes on showing them
+    links.drop(1).each do |link|
+      parent = link.collection
+      make_room_for_promoted_items(link, items.size)
+      items.each_with_index do |ci, i|
+        parent.append_collection_item(parent.collection_item_from_anything(ci), link.seqno + i)
+      end
+    end
+
+    first_link = links.first
+    make_room_for_promoted_items(first_link, items.size)
+    items.each_with_index { |ci, i| ci.update!(collection: first_link.collection, seqno: first_link.seqno + i) }
+    collection_items.reset # they are no longer ours, so the `dependent: :destroy` below must not find them
+  end
+
+  # the promoted items take over the single slot the deleted collection occupied in the containing collection,
+  # so whatever followed that slot moves down to make room for the rest of them
+  def make_room_for_promoted_items(link, count)
+    return if count < 2
+
+    CollectionItem.where(collection_id: link.collection_id)
+                  .where(seqno: (link.seqno + 1)..)
+                  .update_all(['seqno = seqno + ?', count - 1])
+  end
 
   def collection_item_from_anything(item)
     # if a string, just create a wrapper item with the string as the alt_title

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -8,6 +8,15 @@ class CollectionItem < ApplicationRecord
   validates :seqno, presence: true
   validate :ensure_no_cycle
 
+  # CollectionsIndex indexes items_count as a count of these rows, so every operation that changes it --
+  # adding an item, removing one, or moving one between collections -- has to reindex the collection(s)
+  # involved; a move touches both the collection the item left and the one it joined.
+  update_index('collections') do
+    ids = [collection_id]
+    ids << collection_id_before_last_save if saved_change_to_collection_id?
+    ids.compact.uniq
+  end
+
   # Update manifestations count when collection items are added, removed, or changed
   after_create :update_collection_manifestations_count
   after_destroy :update_collection_manifestations_count

--- a/spec/models/collection_item_spec.rb
+++ b/spec/models/collection_item_spec.rb
@@ -55,6 +55,34 @@ describe CollectionItem do
     end
   end
 
+  describe 'keeping CollectionsIndex#items_count up to date' do
+    let(:collection) { create(:collection, collection_type: :volume) }
+    let(:other_collection) { create(:collection, collection_type: :volume) }
+    let(:manifestation) { create(:manifestation) }
+
+    it 'reindexes the collection when an item is added to it' do
+      collection
+      manifestation
+      expect { collection.append_item(manifestation) }
+        .to update_index(CollectionsIndex).and_reindex(collection, with: { items_count: 1 })
+    end
+
+    it 'reindexes the collection when an item is removed from it' do
+      collection_item = create(:collection_item, collection: collection, item: manifestation)
+      expect { collection_item.destroy! }
+        .to update_index(CollectionsIndex).and_reindex(collection, with: { items_count: 0 })
+    end
+
+    it 'reindexes both collections when an item is moved from one to another' do
+      collection_item = create(:collection_item, collection: collection, item: manifestation)
+      other_collection
+      expect { collection_item.update!(collection: other_collection) }
+        .to update_index(CollectionsIndex)
+        .and_reindex(collection, with: { items_count: 0 })
+        .and_reindex(other_collection, with: { items_count: 1 })
+    end
+  end
+
   describe '#to_html' do
     context 'when item is present' do
       let(:collection_item) { build(:collection_item, item: manifestation) }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1200,4 +1200,68 @@ expect(html).to include("by-icon-v02\" title=\"#{expected_genre_title}\">t</span
       end
     end
   end
+
+  describe 'destroying a collection' do
+    let(:first_manifestation) { create(:manifestation) }
+    let(:second_manifestation) { create(:manifestation) }
+    let(:sub) do
+      create(:collection, collection_type: :series, manifestations: [first_manifestation, second_manifestation],
+                          title_placeholders: ['ניר'])
+    end
+    let(:before_sub) { create(:manifestation) }
+    let(:after_sub) { create(:manifestation) }
+    let(:parent) do
+      create(:collection, collection_type: :volume).tap do |collection|
+        collection.append_item(before_sub)
+        collection.append_item(sub)
+        collection.append_item(after_sub)
+      end
+    end
+
+    context 'when it is contained in another collection' do
+      before { parent }
+
+      it 'promotes its items into the containing collection, in place of the deleted collection' do
+        promoted = sub.collection_items.to_a
+        expect { sub.destroy! }.to change(described_class, :count).by(-1)
+
+        items = parent.collection_items.reload
+        expect(items.map(&:item)).to eq [before_sub, first_manifestation, second_manifestation, nil, after_sub]
+        expect(items.map(&:alt_title)).to eq [nil, nil, nil, 'ניר', nil]
+        expect(items.map(&:seqno)).to eq items.map(&:seqno).sort.uniq
+        # the very same items were moved, not re-created
+        expect(promoted.map { |ci| ci.reload.collection }).to all(eq(parent))
+      end
+
+      it 'keeps the containing collection manifestations_count intact' do
+        expect { sub.destroy! }.not_to(change { parent.reload.manifestations_count })
+      end
+    end
+
+    context 'when it is contained in more than one collection' do
+      let(:other_parent) { create(:collection, collection_type: :volume) }
+
+      before do
+        parent
+        other_parent.append_item(sub)
+      end
+
+      it 'promotes the items into every containing collection' do
+        sub.destroy!
+
+        expect(parent.collection_items.reload.map(&:item))
+          .to eq [before_sub, first_manifestation, second_manifestation, nil, after_sub]
+        expect(other_parent.collection_items.reload.map(&:item))
+          .to eq [first_manifestation, second_manifestation, nil]
+        expect(other_parent.collection_items.map(&:alt_title)).to eq [nil, nil, 'ניר']
+      end
+    end
+
+    context 'when it is not contained in any collection' do
+      it 'destroys its items' do
+        sub
+        expect { sub.destroy! }.to change(CollectionItem, :count).by(-3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Collection has_many :collection_items, dependent: :destroy`, so deleting a collection that was itself
contained in another collection destroyed all of its items. From the containing collection's point of
view a whole stretch of its table of contents simply vanished — the texts were not returned to it, they
were gone.

## Fix

A `before_destroy :promote_items_to_parent_collections, prepend: true` callback on `Collection` re-parents
the items first:

- they keep their original order and start at the `seqno` the deleted collection occupied in the
  containing collection, so that ToC reads exactly as before with the sub-collection flattened away;
- items that followed that slot shift down to make room for the rest of them;
- a collection can be included in several collections: the originals are moved into the first one and
  each of the others gets copies (built through the existing `collection_item_from_anything` /
  `append_collection_item` helpers), so every containing collection goes on showing them;
- a collection that is not contained anywhere is unaffected — its items are destroyed as before.

`prepend: true` matters: the callback has to run before the one `dependent: :destroy` registers.

The containing collection's `manifestations_count` stays correct: it already counted these
manifestations through the sub-collection, and it is recalculated when the link row is destroyed.

## Also in this PR

**`CollectionsIndex#items_count` no longer goes stale.** It indexes a count of `CollectionItem` rows, but
only `Collection` had an `update_index`, so nothing reindexed a collection when its items changed — the
count was wrong after every add, removal or move, promotion included. `CollectionItem` now carries an
`update_index('collections')` covering all three operations; a move reindexes both the collection the item
left and the one it joined.

**Removed the dead `Collection#before_destroy`.** It was a plain instance method, not a registered
callback, so Rails never called it; it duplicated what the `dependent: :destroy` associations already do,
and it read as if it competed with the real callback added here.

## Tests

- `spec/models/collection_spec.rb`, `describe 'destroying a collection'`: promotion into the containing
  collection (order, position, placeholders, and that the very same rows are moved rather than
  re-created), an unchanged `manifestations_count`, promotion into several containing collections, and
  the untouched standalone case.
- `spec/models/collection_item_spec.rb`, `describe 'keeping CollectionsIndex#items_count up to date'`:
  uses chewy's `update_index` matcher to assert the indexed `items_count` on add, on removal, and on both
  collections involved in a move.

Confirmed all six new behavioural examples fail without their respective change.

```
bundle exec rspec spec/models/collection_spec.rb spec/models/collection_item_spec.rb \
  spec/services/search_collections_spec.rb spec/controllers/collections_controller_spec.rb
# 214 examples, 0 failures, 1 pending (pre-existing)

bundle exec rspec spec/services/search_manifestations_spec.rb spec/controllers/search_controller_spec.rb \
  spec/requests/periodicals_spec.rb spec/requests/collection_show_ip_status_spec.rb \
  spec/requests/collections_browse_authorities_filter_spec.rb spec/requests/collections_browse_spec.rb \
  spec/services/elasticsearch_autocomplete_spec.rb spec/controllers/authors_controller_spec.rb
# 201 examples, 0 failures   (the Elasticsearch-backed specs, to catch indexing fallout)
```

RuboCop on all changed files adds no new offenses. The full suite was **not** run — it takes 40+ minutes
and needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
