### PR TITLE
Reach lexicon work matches through Authority#volumes, not only publications

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -675,7 +675,7 @@ function confirmWorkMatch(button) {
         },
         data: {
             work_id: workId,
-            publication_id: publicationId,
+            publication_id: publicationId || '',
             collection_id: collectionId || ''
         },
         success: function(data) {

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -503,9 +503,7 @@ module Lexicon
         WorkMatchCandidate.new(title: pub.title, publication: pub, collection: pub.volume)
       end
 
-      already_offered = from_publications.filter_map { |candidate| candidate.collection&.id }.to_set
-      from_volumes = authority.volumes.includes(:publication).reject { |vol| already_offered.include?(vol.id) }
-      from_publications + from_volumes.map do |vol|
+from_volumes = authority.volumes.distinct.includes(:publication).reject { |vol| already_offered.include?(vol.id) }
         # Only propose the volume's publication when it is this authority's own -- confirming a
         # match rejects any other, and a translated author's volume points at the translator's.
         publication = vol.publication if vol.publication&.authority_id == authority.id

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -17,6 +17,11 @@ module Lexicon
     QUEUE_SORTABLE_COLUMNS = %w(updated_at migration_item_count).freeze
     QUEUE_SORT_DIRECTIONS = %w(asc desc).freeze
 
+    # One thing in BYP a lexicon work can be matched against: a bibliographic Publication, a
+    # volume Collection, or both when they are two faces of the same book. `title` is what the
+    # work's title is compared against.
+    WorkMatchCandidate = Struct.new(:title, :publication, :collection, keyword_init: true)
+
     # GET /lexicon/verification/queue
     def index
       scope = LexEntry.needs_verification.includes(:lex_item, :lex_file)
@@ -152,16 +157,15 @@ module Lexicon
     end
 
     # PATCH /lexicon/verification/:id/confirm_work_match
-    # Confirms an auto-matched publication for a work
+    # Confirms an auto-matched publication and/or volume for a work
     def confirm_work_match
       work_id = params[:work_id].to_i
-      publication_id = params[:publication_id].to_i
-      collection_id = params[:collection_id].to_i if params[:collection_id].present?
+      publication_id = params[:publication_id].presence&.to_i
+      collection_id = params[:collection_id].presence&.to_i
 
       # Find the work and verify it belongs to this entry's person
       work = @entry.lex_item.works.find(work_id)
 
-      # Validate that publication belongs to the person's authority
       person = @entry.lex_item
       if person.authority.blank?
         render json: { success: false, error: I18n.t('lexicon.verification.messages.person_no_authority') },
@@ -169,21 +173,10 @@ module Lexicon
         return
       end
 
-      publication = person.authority.publications.find_by(id: publication_id)
-      unless publication
-        render json: { success: false, error: I18n.t('lexicon.verification.messages.publication_not_in_authority') },
-               status: :unprocessable_content
+      error = work_match_error(person.authority, publication_id, collection_id)
+      if error
+        render json: { success: false, error: error }, status: :unprocessable_content
         return
-      end
-
-      # Validate collection if provided
-      if collection_id.present?
-        collection = Collection.find_by(id: collection_id, publication_id: publication_id)
-        unless collection
-          render json: { success: false, error: I18n.t('lexicon.verification.messages.collection_not_in_publication') },
-                 status: :unprocessable_content
-          return
-        end
       end
 
       # Update the work with the confirmed publication and collection
@@ -499,7 +492,28 @@ module Lexicon
       # rubocop:enable Rails/StrongParametersExpect
     end
 
-    # Auto-match works to publications based on title similarity
+    # Everything of this authority's that a work may be matched to.
+    #
+    # Publications alone are not enough: we only did bibliography work for Hebrew authors, so a
+    # translated author usually has no Publication of their own. Their books are still in BYP as
+    # volumes they are an involved authority of -- with the Publication, if any, filed under the
+    # Hebrew *translator*. Those volumes are reachable only through Authority#volumes.
+    def work_match_candidates(authority)
+      from_publications = authority.publications.includes(:volume).map do |pub|
+        WorkMatchCandidate.new(title: pub.title, publication: pub, collection: pub.volume)
+      end
+
+      already_offered = from_publications.filter_map { |candidate| candidate.collection&.id }.to_set
+      from_volumes = authority.volumes.includes(:publication).reject { |vol| already_offered.include?(vol.id) }
+      from_publications + from_volumes.map do |vol|
+        # Only propose the volume's publication when it is this authority's own -- confirming a
+        # match rejects any other, and a translated author's volume points at the translator's.
+        publication = vol.publication if vol.publication&.authority_id == authority.id
+        WorkMatchCandidate.new(title: vol.title, publication: publication, collection: vol)
+      end
+    end
+
+    # Auto-match works to publications and volumes based on title similarity
     # Returns proposed matches WITHOUT persisting to database
     # Format: { work_id => { publication_id:, publication_title:, collection_id:, collection_title:, similarity: } }
     def auto_match_works_to_publications(person)
@@ -507,35 +521,25 @@ module Lexicon
       authority = person.authority
       return matches unless authority
 
-      # Get all publications associated with the authority, with volume (collection) eager loaded
-      authority_publications = authority.publications.includes(:volume).to_a
-      return matches if authority_publications.empty?
-
-      # Build a map of publication_id => collection for efficient lookup
-      publication_collections = {}
-      authority_publications.each do |pub|
-        publication_collections[pub.id] = pub.volume if pub.volume.present?
-      end
+      candidates = work_match_candidates(authority)
+      return matches if candidates.empty?
 
       # Get authority name for cleaning publication titles
       authority_name = authority.name
 
-      # Only match works that don't already have a publication
-      unmatched_works = person.works.where(publication_id: nil)
+      # Only match works that are not associated with anything in BYP yet
+      unmatched_works = person.works.where(publication_id: nil, collection_id: nil)
 
       unmatched_works.each do |work|
-        best_match = find_best_publication_match(work, authority_publications, authority_name)
+        best_match = find_best_work_match(work, candidates, authority_name)
         next unless best_match
 
-        publication = best_match[:publication]
-        # Get collection from our pre-loaded map (no additional query)
-        collection = publication_collections[publication.id]
-
+        candidate = best_match[:candidate]
         matches[work.id] = {
-          publication_id: publication.id,
-          publication_title: publication.title,
-          collection_id: collection&.id,
-          collection_title: collection&.title,
+          publication_id: candidate.publication&.id,
+          publication_title: candidate.publication&.title,
+          collection_id: candidate.collection&.id,
+          collection_title: candidate.collection&.title,
           similarity: best_match[:similarity]
         }
       end
@@ -546,29 +550,54 @@ module Lexicon
     # Publications of the person's authority that neither belong to an existing work nor appear
     # among the proposed matches: works we have in BYP that are missing from the lexicon entry.
     def publications_absent_from_entry(person, work_matches)
-      person.unmatched_publications.where.not(id: work_matches.values.pluck(:publication_id))
+      person.unmatched_publications.where.not(id: work_matches.values.filter_map { |match| match[:publication_id] })
     end
 
-    # Find the best publication match for a work
-    # Returns { publication: Publication, similarity: Integer } or nil
-    def find_best_publication_match(work, publications, authority_name)
+    # Find the best candidate match for a work
+    # Returns { candidate: WorkMatchCandidate, similarity: Integer } or nil
+    def find_best_work_match(work, candidates, authority_name)
       return nil if work.title.blank?
 
       best_match = nil
       best_similarity = 0
 
-      publications.each do |pub|
-        next if pub.title.blank?
+      candidates.each do |candidate|
+        next if candidate.title.blank?
 
-        similarity = Lexicon::TitleSimilarity.call(work.title, pub.title, ignoring: authority_name)
-        return { publication: pub, similarity: similarity } if similarity == 100
+        similarity = Lexicon::TitleSimilarity.call(work.title, candidate.title, ignoring: authority_name)
+        return { candidate: candidate, similarity: similarity } if similarity == 100
         next unless similarity >= Lexicon::TitleSimilarity::MATCH_THRESHOLD && similarity > best_similarity
 
         best_similarity = similarity
-        best_match = pub
+        best_match = candidate
       end
 
-      best_match ? { publication: best_match, similarity: best_similarity } : nil
+      best_match ? { candidate: best_match, similarity: best_similarity } : nil
+    end
+
+    # Validates a proposed publication/volume pair against the authority.
+    # Returns a translated error message, or nil when the pair is acceptable.
+    def work_match_error(authority, publication_id, collection_id)
+      if publication_id.blank? && collection_id.blank?
+        return I18n.t('lexicon.verification.messages.no_match_selected')
+      end
+
+      if publication_id.present? && !authority.publications.exists?(id: publication_id)
+        return I18n.t('lexicon.verification.messages.publication_not_in_authority')
+      end
+
+      return nil if collection_id.blank?
+
+      # A volume confirmed on its own only has to be the authority's; one confirmed together with
+      # a publication has to be that publication's volume.
+      valid = if publication_id.present?
+                Collection.exists?(id: collection_id, publication_id: publication_id)
+              else
+                authority.volumes.exists?(id: collection_id)
+              end
+      return I18n.t('lexicon.verification.messages.collection_not_in_publication') unless valid
+
+      nil
     end
   end
 end

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -3,8 +3,19 @@
   path = @work.new_record? ? lexicon_person_works_path(@person) : lexicon_work_path(@work)
   authority = @person.authority
   publications = authority&.publications || []
-  collections_by_pub = publications.select(&:volume).index_by(&:id)
-                                   .transform_values { |pub| { id: pub.volume.id, title: pub.volume.title } }
+  # Volumes come from the authority's involved_authorities, not from its publications: we only
+  # did bibliography work for Hebrew authors, so a translated author has no Publication of their
+  # own and their volumes' publications are filed under the Hebrew translator instead.
+  collection_volumes = authority ? authority.volumes.order(:title).to_a : []
+  # Whatever the work is already associated with stays selectable, so that re-saving the form
+  # cannot silently drop an association made before this list was sourced from involved_authorities.
+  current_collection = @work.collection
+  if current_collection && collection_volumes.none? { |vol| vol.id == current_collection.id }
+    collection_volumes.unshift(current_collection)
+  end
+  collections_by_pub = collection_volumes.select(&:publication_id)
+                                         .index_by(&:publication_id)
+                                         .transform_values { |vol| { id: vol.id, title: vol.title } }
 
 = simple_form_for(@work, url: path, remote: true) do |f|
   = f.error_notification
@@ -30,8 +41,6 @@
                     include_blank: t('lexicon.person_works.form.select_publication'),
                     input_html: { id: 'lex_person_work_publication_id',
                                   data: { collections: collections_by_pub.to_json } }
-    :ruby
-      collection_volumes = authority.publications.joins(:volume).includes(:volume).map(&:volume)
     = f.association :collection,
                     collection: collection_volumes,
                     label_method: :title,

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -6,7 +6,7 @@
   # Volumes come from the authority's involved_authorities, not from its publications: we only
   # did bibliography work for Hebrew authors, so a translated author has no Publication of their
   # own and their volumes' publications are filed under the Hebrew translator instead.
-  collection_volumes = authority ? authority.volumes.order(:title).to_a : []
+  collection_volumes = authority ? authority.volumes.distinct.order(:title).to_a : []
   # Whatever the work is already associated with stays selectable, so that re-saving the form
   # cannot silently drop an association made before this list was sourced from involved_authorities.
   current_collection = @work.collection

--- a/app/views/lexicon/verification/_edit_works.html.haml
+++ b/app/views/lexicon/verification/_edit_works.html.haml
@@ -5,7 +5,8 @@
     %p.text-muted= t('lexicon.verification.sections.no_auto_match_proposals')
   - else
     %p= t('lexicon.verification.sections.auto_match_intro')
-    - @item.works.where(publication_id: nil).where(id: @work_matches.keys).order(:seqno).each do |work|
+    - unmatched = @item.works.where(publication_id: nil, collection_id: nil)
+    - unmatched.where(id: @work_matches.keys).order(:seqno).each do |work|
       - match = @work_matches[work.id]
       - next unless match
 
@@ -13,8 +14,9 @@
         .match-info
           %strong= work.title
           %span.mx-2 →
-          = match[:publication_title]
-          - if match[:collection_title].present?
+          -# A volume of a translated author has no publication of its own to name it by
+          = match[:publication_title] || match[:collection_title]
+          - if match[:publication_title].present? && match[:collection_title].present?
             %span.text-muted
               = t('lexicon.verification.edit.proposed_collection', title: match[:collection_title])
           %span.badge.bg-secondary.ms-2

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -336,6 +336,7 @@ en:
         person_no_authority: Person has no associated authority
         publication_not_in_authority: Publication does not belong to authority
         collection_not_in_publication: Collection does not belong to publication
+        no_match_selected: No publication or volume was selected
         work_not_found: Work not found
         attachment_not_found: Attachment not found
         unknown_error: Unknown error

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -337,6 +337,7 @@ he:
         person_no_authority: אין ישות מקושרת לאדם זה
         publication_not_in_authority: הפרסום אינו שייך לישות
         collection_not_in_publication: האוסף אינו שייך לפרסום
+        no_match_selected: לא נבחרו פרסום או כרך
         work_not_found: יצירה לא נמצאה
         attachment_not_found: קובץ מצורף לא נמצא
         unknown_error: שגיאה לא ידועה

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -88,6 +88,43 @@ describe '/lexicon/person_works' do
       call
       expect(response.body).to include('per-work-edit-form')
     end
+
+    describe 'the collection dropdown' do
+      subject(:collection_options) do
+        call
+        Nokogiri::HTML(response.body).css('#lex_person_work_collection_id option').pluck('value')
+      end
+
+      let(:authority) { create(:authority, name: 'Translated Author') }
+      let(:person) { create(:lex_person, authority: authority) }
+
+      # We only did bibliography work for Hebrew authors, so a translated author's volume has its
+      # Publication filed under the Hebrew translator -- the volume is reachable only through the
+      # authority's involved_authorities.
+      context 'when the authority\'s volume belongs to another authority\'s publication' do
+        let!(:volume) do
+          create(:collection,
+                 collection_type: :volume,
+                 title: 'Volume Filed Under The Translator',
+                 publication: create(:publication, authority: create(:authority)),
+                 authors: [authority])
+        end
+
+        it 'offers the volume' do
+          expect(collection_options).to include(volume.id.to_s)
+        end
+      end
+
+      context 'when the work is already associated with a collection outside the authority\'s volumes' do
+        let!(:stale_collection) { create(:collection, collection_type: :other, title: 'Stale Association') }
+
+        before { work.update!(collection: stale_collection) }
+
+        it 'keeps the current association selectable' do
+          expect(collection_options).to include(stale_collection.id.to_s)
+        end
+      end
+    end
   end
 
   describe 'PATCH /lex/works/:id' do

--- a/spec/requests/lexicon/verification_auto_matching_spec.rb
+++ b/spec/requests/lexicon/verification_auto_matching_spec.rb
@@ -222,7 +222,88 @@ RSpec.describe 'Lexicon::Verification Auto-Matching', type: :request do
       end
     end
 
-    context 'when authority has no publications' do
+    # We only did bibliography work for Hebrew authors, so a translated author has no Publication
+    # of their own: their books are in BYP as volumes they are an involved authority of, with the
+    # Publication (when there is one) filed under the Hebrew translator.
+    context 'when the authority has volumes but no publications of its own' do
+      let(:translator_authority) { create(:authority, name: 'Hebrew Translator') }
+      let!(:translators_publication) do
+        create(:publication,
+               authority: translator_authority,
+               title: 'The Immigrant / translated by Hebrew Translator')
+      end
+      let!(:volume) do
+        create(:collection,
+               collection_type: :volume,
+               title: 'The Immigrant',
+               publication: translators_publication,
+               authors: [authority],
+               translators: [translator_authority])
+      end
+      let!(:work) do
+        create(:lex_person_work, person: person, title: 'The Immigrant', publication_id: nil, collection_id: nil)
+      end
+
+      it 'proposes the volume, without the translator\'s publication' do
+        get "/lex/verification/#{entry.id}/edit_section", params: { section: 'works' }
+
+        expect(response).to have_http_status(:success)
+
+        # Still a proposal only -- nothing is persisted
+        work.reload
+        expect(work.collection_id).to be_nil
+
+        expect(assigns(:work_matches)[work.id]).to include(
+          publication_id: nil,
+          collection_id: volume.id,
+          collection_title: 'The Immigrant',
+          similarity: 100
+        )
+      end
+    end
+
+    context 'when a volume belongs to a publication of the same authority' do
+      let!(:publication) { create(:publication, authority: authority, title: 'Own Book') }
+      let!(:volume) do
+        create(:collection, collection_type: :volume, title: 'Own Book', publication: publication, authors: [authority])
+      end
+      let!(:work) do
+        create(:lex_person_work, person: person, title: 'Own Book', publication_id: nil, collection_id: nil)
+      end
+
+      it 'proposes the publication together with the volume, and proposes each only once' do
+        get "/lex/verification/#{entry.id}/edit_section", params: { section: 'works' }
+
+        expect(response).to have_http_status(:success)
+        expect(assigns(:work_matches)[work.id]).to include(
+          publication_id: publication.id,
+          collection_id: volume.id,
+          similarity: 100
+        )
+      end
+    end
+
+    context 'when a work is already associated with a volume but no publication' do
+      let(:translators_publication) { create(:publication, title: 'Elsewhere') }
+      let!(:volume) do
+        create(:collection,
+               collection_type: :volume, title: 'Already Matched',
+               publication: translators_publication, authors: [authority])
+      end
+      let!(:work) do
+        create(:lex_person_work,
+               person: person, title: 'Already Matched', publication_id: nil, collection_id: volume.id)
+      end
+
+      it 'does not propose a match for it again' do
+        get "/lex/verification/#{entry.id}/edit_section", params: { section: 'works' }
+
+        expect(response).to have_http_status(:success)
+        expect(assigns(:work_matches)[work.id]).to be_nil
+      end
+    end
+
+    context 'when authority has neither publications nor volumes' do
       let(:authority_no_pubs) { create(:authority) }
       let(:person_no_pubs) { create(:lex_person, authority: authority_no_pubs) }
       let(:entry_no_pubs) { create(:lex_entry, lex_item: person_no_pubs, status: :verifying) }
@@ -351,6 +432,59 @@ RSpec.describe 'Lexicon::Verification Auto-Matching', type: :request do
         json = response.parsed_body
         expect(json['success']).to be false
         expect(json['error']).to eq(I18n.t('lexicon.verification.messages.collection_not_in_publication'))
+      end
+    end
+
+    context 'when confirming a volume on its own' do
+      let!(:volume) do
+        create(:collection,
+               collection_type: :volume,
+               title: 'Translated Volume',
+               publication: create(:publication, title: 'Filed Under The Translator'),
+               authors: [authority])
+      end
+
+      it 'persists the volume with no publication' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, publication_id: '', collection_id: volume.id },
+              headers: { 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['success']).to be true
+
+        work.reload
+        expect(work.publication_id).to be_nil
+        expect(work.collection_id).to eq(volume.id)
+      end
+    end
+
+    context 'when confirming a volume that is not one of the authority\'s' do
+      let!(:foreign_volume) do
+        create(:collection, collection_type: :volume, title: 'Someone Else\'s Volume', authors: [create(:authority)])
+      end
+
+      it 'returns unprocessable with a translated error' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, publication_id: '', collection_id: foreign_volume.id },
+              headers: { 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = response.parsed_body
+        expect(json['success']).to be false
+        expect(json['error']).to eq(I18n.t('lexicon.verification.messages.collection_not_in_publication'))
+      end
+    end
+
+    context 'when neither a publication nor a volume is given' do
+      it 'returns unprocessable with a translated error' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, publication_id: '', collection_id: '' },
+              headers: { 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = response.parsed_body
+        expect(json['success']).to be false
+        expect(json['error']).to eq(I18n.t('lexicon.verification.messages.no_match_selected'))
       end
     end
   end


### PR DESCRIPTION
## Problem

In the lexicon migration of `lexicon/00098.php` (אפרים קישון), the sole work of that authority — **העולה היורד לחיינו** — was not auto-matched, and could not be associated by hand either: the collection dropdown on the `LexPersonWork` form rendered empty.

Both code paths reached collections only through `Authority → publications → volume`:

- `auto_match_works_to_publications` iterated `authority.publications` and bailed out early when empty
- `person_works/_form.html.haml` built the dropdown from `authority.publications.joins(:volume).map(&:volume)`

Authority 315 (קישון) has **zero** publications. The book is collection 9419, whose publication 2947 is filed under authority 10 (אביגדור המאירי — the **translator**). The collection itself is correct: it lists 315 as `author` and 10 as `translator`.

This is systematic, not a one-off. We only did bibliography work for Hebrew authors, so a translated author practically never has Publications of their own. In the dev DB: **175** collections whose author-role authority differs from `publication.authority_id`, across **138** authorities, **124** of which have no publications at all.

Title matching was never the problem — `TitleSimilarity` scores **100** for this pair once the volume is in the candidate set.

## Changes

- **`verification_controller`** — work-match candidates are now built from the authority's publications **and** its volumes (`Authority#volumes`, which goes through `involved_authorities`), deduplicating volumes reachable both ways. A volume's publication is proposed only when it is the authority's own, since confirming a match rejects any other.
- **`confirm_work_match`** — accepts a volume with no publication, validating it against `Authority#volumes`; rejects a confirmation that names neither (new `no_match_selected` message in both locales).
- **`_edit_works.html.haml`** — a proposal with no publication is labelled by its volume title.
- **`_form.html.haml`** — the collection dropdown is sourced from `Authority#volumes`. The work's current collection is kept selectable so that re-saving the form cannot silently drop an association made before this change. `collections_by_pub` (used by the publication→collection auto-select JS) is now derived from the dropdown's own contents, so it can never point at an option that isn't there.
- Auto-matching now skips works already associated with a collection, not just those with a publication.

## Verification against real data

For authority 315 the candidate list is now 1 entry (collection 9419, no publication), similarity **100**, and the resulting `LexPersonWork` with `collection_id` set and `publication_id` nil validates cleanly.

## Test plan

New specs in `spec/requests/lexicon/verification_auto_matching_spec.rb` and `spec/requests/lexicon/person_works_spec.rb` covering: a volume-only proposal for an authority with no publications; a publication+volume proposal not double-counted; works already matched to a volume not re-proposed; confirming a volume alone; rejecting a foreign volume; rejecting an empty confirmation; the dropdown offering an involved-authority volume; and the current association staying selectable.

**All 6 new examples fail on master and pass with this change** (verified by stashing the app changes).

Ran green:
- `spec/requests/lexicon/` + `spec/models/lex_person_work_spec.rb` — 338 examples, 0 failures
- `spec/system/lexicon/verification_auto_matching_spec.rb`, `verification_works_modal_spec.rb`, `verification_missing_publication_report_spec.rb`, `verification_works_header_spec.rb` — 20 examples, 0 failures

The full suite (40+ min) was **not** run — that needs your approval.

## Known gap, deliberately out of scope

The "publications known in BYP but absent from the entry" report still lists only `Publication` records, so it stays empty for a translated author. Widening it to volumes would change what the Monday reporting integration submits (it takes a `publication_id`), so I left it alone.

Closes bead by-slg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
