### PR TITLE
Move the delete button to the far edge of verification citation and link cards

### DIFF
--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -455,6 +455,15 @@ body:has(.verification-container) {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
+
+    // Keep the destructive delete button away from edit/verify: those stay packed at the
+    // start of the row, delete is pushed to the opposite edge of the card.
+    // These rows always run left-to-right (the [dir="rtl"] block below sets row-reverse),
+    // so the main-start side is the physical left in both directions, and an auto margin
+    // there absorbs the free space, sending delete to the right edge.
+    .delete-citation, .delete-link {
+      margin-left: auto;
+    }
   }
 }
 

--- a/spec/system/lexicon/verification_delete_button_placement_spec.rb
+++ b/spec/system/lexicon/verification_delete_button_placement_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The destructive delete button used to sit right next to edit/verify, making a
+# mis-click easy. It is now pushed to the opposite edge of the card while the
+# other actions stay packed at the start of the row.
+RSpec.describe 'Delete button placement in verification cards', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+  let!(:citation) { create(:lex_citation, person: person, title: 'A cited work') }
+  let!(:link) { create(:lex_link, item: person, url: 'https://example.com/somewhere') }
+
+  # Horizontal geometry of a card's action row, in viewport pixels.
+  def action_row_geometry(card_selector, delete_selector)
+    page.evaluate_script(<<~JS)
+      (function() {
+        var card = document.querySelector('#{card_selector}');
+        var actions = card.querySelector('.citation-actions, .link-actions');
+        var del = card.querySelector('#{delete_selector}');
+        var others = Array.prototype.filter.call(
+          actions.children, function(el) { return el !== del; }
+        );
+        var rects = others.map(function(el) { return el.getBoundingClientRect(); });
+        return {
+          actions_left: actions.getBoundingClientRect().left,
+          actions_right: actions.getBoundingClientRect().right,
+          delete_left: del.getBoundingClientRect().left,
+          delete_right: del.getBoundingClientRect().right,
+          others_left: Math.min.apply(null, rects.map(function(r) { return r.left; })),
+          others_right: Math.max.apply(null, rects.map(function(r) { return r.right; })),
+          others_count: others.length
+        };
+      })()
+    JS
+  end
+
+  shared_examples 'a card with the delete button on the far side' do |card_selector, delete_selector|
+    it 'keeps edit/verify on the left and pushes delete to the right' do
+      visit lexicon_verification_path(entry)
+      expect(page).to have_css("#{card_selector} #{delete_selector}", wait: 5)
+
+      geo = action_row_geometry(card_selector, delete_selector)
+
+      # Sanity: the row really does hold the other actions besides delete.
+      expect(geo['others_count']).to be >= 2
+
+      # The non-destructive actions hug the left edge of the row...
+      expect(geo['others_left'] - geo['actions_left']).to be < 2
+
+      # ...while delete hugs the right edge...
+      expect(geo['actions_right'] - geo['delete_right']).to be < 2
+
+      # ...with real separation between the two groups, not the 0.5rem flex gap.
+      expect(geo['delete_left'] - geo['others_right']).to be > 20
+    end
+  end
+
+  it_behaves_like 'a card with the delete button on the far side',
+                  '.citation-card', 'a.delete-citation'
+
+  it_behaves_like 'a card with the delete button on the far side',
+                  '.link-card', 'a.delete-link'
+end


### PR DESCRIPTION
## What changed

In the lexicon migration verification workbench, the destructive **delete** button sat immediately beside **edit** and **mark verified**, making a mis-click easy. It is now pushed to the opposite edge of the card, with the non-destructive actions staying packed at the start of the row.

Covers:
- citation cards (`_person_sections.html.haml`)
- LexLink cards on **both** person entries (`_person_sections.html.haml`) and publication entries (`_publication_sections.html.haml`) — same markup, same CSS

CSS-only; no HAML was touched.

## Why `margin-left` and not a logical property

These action rows get `flex-direction: row-reverse` under the existing `[dir="rtl"]` block, and the page is `<html dir="rtl">`. Both `ltr + row` and `rtl + row-reverse` put main-start at the **physical left**, so an auto margin on the left absorbs the free space and sends delete to the physical right edge in either direction. A logical `margin-inline-start` would do the wrong thing in RTL.

The rule is nested under `.citation-actions` / `.link-actions` deliberately: `.delete-citation` / `.delete-link` are also used on the plain `lexicon/citations/index` and `lexicon/links/index` table rows, which must remain unaffected.

## Test plan

New system spec `spec/system/lexicon/verification_delete_button_placement_spec.rb` — a shared example run against both card types, asserting via `getBoundingClientRect` that edit/verify hug the row's left edge, delete hugs the right edge, and there is real separation (>20px) between the groups rather than the 0.5rem flex gap.

Verified it is a genuine regression test: with the new rule neutralised, both examples fail with the delete button 296px short of the right edge.

Specs run:

```
bundle exec rspec \
  spec/system/lexicon/verification_delete_button_placement_spec.rb \
  spec/system/lexicon/verification_citation_delete_spec.rb \
  spec/system/lexicon/verification_link_delete_spec.rb \
  spec/system/lexicon/verification_layout_spacing_spec.rb \
  spec/system/lexicon/verification_workbench_spec.rb
# => 49 examples, 0 failures
```

RuboCop clean on the new spec. **The full suite was not run** (40+ min) — CI will cover it.

## Not touched

`.work-actions` — works cards have no delete button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
