### PR TITLE
Add an image picker to both lexicon biography editors

### DIFF
--- a/app/assets/javascripts/insert_image.js
+++ b/app/assets/javascripts/insert_image.js
@@ -4,8 +4,10 @@
  * The image tag is generated from the selected item in the ddslick dropdown.
  * @param textAreaSelector - the selector of the TextArea where the image tag should be inserted (e.g. '#markdown')
  * @param ddslickDropDownSelector - the selector of the ddslick dropdown (e.g. '#images')
+ * @param extraAttrs - optional object of additional attributes to set on the tag,
+ *                     e.g. {'data-align': 'left'} for lexicon biography images
  */
-function insertImageFromDDSlick(textAreaSelector, ddslickDropDownSelector) {
+function insertImageFromDDSlick(textAreaSelector, ddslickDropDownSelector, extraAttrs) {
   const $txt = $(textAreaSelector);
   const caretPos = $txt[0].selectionStart;
   const scrollLeft = $txt[0].scrollLeft;
@@ -14,7 +16,7 @@ function insertImageFromDDSlick(textAreaSelector, ddslickDropDownSelector) {
 
   const ddData = $(ddslickDropDownSelector).data('ddslick');
   const $selectedOption = ddData.original.find('option:selected');
-  const txtToAdd = "\n" + imageTagFromOption($selectedOption) + "\n";
+  const txtToAdd = "\n" + imageTagFromOption($selectedOption, extraAttrs) + "\n";
   $txt.val(textAreaTxt.substring(0, caretPos) + txtToAdd + textAreaTxt.substring(caretPos) );
   $txt.focus();
   $txt.caretTo(caretPos+txtToAdd.length);
@@ -26,7 +28,11 @@ function sanitizeImageUrl(rawUrl) {
   try {
     const parsed = new URL(rawUrl, window.location.origin);
     if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return parsed.href;
+      // Keep a root-relative src exactly as given: it is host-independent (so content authored
+      // in development does not embed localhost), and parsed.href would percent-encode the
+      // non-ASCII (Hebrew) filenames these download paths are deliberately kept readable for.
+      const isRootRelative = rawUrl.charAt(0) === '/' && rawUrl.charAt(1) !== '/';
+      return isRootRelative ? rawUrl : parsed.href;
     }
   } catch (e) {
     // Invalid URL: ignore
@@ -34,7 +40,7 @@ function sanitizeImageUrl(rawUrl) {
   return null;
 }
 
-function imageTagFromOption(option) {
+function imageTagFromOption(option, extraAttrs) {
   const $opt = $(option);
   // Use DOM API so width/height become HTML attributes (not inline styles).
   // jQuery's $('<img>', {width, height}) routes through .width()/.height(),
@@ -44,6 +50,9 @@ function imageTagFromOption(option) {
   if (!safeSrc) return '';
   img.src = safeSrc;
   img.alt = $opt.text().trim();
+  $.each(extraAttrs || {}, function(name, value) {
+    img.setAttribute(name, value);
+  });
   const width = $opt.data('width');
   const height = $opt.data('height');
   if (width) img.setAttribute('width', width);

--- a/app/assets/javascripts/lexicon_backend.js
+++ b/app/assets/javascripts/lexicon_backend.js
@@ -3,6 +3,9 @@
 //= require autocomplete_init
 //= require sortable.min
 //= require verification
+//= require jquery.caret
+//= require jquery.ddslick.min
+//= require insert_image
 //= require bootstrap-rtl-4.2.1.bundle.min
 
 $(function() {

--- a/app/helpers/manifestation_helper.rb
+++ b/app/helpers/manifestation_helper.rb
@@ -1,7 +1,10 @@
 module ManifestationHelper
+  # Builds <option> tags for the ddslick image picker (see insert_image.js). Works for any
+  # DownloadLink record — Manifestation and StaticPage keep their images in `images`,
+  # LexEntry in `attachments` — since downloadable_attachments resolves the right association.
   def options_from_images(record)
     # skip any non-image attachments that may have been accidentally uploaded
-    record.images.select(&:variable?).map do |img|
+    record.downloadable_attachments.select(&:variable?).map do |img|
       blob = img.blob
       filename = blob.filename.to_s
       content_tag(

--- a/app/views/lexicon/people/_form.html.haml
+++ b/app/views/lexicon/people/_form.html.haml
@@ -22,4 +22,5 @@
   = f.input :birthdate
   = f.input :deathdate
   = f.input :bio, as: :text, input_html: { rows: 20 }
+  = render 'lexicon/shared/insert_image', entry: @lex_person.entry, textarea: '#lex_person_bio'
   = f.button :submit, class: 'btn btn-primary'

--- a/app/views/lexicon/shared/_insert_image.html.haml
+++ b/app/views/lexicon/shared/_insert_image.html.haml
@@ -13,7 +13,7 @@
         Deliberately nameless: this is a UI control, not a value the surrounding form submits.
         (ddslick replaces the element with a div of the same id, so it never reaches the server.)
       %select{ id: picker_id }= image_options
-      %button.btn.btn-sm.btn-outline-primary.lex-insert-image-btn.ml-2{ type: 'button' }
+      %button.btn.btn-sm.btn-outline-primary.lex-insert-image-btn.ms-2{ type: 'button' }
         = t('lexicon.shared.insert_image.button')
     %small.form-text.text-muted= t('lexicon.shared.insert_image.hint')
   :javascript

--- a/app/views/lexicon/shared/_insert_image.html.haml
+++ b/app/views/lexicon/shared/_insert_image.html.haml
@@ -1,0 +1,28 @@
+-#
+  Image picker for the biography editors (the verification workbench's bio modal and the
+  entry-edit properties form). Emits the same shape of tag the migrated entries already carry,
+  so an image inserted by hand floats and wraps like one that came out of the old PHP lexicon.
+  Locals: entry (LexEntry), textarea (CSS selector of the textarea to insert into).
+  A brand-new entry has neither an id nor attachments, so nothing is rendered for it.
+- image_options = entry ? options_from_images(entry) : nil
+- if image_options.present?
+  - picker_id = "lex_insert_image_#{entry.id}"
+  .form-group.lex-insert-image{ id: "#{picker_id}_wrapper" }
+    .d-flex.align-items-center
+      -#
+        Deliberately nameless: this is a UI control, not a value the surrounding form submits.
+        (ddslick replaces the element with a div of the same id, so it never reaches the server.)
+      %select{ id: picker_id }= image_options
+      %button.btn.btn-sm.btn-outline-primary.lex-insert-image-btn.ml-2{ type: 'button' }
+        = t('lexicon.shared.insert_image.button')
+    %small.form-text.text-muted= t('lexicon.shared.insert_image.hint')
+  :javascript
+    (function() {
+      var pickerSelector = '##{picker_id}';
+      $(pickerSelector).ddslick({ width: 320 });
+      $('##{picker_id}_wrapper').on('click', '.lex-insert-image-btn', function(e) {
+        e.preventDefault();
+        insertImageFromDDSlick('#{textarea}', pickerSelector,
+                               { 'data-border': '0', 'data-align': 'left', 'data-hspace': '10' });
+      });
+    })();

--- a/app/views/lexicon/verification/_edit_bio.html.haml
+++ b/app/views/lexicon/verification/_edit_bio.html.haml
@@ -8,6 +8,8 @@
     .form-text.text-muted
       = t('lexicon.verification.edit.html_allowed')
 
+  = render 'lexicon/shared/insert_image', entry: @entry, textarea: '#lex_person_bio'
+
   .form-check.mt-3
     = check_box_tag :mark_verified, '1', false, class: 'form-check-input'
     = label_tag :mark_verified, t('lexicon.verification.edit.mark_as_verified'), class: 'form-check-label'

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -159,6 +159,10 @@ en:
     header:
       title: Lexicon of New Hebrew Literature
       part_of_pby: Part of the Ben-Yehuda Project
+    shared:
+      insert_image:
+        button: Insert image
+        hint: "The image is inserted at the caret, floated to the left with the text wrapping around it."
     people:
       create:
         success: Lexicon Person created

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -160,6 +160,10 @@ he:
     header:
       title: לקסיקון הספרות העברית החדשה
       part_of_pby: חלק מפרויקט בן־יהודה
+    shared:
+      insert_image:
+        button: הוסף תמונה
+        hint: "התמונה תיווסף במקום הסמן, ותוצג בצד שמאל כשהטקסט זורם סביבה."
     people:
       create:
         success: נוצרה ישות חדשה

--- a/spec/helpers/manifestation_helper_spec.rb
+++ b/spec/helpers/manifestation_helper_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManifestationHelper do
+  describe '#options_from_images' do
+    let(:image_data) { Rails.root.join('spec/fixtures/files/test_image.jpg').binread }
+
+    # Pin the dimensions so data-width/data-height are deterministic. 'analyzed' must live in the
+    # metadata JSON, otherwise the helper calls blob.analyze and overwrites them with the real size.
+    def stamp_dimensions(attachment, width, height)
+      blob = attachment.blob
+      blob.update!(metadata: blob.metadata.merge('analyzed' => true, 'width' => width, 'height' => height))
+    end
+
+    context 'with a LexEntry' do
+      let(:entry) { create(:lex_entry, :person) }
+
+      before do
+        entry.attachments.attach(io: StringIO.new(image_data), filename: 'image004.jpg',
+                                 content_type: 'image/jpeg')
+        stamp_dimensions(entry.attachments.first, 200, 299)
+      end
+
+      it 'offers each attached image, valued by its user-friendly download path' do
+        options = Nokogiri::HTML.fragment(helper.options_from_images(entry.reload)).css('option')
+
+        expect(options.map(&:text)).to eq ['image004.jpg']
+        expect(options.first['value']).to eq "/files/lex/#{entry.id}/image004.jpg"
+        expect(options.first['data-width']).to eq '200'
+        expect(options.first['data-height']).to eq '299'
+      end
+
+      it 'skips non-image attachments' do
+        entry.attachments.attach(io: StringIO.new('not an image'), filename: 'source.pdf',
+                                 content_type: 'application/pdf')
+
+        options = Nokogiri::HTML.fragment(helper.options_from_images(entry.reload)).css('option')
+
+        expect(options.map(&:text)).to eq ['image004.jpg']
+      end
+    end
+
+    context 'with a Manifestation' do
+      let(:manifestation) { create(:manifestation, status: :published) }
+
+      before do
+        manifestation.images.attach(io: StringIO.new(image_data), filename: 'plate.jpg',
+                                    content_type: 'image/jpeg')
+        stamp_dimensions(manifestation.images.first, 800, 600)
+      end
+
+      it 'still reads images off the images association' do
+        options = Nokogiri::HTML.fragment(helper.options_from_images(manifestation.reload)).css('option')
+
+        expect(options.map(&:text)).to eq ['plate.jpg']
+        expect(options.first['value']).to eq "/files/text/#{manifestation.id}/plate.jpg"
+        expect(options.first['data-width']).to eq '800'
+      end
+    end
+  end
+end

--- a/spec/system/lexicon/bio_insert_image_spec.rb
+++ b/spec/system/lexicon/bio_insert_image_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Editors used to have to hand-type the <img> tag for an attached image. Both bio editors now
+# carry a picker that inserts the tag the migrated entries use, e.g.
+#   <img src="/files/lex/3/image004.jpg" data-border="0" data-align="left" data-hspace="10" ... />
+RSpec.describe 'Inserting an attached image into a lexicon biography', :js, type: :system do
+  let(:person) { create(:lex_person, bio: 'ביוגרפיה קצרה.') }
+  let(:entry) { create(:lex_entry, :person, title: 'Test Person', lex_item: person, status: :draft) }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+
+    image_data = Rails.root.join('spec/fixtures/files/test_image.jpg').binread
+    entry.attachments.attach(io: StringIO.new(image_data), filename: 'image004.jpg',
+                             content_type: 'image/jpeg')
+    # Pin the dimensions so the emitted width/height are deterministic. 'analyzed' must be in the
+    # metadata JSON, else the helper re-analyzes the blob and overwrites them with the real size.
+    blob = entry.attachments.first.blob
+    blob.update!(metadata: blob.metadata.merge('analyzed' => true, 'width' => 200, 'height' => 299))
+  end
+
+  def bio_textarea_value
+    page.evaluate_script("$('#lex_person_bio').val()")
+  end
+
+  shared_examples 'a biography image picker' do
+    it 'inserts the attached image as a left-floated tag with its real dimensions' do
+      # Waiting on the picker's rendered label also waits out the AJAX load of the editor itself.
+      expect(page).to have_css('.lex-insert-image .dd-selected-text', text: 'image004.jpg', wait: 10)
+
+      click_button I18n.t('lexicon.shared.insert_image.button')
+
+      expect(page).to have_css('#lex_person_bio', wait: 5)
+      expect(bio_textarea_value).to include(
+        %(src="/files/lex/#{entry.id}/image004.jpg"),
+        'data-border="0"',
+        'data-align="left"',
+        'data-hspace="10"',
+        'width="200"',
+        'height="299"'
+      )
+      # host-independent, so a bio authored in development does not embed localhost
+      expect(bio_textarea_value).not_to include('http://')
+    end
+  end
+
+  describe 'in the migration verification workbench' do
+    before do
+      entry.start_verification!('test@example.com')
+      visit lexicon_verification_path(entry)
+
+      within('#section-bio .section-actions') do
+        click_button I18n.t('lexicon.verification.migrated.edit')
+      end
+    end
+
+    it_behaves_like 'a biography image picker'
+  end
+
+  describe 'in the entry-edit properties form' do
+    before { visit edit_lexicon_entry_path(entry) }
+
+    it_behaves_like 'a biography image picker'
+  end
+
+  describe 'when the entry has no image attachments' do
+    before do
+      entry.attachments.purge
+      visit edit_lexicon_entry_path(entry)
+    end
+
+    it 'renders no picker at all' do
+      expect(page).to have_css('#properties #lex_person_bio', visible: :visible, wait: 10)
+      expect(page).to have_no_css('.lex-insert-image')
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds an image picker + **הוסף תמונה** button to both lexicon biography editors, so an editor can embed an attached image without hand-typing the tag.

- `app/views/lexicon/verification/_edit_bio.html.haml` — the verification workbench's bio modal
- `app/views/lexicon/people/_form.html.haml` — the entry-edit **properties** tab

Both render the new shared partial `lexicon/shared/_insert_image`, which puts a ddslick thumbnail dropdown over the entry's image attachments next to an insert button. Clicking it drops the tag at the caret:

```html
<img src="/files/lex/3/image004.jpg" alt="image004.jpg" data-border="0" data-align="left" data-hspace="10" width="200" height="299">
```

`data-align="left"` is what `lexicon.scss` already floats, so an image added this way wraps text exactly like one that came out of the old PHP lexicon. Nothing renders when the entry has no image attachments (including a brand-new, unsaved entry).

## How — reuse rather than a parallel picker

The app already had this exact control on manifestation edit and static-page edit. Three small generalisations let the lexicon share it:

- **`options_from_images`** now reads through `DownloadLink#downloadable_attachments` instead of `record.images`, so one helper serves `Manifestation`/`StaticPage` (`images`) and `LexEntry` (`attachments`). `src` therefore comes from `download_path`, i.e. `/files/lex/<id>/<filename>`.
- **`insertImageFromDDSlick` / `imageTagFromOption`** take an optional `extraAttrs` object for the `data-*` attributes. Both existing callers pass nothing and are unaffected.
- **`sanitizeImageUrl`** keeps a root-relative `src` as given instead of absolutising it. A bio is persisted, so `parsed.href` would bake in the authoring host (`http://localhost:3000/...`) and percent-encode the Hebrew filenames these download paths are deliberately kept readable for. The `javascript:`/`data:` rejection is unchanged.
- **`lexicon_backend.js`** now bundles `jquery.caret`, `jquery.ddslick.min` and `insert_image`, which only `application.js` carried before.

## Notes for review

- The alignment is fixed (always `left`) rather than editor-selectable, per the request. Editors who want it on the right or in-flow edit the attribute by hand.
- The emitted tag carries `alt="<filename>"`, which the shared `imageTagFromOption` has always added for manifestations and static pages. It is the one attribute beyond the requested shape; say the word and I will suppress it for the lexicon.
- The `<select>` is deliberately nameless so it cannot be submitted with the surrounding form if JS fails to load. (ddslick replaces it with a `<div>` of the same id anyway.)

## Test plan

New:
- `spec/system/lexicon/bio_insert_image_spec.rb` (`:js`) — shared example run against **both** editors: asserts the inserted tag has the right `src`, all three `data-*` attributes, the real `width`/`height`, and no `http://`. Third example asserts no picker renders when there are no image attachments.
- `spec/helpers/manifestation_helper_spec.rb` — `options_from_images` over a `LexEntry` (download-path value, dimensions, non-image attachments skipped) plus a `Manifestation` regression for the association change.

Run and green:
```
spec/system/lexicon/                      184 examples, 0 failures
spec/system/manifestation_edit_ddslick_spec.rb
spec/helpers/manifestation_helper_spec.rb
spec/helpers/lexicon_helper_spec.rb
spec/requests/files_spec.rb
spec/controllers/manifestations_controller_spec.rb   (224 examples across these, 0 failures)
```

RuboCop and haml-lint clean on all changed files. **The full suite was not run** — it takes 40+ minutes and needs explicit approval; CI will cover it.

Closes bd `by-jek`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
