### PR TITLE
Render all footnote bodies as <p> for uniform vertical spacing

### DIFF
--- a/app/services/markdown_to_html.rb
+++ b/app/services/markdown_to_html.rb
@@ -10,10 +10,12 @@ class MarkdownToHtml < ApplicationService
                         .gsub(%r{<figcaption>.*?</figcaption>}, '')
                         .gsub('<table', '<div style="overflow-x:auto;"><table')
                         .gsub('</table>', '</table></div>')
-    html.gsub!(%r{(<li id="fn:\d+"[^>]*>\s*)<p>(.*?)</p>}) do
-      # Change first <p> element in footnotes to <span> to prevent line break
-      "#{::Regexp.last_match(1)}<span>#{::Regexp.last_match(2)}</span>"
-    end
+    # Footnote bodies are left as MultiMarkdown emits them: every paragraph, including the first,
+    # stays a <p>. We used to rewrite the first one to a <span> to keep it on the same line as the
+    # list marker, but that was only needed while `.footnotes ol li` used `list-style-position:
+    # inside`; with the default `outside` the marker already aligns with the paragraph's first line.
+    # Worse, the rewrite only fired when the whole body sat on one source line, so identical
+    # footnotes rendered with different vertical spacing depending on how the markdown was wrapped.
     # Add target="_blank" to external links (not internal anchor links starting with #)
     html.gsub!(/<a\s+([^>]*?)>/) do
       attributes = ::Regexp.last_match(1)

--- a/spec/services/manifestation_html_with_chapters_spec.rb
+++ b/spec/services/manifestation_html_with_chapters_spec.rb
@@ -213,8 +213,8 @@ describe ManifestationHtmlWithChapters do
       end
 
       it 'preserves the footnote list at the bottom' do
-        expect(result[:html]).to include('<span>Footnote 1')
-        expect(result[:html]).to include('<span>Footnote 2')
+        expect(result[:html]).to include('<p>Footnote 1')
+        expect(result[:html]).to include('<p>Footnote 2')
       end
     end
 
@@ -272,7 +272,7 @@ describe ManifestationHtmlWithChapters do
           <ol>
 
           <li id="fn:1">
-          <span>This is a footnote at the beginning <a href="#fnref:1" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></span>
+          <p>This is a footnote at the beginning <a href="#fnref:1" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
           </li>
 
           </ol>

--- a/spec/services/markdown_to_html_spec.rb
+++ b/spec/services/markdown_to_html_spec.rb
@@ -6,46 +6,61 @@ describe MarkdownToHtml do
   describe '#call' do
     context 'when markdown is blank' do
       it 'returns empty string' do
-        result = MarkdownToHtml.call('')
+        result = described_class.call('')
         expect(result).to eq('')
       end
 
       it 'returns empty string for nil' do
-        result = MarkdownToHtml.call(nil)
+        result = described_class.call(nil)
         expect(result).to eq('')
       end
     end
 
     context 'when markdown contains footnotes' do
-      it 'converts first paragraph in footnotes to span' do
+      it 'keeps the footnote body in a paragraph' do
         markdown = "Text with footnote[^1].\n\n[^1]: This is the footnote content."
-        result = MarkdownToHtml.call(markdown)
+        result = described_class.call(markdown)
 
-        expect(result).to include('<span>This is the footnote content.')
-        expect(result).not_to include('<li id="fn:1"><p>This is the footnote content.')
+        expect(result).to include('<p>This is the footnote content.')
+        expect(result).not_to include('<span>This is the footnote content.')
       end
 
       it 'handles multiple footnotes correctly' do
         markdown = "Text with footnotes[^1] and more[^2].\n\n[^1]: First footnote.\n\n[^2]: Second footnote."
-        result = MarkdownToHtml.call(markdown)
+        result = described_class.call(markdown)
 
-        expect(result).to include('<span>First footnote.')
-        expect(result).to include('<span>Second footnote.')
-        expect(result).not_to include('<li id="fn:1"><p>First footnote.')
-        expect(result).not_to include('<li id="fn:2"><p>Second footnote.')
+        expect(result).to include('<p>First footnote.')
+        expect(result).to include('<p>Second footnote.')
+        expect(result).not_to include('<span>First footnote.')
+        expect(result).not_to include('<span>Second footnote.')
       end
 
-      it 'only changes first paragraph in multi-paragraph footnotes' do
+      it 'wraps every paragraph of a multi-paragraph footnote in <p>' do
         markdown = "Text with footnote[^1].\n\n[^1]: First paragraph.\n\n    Second paragraph."
-        result = MarkdownToHtml.call(markdown)
+        result = described_class.call(markdown)
 
-        expect(result).to include('<span>First paragraph.')
+        expect(result).to include('<p>First paragraph.')
         expect(result).to include('<p>Second paragraph.')
+        expect(result).not_to include('<span>')
+      end
+
+      # Regression: the old first-<p>-to-<span> rewrite used a regex without /m, so it only fired
+      # when the whole footnote body sat on a single source line. Footnotes therefore rendered with
+      # inconsistent vertical spacing depending purely on how the markdown happened to be wrapped.
+      it 'renders hard-wrapped and single-line footnote bodies with the same markup' do
+        wrapped = described_class.call("Text[^1].\n\n[^1]: A body that is\nwrapped across lines.")
+        single = described_class.call("Text[^1].\n\n[^1]: A body on one line.")
+
+        expect(wrapped).to include('<li id="fn:1">')
+        expect(wrapped).to match(/<li id="fn:1">\s*<p>A body that is/)
+        expect(single).to match(/<li id="fn:1">\s*<p>A body on one line\./)
+        expect(wrapped).not_to include('<span>')
+        expect(single).not_to include('<span>')
       end
 
       it 'preserves return links in footnotes' do
         markdown = "Text with footnote[^1].\n\n[^1]: Footnote content."
-        result = MarkdownToHtml.call(markdown)
+        result = described_class.call(markdown)
 
         expect(result).to include('class="reversefootnote"')
         expect(result).to include('href="#fnref:1"')
@@ -163,7 +178,7 @@ describe MarkdownToHtml do
     context 'when markdown does not contain footnotes' do
       it 'does not change regular paragraphs' do
         markdown = "# Title\n\nThis is a regular paragraph."
-        result = MarkdownToHtml.call(markdown)
+        result = described_class.call(markdown)
 
         expect(result).to include('<p>This is a regular paragraph.</p>')
       end
@@ -179,7 +194,7 @@ describe MarkdownToHtml do
         # Mock MultiMarkdown to return HTML with figcaption
         allow_any_instance_of(MultiMarkdown).to receive(:to_html).and_return(html_with_figcaption)
 
-        result = MarkdownToHtml.call(markdown)
+        result = described_class.call(markdown)
         expect(result).not_to include('figcaption')
         expect(result).to include('<p>Text content</p>')
       end


### PR DESCRIPTION
## Problem

Footnote bodies rendered inconsistently: some in a `<p>`, some in a `<span>`, producing uneven vertical spacing (and uneven type size) between adjacent footnotes.

`MarkdownToHtml` rewrote the first `<p>` of every footnote body into a `<span>`:

```ruby
html.gsub!(%r{(<li id="fn:\d+"[^>]*>\s*)<p>(.*?)</p>}) do
```

The regex has no `/m` flag, so `.` never matches a newline. MultiMarkdown preserves the markdown source's hard line wrapping inside the generated `<p>`, so **the rewrite only fired when the whole footnote body happened to sit on a single physical line in the source.**

On a real 40-footnote text, exactly **one** footnote became a `<span>` — the only one whose source wasn't wrapped:

```html
<li id="fn:24">
<p>[באומצא, עי' JQR,          ← newline inside <p> → regex misses → stays <p>
מהדו"ח,,XII 352]. <a class="reversefootnote">…</a></p>

<li id="fn:25">
<p>ראה תוספות מנחות קא א ד"ה: ששונאים. <a …>…</a></p>   ← one line → became <span>
```

So the rendered markup was determined by an invisible, meaningless property of the source text. The two shapes differ visually in two ways:

- `<p>` carries Bootstrap's `margin-bottom: 1rem`; `<span>` does not.
- `#actualtext .footnotes p` (`application.scss:1125`) sets `font-size: 11pt; line-height: 13pt`, which the `<span>` bodies silently missed.

## Fix

Remove the rewrite rather than adding `/m`, so every footnote body is a `<p>`.

The rewrite was only ever needed to keep the body on the same line as the list marker while `.footnotes ol li` carried `list-style-position: inside` — and 4ae3d6a27 ("Fix footnotes placement in all browsers") **deleted that declaration in the same commit that added the rewrite**. With the default `outside`, the marker already aligns with the paragraph's first line, so the rewrite has been vestigial since November.

Verified by rendering a footnote list against the current SCSS rules in headless Chrome: numbers sit on the same line as their `<p>` bodies, spacing is uniform, and multi-paragraph footnotes keep their internal breaks.

Also confirmed no regression in the two consumers that read footnote `<li>` markup:
- `MarkdownToHtml#add_footnote_popovers` — popover `data-content` is now consistently `<p>`-wrapped (it already was for 39 of 40 footnotes).
- `BybeUtils#epub_footnote_transform!` — matches on `<li id="fn:…">…</li>` and is agnostic to the inner element.
- `ExtractFirstFootnoteReference` operates on body-text paragraphs, not footnote bodies; unaffected.

## Test plan

- Rewrote the three `markdown_to_html_spec` examples that asserted `<span>` to assert `<p>`.
- **Added a regression test** covering the actual bug: a hard-wrapped footnote body and a single-line one must produce identical markup. This fails on `master`.
- Updated the two `<span>` expectations in `manifestation_html_with_chapters_spec`.
- Also switched the remaining `MarkdownToHtml.call` references in the spec to `described_class` to clear `RSpec/DescribedClass`.

Specs run (all green):

```
spec/services/markdown_to_html_spec.rb
spec/services/manifestation_html_with_chapters_spec.rb
spec/services/extract_first_footnote_reference_spec.rb
spec/lib/bybe_utils_epub_spec.rb
spec/lib/bybe_utils_spec.rb
spec/controllers/ingestibles_controller_spec.rb
spec/controllers/ingestible_texts_controller_spec.rb
spec/models/manifestation_spec.rb
spec/models/collection_item_spec.rb
spec/helpers/lexicon_helper_spec.rb
spec/services/lexicon/bio_comparison_spec.rb
→ 378 examples, 0 failures
```

RuboCop clean on all changed files, apart from one pre-existing `RSpec/AnyInstance` in an untouched figcaption test.

**The full suite was not run** (40+ min) and needs approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
