### PR TITLE
Don't double-wrap citation subjects already phrased 'על "..."'

### DIFF
--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -142,11 +142,19 @@ module LexiconHelper
     end
   end
 
+  # Many legacy subjects are already phrased as 'על "שם היצירה"', so wrapping them in the
+  # subject_line template would yield a doubled 'על ״על "שם היצירה"״'. Such subjects are shown
+  # as-is. The quote is required: genuine work titles that merely begin with the word על
+  # (e.g. 'על חכמות דרכים : שירים') still get the wrapper.
+  ALREADY_ABOUT_SUBJECT_RE = /\Aעל\s+["״“”]/
+
   def citations_subject_header(subject_title)
-    if subject_title.present?
-      t('lexicon.citations.header.subject_line', subject: subject_title)
-    else
+    if subject_title.blank?
       t('lexicon.citations.header.general')
+    elsif subject_title.match?(ALREADY_ABOUT_SUBJECT_RE)
+      subject_title
+    else
+      t('lexicon.citations.header.subject_line', subject: subject_title)
     end
   end
 

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -307,6 +307,32 @@ RSpec.describe LexiconHelper, type: :helper do
     end
   end
 
+  describe '#citations_subject_header' do
+    it 'wraps a plain work title in the "about" template' do
+      expect(helper.citations_subject_header('שורשי אויר')).to eq('על ״שורשי אויר״')
+    end
+
+    it 'falls back to the general header when there is no subject' do
+      expect(helper.citations_subject_header(nil)).to eq('כללי')
+    end
+
+    it 'shows a subject already phrased as על "..." as-is' do
+      expect(helper.citations_subject_header('על "שורשי אויר"')).to eq('על "שורשי אויר"')
+    end
+
+    it 'shows an already-phrased subject with trailing text as-is' do
+      expect(helper.citations_subject_header('על "כל השירים" (2009)')).to eq('על "כל השירים" (2009)')
+    end
+
+    it 'recognizes Hebrew gershayim as the opening quote' do
+      expect(helper.citations_subject_header('על ״שורשי אויר״')).to eq('על ״שורשי אויר״')
+    end
+
+    it 'still wraps a work title that merely begins with the word על' do
+      expect(helper.citations_subject_header('על חכמות דרכים : שירים')).to eq('על ״על חכמות דרכים : שירים״')
+    end
+  end
+
   describe '#render_citation with text_links' do
     let(:person) { create(:lex_person) }
     let!(:target_entry) { create(:lex_entry, :publication, title: 'שדות ומזוודות') }


### PR DESCRIPTION
## What

On a lexicon person entry (`LexEntry#show`), each citation section is headed with the I18n template `lexicon.citations.header.subject_line` — `על ״%{subject}״`. But most legacy subjects are *themselves* already phrased as `על "שם היצירה"`, so the header came out doubled:

> על ״על "שורשי אויר"״

Such subjects are now shown as-is, since they already carry both the על and the quotes.

## Detection rule

The subject must start with `על` followed by whitespace and an opening quote (`"`, `״`, `“`, `”`). The quote is what distinguishes an "about X" phrasing from a genuine work title that merely happens to begin with the word על.

Counts from the dev DB (`lex_citations.subject` + `lex_person_works.title`), 290 rows starting with `על `:

| subject | before | after |
| --- | --- | --- |
| `על "שורשי אויר"` (256 rows) | `על ״על "שורשי אויר"״` | `על "שורשי אויר"` |
| `על "כל השירים" (2009)` (12 rows, quoted + trailing text) | `על ״על "כל השירים" (2009)״` | `על "כל השירים" (2009)` |
| `על הספר` (22 rows, unquoted) | `על ״על הספר״` | unchanged |
| `על חכמות דרכים : שירים` (a real work title) | `על ״על חכמות דרכים : שירים״` | unchanged |

The last two rows are the reason for requiring the quote: `על חכמות דרכים : שירים` is an actual `LexPersonWork` title and does want the wrapper.

## Scope note

`lexicon/citations/index.html.haml` (the editor's citation list) shares `citations_subject_header`, so its headers change identically. That seemed desirable rather than a regression.

## Test plan

- New `#citations_subject_header` specs in `spec/helpers/lexicon_helper_spec.rb`: plain title, blank subject, exact `על "…"`, `על "…"` with trailing text, gershayim quotes, and a work title merely starting with the word על.
- `bundle exec rspec spec/helpers/lexicon_helper_spec.rb` → 60 examples, 0 failures.
- `bundle exec rubocop app/helpers/lexicon_helper.rb spec/helpers/lexicon_helper_spec.rb` → no offenses.
- Full suite not run (40+ min, needs maintainer approval); the change is confined to one helper method covered by the specs above.

bd: by-4jk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
