### PR TITLE
Fix SyntaxError in verification_controller that breaks every spec run on master

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -503,12 +503,18 @@ module Lexicon
         WorkMatchCandidate.new(title: pub.title, publication: pub, collection: pub.volume)
       end
 
-from_volumes = authority.volumes.distinct.includes(:publication).reject { |vol| already_offered.include?(vol.id) }
+      # A volume reachable through a publication of this authority is already offered with it
+      already_offered = from_publications.filter_map { |candidate| candidate.collection&.id }.to_set
+      unoffered_volumes = authority.volumes.distinct.includes(:publication)
+                                   .reject { |vol| already_offered.include?(vol.id) }
+      from_volumes = unoffered_volumes.map do |vol|
         # Only propose the volume's publication when it is this authority's own -- confirming a
         # match rejects any other, and a translated author's volume points at the translator's.
         publication = vol.publication if vol.publication&.authority_id == authority.id
         WorkMatchCandidate.new(title: vol.title, publication: publication, collection: vol)
       end
+
+      from_publications + from_volumes
     end
 
     # Auto-match works to publications and volumes based on title similarity


### PR DESCRIPTION
## The breakage

`master` does not parse. `app/controllers/lexicon/verification_controller.rb` has a `SyntaxError`, so `rails_helper` cannot load and **every** spec run aborts before the first example:

```
While loading ./spec/api/v1/authorities_api_spec.rb a `raise SyntaxError` occurred
  --> app/controllers/lexicon/verification_controller.rb
  Unmatched `end', missing keyword (`do', `def`, `if`, etc.)
```

It arrived with #1627 (02a924fa4); its parent parses fine. `work_match_candidates` was left as:

```ruby
from_volumes = authority.volumes.distinct.includes(:publication).reject { |vol| already_offered.include?(vol.id) }
        # Only propose the volume's publication when it is this authority's own -- ...
        publication = vol.publication if vol.publication&.authority_id == authority.id
        WorkMatchCandidate.new(title: vol.title, publication: publication, collection: vol)
      end
    end
```

Three things went missing from that line: the `already_offered` definition it references, the `.map do |vol|` that opens the block those three lines are the body of, and the method's `from_publications + from_volumes` return value — leaving a stray `end`.

## The fix

Restored the method to what its own comments and the specs from #1627 describe: candidates are built from the authority's publications *and* its volumes, with a volume reachable both ways offered only once.

## Test plan

- `ruby -c app/controllers/lexicon/verification_controller.rb` → Syntax OK (every other tracked `.rb` file already parsed; this was the only one).
- `bundle exec rspec spec/requests/lexicon/verification_auto_matching_spec.rb spec/requests/lexicon/person_works_spec.rb` → 66 examples, 0 failures. These are #1627's own specs, including the volume-without-publication, dedup ("proposes each only once"), and already-matched cases that pin the restored behaviour.
- `bundle exec rspec spec/requests/lexicon/ spec/controllers/lexicon` → 399 examples, 0 failures.
- `bundle exec rubocop app/controllers/lexicon/verification_controller.rb` → no offenses.
- Full suite not run (40+ min, needs maintainer approval) — but note it could not have run at all before this fix.

Merging this unblocks CI on every open PR, including #1628.

bd: by-4au

🤖 Generated with [Claude Code](https://claude.com/claude-code)
