### PR TITLE
Enlarge LexPersonWork#comment to hold long notes

### DIFF
--- a/db/migrate/20260824090000_increase_length_of_lex_person_works_comment.rb
+++ b/db/migrate/20260824090000_increase_length_of_lex_person_works_comment.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# The default varchar(255) was too short for real work comments, which sometimes carry a full
+# bibliographic note. Widen to 4096 so long comments survive ingest instead of being rejected.
+class IncreaseLengthOfLexPersonWorksComment < ActiveRecord::Migration[8.0]
+  def up
+    change_column :lex_person_works, :comment, :string, limit: 4096
+  end
+
+  def down
+    change_column :lex_person_works, :comment, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_090000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -794,7 +794,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
 
   create_table "lex_person_works", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "collection_id"
-    t.string "comment"
+    t.string "comment", limit: 4096
     t.json "comment_links"
     t.datetime "created_at", null: false
     t.bigint "lex_person_id", null: false

--- a/spec/models/lex_person_work_spec.rb
+++ b/spec/models/lex_person_work_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LexPersonWork do
+  describe '#comment' do
+    # Regression: the column was varchar(255), so a long bibliographic note was silently
+    # truncated (or rejected in strict mode) on save. It is now varchar(4096).
+    it 'persists a comment of 4096 characters without truncation' do
+      long_comment = 'א' * 4096
+      work = create(:lex_person_work, comment: long_comment)
+
+      expect(work.reload.comment).to eq long_comment
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`lex_person_works.comment` was the default `varchar(255)`, too short for work comments that carry a full bibliographic note. This widens it to `varchar(4096)`.

Note on units: MySQL `VARCHAR(n)` counts **characters**, not bytes. `varchar(4096)` under `utf8mb4` therefore holds at least 4096 bytes for any content, and 4096 characters of Hebrew (~8 KB) in practice — a superset of the 4096-byte requirement.

## Changes

- `db/migrate/20260824090000_increase_length_of_lex_person_works_comment.rb` — `change_column` to `limit: 4096`, with a `down` back to 255.
- `db/schema.rb` — regenerated.
- `spec/models/lex_person_work_spec.rb` — new model spec asserting a 4096-character comment round-trips without truncation. Would have failed against the old column.

No application code needed changing: there is no length validation on `comment`, no `maxlength` on the form field, and no truncation in the ingest path.

## Test plan

- `bundle exec rspec spec/models/lex_person_work_spec.rb` — 1 example, 0 failures
- Related specs, no regressions: `spec/models/lex_person_spec.rb`, `spec/requests/lexicon/person_works_spec.rb`, `spec/helpers/lexicon_helper_spec.rb`, `spec/services/lexicon/lex_person_content_spec.rb` — 121 examples, 0 failures
- RuboCop clean on both new files
- Full suite **not** run (40+ min; needs your go-ahead) — CI will cover it

🤖 Generated with [Claude Code](https://claude.com/claude-code)