### PR TITLE
Fix PROFILE=1 development mode: drop the uglifier js_compressor

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -95,7 +95,8 @@ Rails.application.configure do
       'Cache-Control' => 'max-age=315360000, public',
       'Expires' => 'Thu, 31 Dec 2037 23:55:55 GMT'
     }
-    config.assets.js_compressor = :uglifier
+    # NOTE: no js_compressor is set, matching production (production.rb sets none).
+    # Uglifier cannot parse the ES6 in our assets and 500s every request under PROFILE.
     config.assets.css_compressor = :sass
     config.assets.compile = true
     config.assets.digest = true


### PR DESCRIPTION
## Problem

`config/environments/development.rb` has an `ENV['PROFILE']` block (lines 86-107) that flips
`cache_classes` and `eager_load` on, so that `derailed_benchmarks` can be run against a
production-like boot of the development environment.

That mode was unusable. Line 98 set `config.assets.js_compressor = :uglifier`, and Uglifier
cannot parse the ES6 in our assets, so **every** request under `PROFILE=1` returned a 500:

```
ActionView::Template::Error (Unexpected token: keyword (const).
To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
Caused by: Uglifier::Error
  sprockets (4.2.2) lib/sprockets/uglifier_compressor.rb:58:in `call'
```

## Fix

Remove the line. `js_compressor` is set nowhere else in the app — `production.rb` sets none —
so dropping it makes `PROFILE` mode *match* production rather than diverge from it. The
`css_compressor = :sass` line is left alone; it works fine.

## Test plan

This is a development-environment-only config change. The test environment never loads
`config/environments/development.rb`, so there is no meaningful RSpec test to add, and I did
not invent one. Verified by running the tool it exists to serve:

```bash
RAILS_ENV=development PROFILE=1 DERAILED_SKIP_ACTIVE_RECORD=1 \
HTTP_HOST=localhost TEST_COUNT=40 PATH_TO_HIT=/ \
bundle exec derailed exec perf:mem_over_time
```

**Before:** 500 on every request (Uglifier::Error).
**After:** 40/40 requests `200 OK`, and a usable memory curve that plateaus as it should:

```
257.36
423.33
432.34
435.00
```

Also ran `bundle exec rspec spec/models/work_spec.rb` (1 example, 0 failures) to confirm the
test-env boot is unaffected. The full suite was **not** run — it takes 40+ minutes and this
change cannot reach the test environment.

RuboCop: `config/environments/*` is excluded in `.rubocop.yml`; `rubocop --force-exclusion`
reports `0 files inspected`. Forcing an inspection shows 9 pre-existing offenses at lines
1/20/24/25/50/90, none at the lines touched here. Left alone per scope.

## Follow-up not done here

With this line gone, the `uglifier` gem has no remaining `js_compressor` reference in the app.
It may now be dead weight in the `Gemfile` (it's a boot-time cost in every Puma worker), but
removing a gem is out of scope for this fix and wants its own check.

Closes by-axt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
