### PR TITLE
Add a 'deletions' editor bit, gate soft-deletion on it, and allow undoing it

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -9,10 +9,21 @@ class ManifestationController < ApplicationController
   include KwicConcordanceConcern
   include PaperTrailHelpers
 
-  before_action only: %i(list show remove_link edit_metadata add_aboutnesses versions version_diff
-                         restore_version preview_link_expression link_expression add_images remove_image
-                         soft_delete) do |c|
+  before_action only: %i(list remove_link edit_metadata add_aboutnesses versions version_diff
+                         restore_version preview_link_expression link_expression add_images
+                         remove_image) do |c|
     c.require_editor('edit_catalog')
+  end
+  # Soft-deleting a text, and undoing that, are gated on their own bit rather than on edit_catalog:
+  # they take a text out of (and back into) public view, which is a heavier act than cataloguing.
+  before_action only: %i(soft_delete undo_soft_delete) do |c|
+    c.require_editor('deletions')
+  end
+  # #show also admits the deletions bit, because it is where both of the above land afterwards and
+  # the only page on which a soft-deleted text is reachable at all -- #read forwards even an editor
+  # to the replacement. The individual editing actions the page links to keep their own checks.
+  before_action only: %i(show) do |c|
+    c.require_editor(%w(edit_catalog deletions))
   end
   before_action only: %i(edit update) do |c|
     c.require_editor(%w(edit_catalog conversion_verification handle_proofs))
@@ -785,6 +796,21 @@ class ManifestationController < ApplicationController
       flash[:notice] = t(:soft_delete_succeeded, id: target_id)
     else
       flash[:alert] = t(:soft_delete_failed, error: result[:error])
+    end
+    redirect_to manifestation_show_path(@m.id)
+  end
+
+  # Undoes a soft-deletion by returning the text to public view. Only the status is restored: the
+  # collection items, anthology texts, taggings, recommendations and external links moved to the
+  # redirect target are indistinguishable from the ones that were already there, so they stay put,
+  # and the text does not rejoin any collection it was removed from.
+  def undo_soft_delete
+    @m = Manifestation.find(params[:id])
+    if @m.deprecated?
+      @m.update!(status: :published)
+      flash[:notice] = t(:undo_soft_delete_succeeded)
+    else
+      flash[:alert] = t(:undo_soft_delete_not_deprecated)
     end
     redirect_to manifestation_show_path(@m.id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   # editor bits
   EDITOR_BITS = %w(handle_proofs handle_recommendations curate_featured_content bib_workshop edit_catalog
                    legacy_metadata edit_people conversion_verification edit_sitenotice
-                   moderate_tags link_moderation batch_editing edit_lexicon).freeze
+                   moderate_tags link_moderation batch_editing edit_lexicon deletions).freeze
 
   def admin?
     admin

--- a/app/views/manifestation/_metadata.html.haml
+++ b/app/views/manifestation/_metadata.html.haml
@@ -20,11 +20,11 @@
       - task_opts = { data: { 'manifestation-id': @m.id } }
       %span.static-btn#originating-task-btn= link_to t(:find_originating_task), '#', task_opts
       %span#originating-task-result
-      -# the modal this opens lives in read.html.haml, which print.html.haml does not render
-      - unless @print
-        != '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'
-        - soft_delete_opts = { data: { toggle: 'modal', target: '#softDeleteDlg' } }
-        %span.static-btn#soft-delete-btn= link_to t(:soft_delete_work), '#', soft_delete_opts
+    -# the modal this opens lives in read.html.haml, which print.html.haml does not render
+    - if current_user.has_bit?(:deletions) && !@print
+      != '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'
+      - soft_delete_opts = { data: { toggle: 'modal', target: '#softDeleteDlg' } }
+      %span.static-btn#soft-delete-btn= link_to t(:soft_delete_work), '#', soft_delete_opts
     != "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
     %span.impressions-count #{number_with_delimiter(@m.impressions_count, delimiter: ',')} #{t(:impressions_count)}
     %br

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -242,7 +242,7 @@
   = render partial: 'bookmark_delete'
 #tagPolicyDlg.modal{'aria-hidden' => 'true', role: 'dialog', tabindex: '-1'}
   = render partial: 'tag_policy', locals: { taggable: @m }
-- if current_user&.has_bit?(:edit_catalog)
+- if current_user&.has_bit?(:deletions)
   .modal#softDeleteDlg{ 'aria-hidden' => 'true', role: 'dialog', tabindex: '-1' }
     = render partial: 'soft_delete_modal', locals: { manifestation: @m }
 -# chapter popup

--- a/app/views/manifestation/show.html.haml
+++ b/app/views/manifestation/show.html.haml
@@ -5,17 +5,28 @@
     %b= link_to t(:edit_markdown), manifestation_edit_path(@m.id)
   %p
     %b= link_to t(:render), url_for(action: :read, id: @m.id)
-  %p
-    -# an href-less <a> is caught by Bootstrap's `a:not([href]):not([tabindex]) { color: inherit }`,
-    -# which outranks the site's `a { color: #660248 }` and renders it black, unlike its siblings above
-    %b= link_to t(:soft_delete_work), '#', data: { toggle: 'modal', target: '#softDeleteDlg' }
+  -#
+    A soft-deleted text is offered the undo instead of a second soft-deletion: this page is the
+    only place an editor can still see it, since #read forwards even editors to the replacement.
+  - may_delete = current_user&.has_bit?(:deletions)
+  - if may_delete && @m.deprecated?
+    %p
+      - undo_opts = { method: :post, id: 'undo-soft-delete-btn',
+                      data: { confirm: t(:undo_soft_delete_confirm) } }
+      %b= link_to t(:undo_soft_delete), manifestation_undo_soft_delete_path(@m.id), undo_opts
+  - elsif may_delete
+    %p
+      -# an href-less <a> is caught by Bootstrap's `a:not([href]):not([tabindex]) { color: inherit }`,
+      -# which outranks the site's `a { color: #660248 }` and renders it black, unlike its siblings above
+      %b= link_to t(:soft_delete_work), '#', data: { toggle: 'modal', target: '#softDeleteDlg' }
   - if @m.deprecated?
     %p.alert.alert-warning#soft-delete-status
       = t(:soft_delete_status_deprecated)
       - if @m.soft_redirect_target.present?
         = link_to @m.soft_redirect_target.title_and_authors, manifestation_show_path(@m.soft_redirect)
-  .modal#softDeleteDlg{ 'aria-hidden' => 'true', role: 'dialog', tabindex: '-1' }
-    = render partial: 'soft_delete_modal', locals: { manifestation: @m }
+  - elsif may_delete
+    .modal#softDeleteDlg{ 'aria-hidden' => 'true', role: 'dialog', tabindex: '-1' }
+      = render partial: 'soft_delete_modal', locals: { manifestation: @m }
   %h1
     != "#{t(:work_details)}: #{@m.title} / #{linkify_people(@w.involved_authorities.map(&:authority))}"
     - if @e.translation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1109,6 +1109,12 @@ en:
   soft_delete_target_not_published: The chosen work is not published, so readers sent to it would
     not be able to see it. Please choose a published work.
   soft_delete_status_deprecated: 'This work has been soft-deleted. It redirects to: '
+  undo_soft_delete: Undo the soft-deletion
+  undo_soft_delete_confirm: Undo the soft-deletion and return this work to public view?
+  undo_soft_delete_succeeded: Soft-deletion undone, and the work is published again. Note that tags,
+    recommendations, links and collection items moved to the other work were not moved back, and
+    the work does not rejoin the collections it was removed from.
+  undo_soft_delete_not_deprecated: This work is not soft-deleted.
   error_loading_preview: Error loading preview
   involved_authorities_label: Involved Authorities
   additional_warning_explanation: 'Here is a note from the editor who identified the
@@ -2594,6 +2600,7 @@ en:
   link_moderation: Link Moderation
   edit_lexicon: Edit Lexicon
   batch_editing: Batch Editing
+  deletions: Deletions
   link_type: Link Type
   linked_author: Linked Author
   linked_taggings: Linked Taggings

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -680,6 +680,11 @@ he:
   soft_delete_target_not_published: היצירה שנבחרה אינה מפורסמת, ולכן קוראים שיופנו אליה לא יוכלו
     לראות אותה. אנא בחרו יצירה מפורסמת.
   soft_delete_status_deprecated: 'היצירה הזאת נמחקה מחיקה רכה. היא מפנה אל: '
+  undo_soft_delete: ביטול המחיקה הרכה
+  undo_soft_delete_confirm: לבטל את המחיקה הרכה ולהחזיר את היצירה לתצוגה פומבית?
+  undo_soft_delete_succeeded: המחיקה הרכה בוטלה והיצירה שבה להיות מפורסמת. שימו לב שתיוגים, המלצות,
+    קישורים ופריטי אוספים שהועברו ליצירה האחרת לא הוחזרו, והיצירה אינה שבה אל האוספים שהוסרה מהם.
+  undo_soft_delete_not_deprecated: היצירה הזאת אינה מחוקה מחיקה רכה.
   error_loading_preview: שגיאה בטעינת הפרטים
   involved_authorities_label: יוצרים מעורבים
   mistake_important: חשוב לנו שהטקסט יהא מדויק וחף משגיאות
@@ -946,6 +951,7 @@ he:
   link_moderation: ניטור קישוריות מהציבור
   edit_lexicon: עריכת הלקסיקון
   batch_editing: עריכה באצווה
+  deletions: מחיקות
   next_milestone: היעד הבא
   my_activity: הפעילות שלי
   similar_to_x: "דומה לפריט: %{x}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,8 @@ Bybeconv::Application.routes.draw do
   post 'manifestation/link_expression/:id' => 'manifestation#link_expression',
        as: 'manifestation_link_expression'
   post 'manifestation/soft_delete/:id' => 'manifestation#soft_delete', as: 'manifestation_soft_delete'
+  post 'manifestation/undo_soft_delete/:id' => 'manifestation#undo_soft_delete',
+       as: 'manifestation_undo_soft_delete'
   match 'manifestation/list', via: %i(get post)
   get 'manifestation/genre' => 'manifestation#genre', as: 'manifestation_genre'
   get 'manifestation/index', as: 'manifestation_index'

--- a/spec/controllers/manifestation_controller_soft_delete_spec.rb
+++ b/spec/controllers/manifestation_controller_soft_delete_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe ManifestationController do
-  let(:editor) { create(:user, :edit_catalog) }
+  let(:editor) { create(:user, :deletions) }
   let(:manifestation) { create(:manifestation) }
   let(:target) { create(:manifestation) }
 
@@ -83,7 +83,7 @@ describe ManifestationController do
       end
     end
 
-    context 'when the user is not an edit_catalog editor' do
+    context 'when nobody is logged in' do
       before { session.delete(:user_id) }
 
       it 'refuses and leaves the manifestation published' do
@@ -93,12 +93,84 @@ describe ManifestationController do
       end
     end
 
-    context 'when the user is an editor without the edit_catalog bit' do
+    context 'when the user is an editor without the deletions bit' do
       let(:editor) { create(:user, editor: true) }
 
       it 'refuses' do
         perform
         expect(manifestation.reload).to be_published
+      end
+    end
+
+    context 'when the user is an edit_catalog editor without the deletions bit' do
+      let(:editor) { create(:user, :edit_catalog) }
+
+      it 'refuses' do
+        perform
+        expect(response).to redirect_to('/')
+        expect(manifestation.reload).to be_published
+      end
+    end
+  end
+
+  describe '#undo_soft_delete' do
+    subject(:perform) { post :undo_soft_delete, params: { id: manifestation.id } }
+
+    let(:tagging) { create(:tagging, taggable: manifestation) }
+
+    before do
+      session[:user_id] = editor.id
+      tagging # referenced here so that it exists before the soft-deletion, which moves it
+      SoftDeleteManifestation.call(manifestation, target)
+    end
+
+    it 'republishes the manifestation and redirects back to its show page' do
+      perform
+      expect(response).to redirect_to(manifestation_show_path(manifestation.id))
+      expect(flash[:notice]).to eq(I18n.t(:undo_soft_delete_succeeded))
+      expect(manifestation.reload).to be_published
+    end
+
+    it 'stops redirecting readers to the former target' do
+      perform
+      get :read, params: { id: manifestation.id }
+      expect(response).to be_successful
+    end
+
+    # The moved associations cannot be told apart from ones the target already had, so undoing
+    # restores visibility only -- see the note on ManifestationController#undo_soft_delete.
+    it 'leaves the tagging the soft-deletion moved on the target' do
+      expect(tagging.reload.taggable).to eq(target)
+      perform
+      expect(tagging.reload.taggable).to eq(target)
+    end
+
+    context 'when the manifestation was not soft-deleted' do
+      before { manifestation.update!(status: :published) }
+
+      it 'refuses and says so' do
+        perform
+        expect(flash[:alert]).to eq(I18n.t(:undo_soft_delete_not_deprecated))
+        expect(manifestation.reload).to be_published
+      end
+    end
+
+    context 'when the manifestation is unpublished rather than soft-deleted' do
+      before { manifestation.update!(status: :unpublished) }
+
+      it 'does not publish it' do
+        perform
+        expect(manifestation.reload).to be_unpublished
+      end
+    end
+
+    context 'when the user is an editor without the deletions bit' do
+      let(:editor) { create(:user, editor: true) }
+
+      it 'refuses and leaves the manifestation soft-deleted' do
+        perform
+        expect(response).to redirect_to('/')
+        expect(manifestation.reload).to be_deprecated
       end
     end
   end

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -374,6 +374,20 @@ describe ManifestationController do
       end
 
       it { is_expected.to be_successful }
+
+      # The page carries the soft-delete and undo-soft-delete buttons, so the deletions bit gets in
+      # too -- a soft-deleted text is reachable on no other page.
+      context 'when the editor holds only the deletions bit' do
+        let!(:user) { create(:user, :deletions) }
+
+        it { is_expected.to be_successful }
+      end
+
+      context 'when the editor holds neither bit' do
+        let!(:user) { create(:user, editor: true) }
+
+        it { is_expected.to redirect_to('/') }
+      end
     end
 
     describe '#read' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,6 +19,13 @@ FactoryBot.define do
         create(:list_item, item: user, listkey: 'bib_workshop')
       end
     end
+    trait :deletions do
+      editor { true }
+      after :create do |user|
+        create(:list_item, item: user, listkey: 'deletions')
+      end
+    end
+
     trait :admin do
       admin { true }
     end

--- a/spec/system/manifestation_soft_delete_spec.rb
+++ b/spec/system/manifestation_soft_delete_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 describe 'Soft-deleting a Manifestation', :js, type: :system do
-  let(:editor) { create(:user, :edit_catalog) }
+  let(:editor) { create(:user, :deletions) }
   let(:plain_editor) { create(:user, editor: true) }
+  let(:catalog_editor) { create(:user, :edit_catalog) }
   let!(:manifestation) { create(:manifestation) }
   let!(:target) { create(:manifestation) }
 
@@ -12,7 +13,7 @@ describe 'Soft-deleting a Manifestation', :js, type: :system do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
   end
 
-  context 'when an edit_catalog editor is reading the work' do
+  context 'when an editor holding the deletions bit is reading the work' do
     before do
       login_as(editor)
       visit manifestation_path(id: manifestation.id)
@@ -87,11 +88,21 @@ describe 'Soft-deleting a Manifestation', :js, type: :system do
     end
   end
 
-  context 'when an editor lacks the edit_catalog bit' do
+  context 'when an editor lacks the deletions bit' do
     it 'does not offer the button' do
       login_as(plain_editor)
       visit manifestation_path(id: manifestation.id)
       expect(page).to have_content(manifestation.title)
+      expect(page).to have_no_css('#soft-delete-btn')
+    end
+  end
+
+  # edit_catalog used to be what gated this, so it is worth pinning down that it no longer does.
+  context 'when an editor has edit_catalog but not the deletions bit' do
+    it 'offers the other editor actions but not this one' do
+      login_as(catalog_editor)
+      visit manifestation_path(id: manifestation.id)
+      expect(page).to have_css('#originating-task-btn')
       expect(page).to have_no_css('#soft-delete-btn')
     end
   end
@@ -101,6 +112,43 @@ describe 'Soft-deleting a Manifestation', :js, type: :system do
       visit manifestation_path(id: manifestation.id)
       expect(page).to have_content(manifestation.title)
       expect(page).to have_no_css('#soft-delete-btn')
+    end
+  end
+
+  describe 'undoing a soft-deletion from the backend show page' do
+    # #show is gated on edit_catalog, and the undo button on the deletions bit, so an editor has to
+    # hold both to use it -- and a soft-deleted work has no other page an editor can reach it on,
+    # since #read forwards even editors to the replacement.
+    let(:deleter) { create(:user, :edit_catalog, :deletions) }
+
+    before { SoftDeleteManifestation.call(manifestation, target) }
+
+    it 'republishes the work and stops redirecting readers away from it' do
+      login_as(deleter)
+      visit manifestation_show_path(manifestation.id)
+      expect(page).to have_css('#soft-delete-status')
+      accept_confirm { find('#undo-soft-delete-btn').click }
+
+      expect(page).to have_content(I18n.t(:undo_soft_delete_succeeded))
+      expect(manifestation.reload).to be_published
+
+      visit manifestation_path(id: manifestation.id)
+      expect(page).to have_current_path(manifestation_path(id: manifestation.id))
+      expect(page).to have_content(manifestation.title)
+    end
+
+    it 'is not offered to an editor without the deletions bit' do
+      login_as(catalog_editor)
+      visit manifestation_show_path(manifestation.id)
+      expect(page).to have_css('#soft-delete-status')
+      expect(page).to have_no_css('#undo-soft-delete-btn')
+    end
+
+    it 'is not offered on a work that is not soft-deleted' do
+      login_as(deleter)
+      visit manifestation_show_path(target.id)
+      expect(page).to have_link(I18n.t(:soft_delete_work))
+      expect(page).to have_no_css('#undo-soft-delete-btn')
     end
   end
 end

--- a/spec/system/manifestation_soft_delete_spec.rb
+++ b/spec/system/manifestation_soft_delete_spec.rb
@@ -116,9 +116,9 @@ describe 'Soft-deleting a Manifestation', :js, type: :system do
   end
 
   describe 'undoing a soft-deletion from the backend show page' do
-    # #show is gated on edit_catalog, and the undo button on the deletions bit, so an editor has to
-    # hold both to use it -- and a soft-deleted work has no other page an editor can reach it on,
-    # since #read forwards even editors to the replacement.
+    # #show is reachable to editors holding either edit_catalog or deletions (so a deletions-only editor can
+    # reach the undo button). A soft-deleted work has no other page an editor can reach it on, since
+    # #read forwards even editors to the replacement.
     let(:deleter) { create(:user, :edit_catalog, :deletions) }
 
     before { SoftDeleteManifestation.call(manifestation, target) }


### PR DESCRIPTION
## What

1. **New editor bit `deletions`** (`User::EDITOR_BITS`), with `he`/`en` labels so it shows up in the
   user-list bit-granting UI automatically.
2. **Soft-deletion is now gated on that bit** instead of `edit_catalog`: `ManifestationController#soft_delete`,
   the button in the reading page's metadata area, the button on the backend `#show` page, and the
   dialog partial on both.
3. **`#show` of a soft-deleted work offers an UNDO button** next to the other editor actions. It flips
   `status` back to `published` and nothing else.

## Why `#show` also admits the `deletions` bit

`#soft_delete` redirects to `manifestation#show` afterwards, and `#show` is the only page a soft-deleted
work is reachable on at all — `#read` forwards even an editor to the replacement. A `deletions`-only
editor who could not reach `#show` would be bounced to `/` right after soft-deleting, and could never
reach the undo button. So `#show` is gated on `edit_catalog` **or** `deletions`; the editing actions
that page links to (`edit_metadata`, `versions`, `add_images`, …) keep their own `edit_catalog` checks.

## What undo does *not* do

Per the issue: the collection items, anthology texts, taggings, recommendations and external links that
`SoftDeleteManifestation` moved to the redirect target are indistinguishable from ones the target
already had, so they are **not** moved back, and the work does **not** rejoin any collection it was
removed from. Only the status — and therefore public visibility — changes. The flash message says so.
The stale `soft_redirect` column value is left in place; it is only ever read while `deprecated?`, so
it is inert on a republished work and gets overwritten by any later soft-deletion.

The soft-delete and undo buttons are mutually exclusive on `#show`: re-soft-deleting an already
soft-deleted work is meaningless.

## Test plan

- `spec/controllers/manifestation_controller_soft_delete_spec.rb` — existing `#soft_delete` cases moved
  to the `deletions` bit, plus a new case pinning down that `edit_catalog` alone is now refused; new
  `#undo_soft_delete` group covering the happy path, that `#read` stops redirecting afterwards, that a
  moved tagging stays on the target, that an `unpublished` (not `deprecated`) work is not published by
  it, and that the bit is required.
- `spec/controllers/manifestations_controller_spec.rb` — `#show` admits a `deletions`-only editor and
  still refuses an editor holding neither bit.
- `spec/system/manifestation_soft_delete_spec.rb` — retargeted to the new bit, plus a case that an
  `edit_catalog`-only editor sees the other editor buttons but not this one, and a new group driving
  the undo button through the browser (republishes, stops redirecting, hidden without the bit, absent
  on a live work).

Ran: those three files plus `spec/services/soft_delete_manifestation_spec.rb`, `spec/models/manifestation_spec.rb`,
`spec/models/user_spec.rb` (277 examples, 0 failures) and `spec/requests` excluding `lexicon/`
(197 examples, 0 failures). RuboCop and haml-lint on every changed file are at their pre-change baselines.

**The full suite was not run** — it takes 40+ minutes and needs the maintainer's go-ahead.

## Unrelated breakage found

`app/controllers/lexicon/verification_controller.rb` has a **Ruby syntax error on master** (line 601,
`unexpected 'end'`), which fails ~19 examples across `spec/requests/lexicon/verification*_spec.rb`.
Reproduces from `git show master:…` — untouched by this branch. Filed separately as a P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
