### PR TITLE
Bring the Authority TOC's lexicon block in line with LexEntry#show

### DIFF
--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -197,6 +197,36 @@ module LexiconHelper
     raw pairs.join(' | ') if pairs.any?
   end
 
+  # Which of an entry's lexicon sections actually have content, in display order.
+  #
+  # A section with nothing in it is omitted entirely rather than shown as an empty card, so the
+  # cards and the navbar lines that scroll to them must agree on what "empty" means. Four views
+  # share this: the entry page and its navbar (lexicon/entries/_show_person, _show_publication,
+  # _navbar) and the Authority TOC and its navbar (authors/_generated_toc, shared/_newtoc_navbar).
+  #
+  # Insertion order is the display order, so `.keys.first` is the topmost visible section --
+  # which is what the navbars mark active and scroll to by default.
+  def lexicon_sections_present(lex_item, lex_entry)
+    if lex_item.is_a?(LexPerson)
+      { biography: lex_item.bio.present?,
+        works: lex_item.works.any?,
+        about: lex_item.citations.any?,
+        links: lex_item.links.any?,
+        authority_control: render_external_identifiers(lex_entry.external_identifiers).present? }
+    else
+      { description: lex_item.description.present?,
+        toc: lex_item.toc.present?,
+        links: lex_item.links.any? }
+    end.select { |_section, present| present }
+  end
+
+  # Attributes for one link in the lexicon entry navbar. Sections are omitted when empty, so
+  # which one starts out active depends on the entry: it is whichever is shown first.
+  def lexicon_nav_link_attributes(section, first_section)
+    active = section == first_section
+    { class: ('active' if active), 'aria-selected' => active.to_s, href: '#' }
+  end
+
   # Returns bio text with any <img> tag whose src contains the profile image filename removed.
   # Call this before passing bio to MarkdownToHtml to avoid showing the profile image twice.
   def bio_for_display(bio_text, lex_entry)

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -21,39 +21,58 @@
                          authority_id: @author.id,
                          editable: false,
                          nonce: role }
-  - if @lexicon_entry.present?
-    - lex_person = @lexicon_entry.lex_item # TODO: generalize for other lex_item types
+  - lex_person = @lexicon_entry&.lex_item # TODO: generalize for other lex_item types
+  -# empty sections are omitted entirely, here and in the navbar that scrolls to them; with
+     every section empty there is no lexicon content to introduce, so the heading goes too
+  - lexicon_sections = lex_person ? lexicon_sections_present(lex_person, @lexicon_entry) : {}
+  - if lexicon_sections.any?
     .headline-books
       = t('lexicon.header.title')
       .lexicon-logo
       = image_tag 'osu-logo.jpg', class: 'osu-partner-logo', alt: 'OSU'
     .peach2-lexicon
-      .by-card-v02
-        #lexicon-bio
-        .by-card-content-v02
-          -# a div, not a p: see lexicon/entries/_show_person
-          #lexicon-biography!= MarkdownToHtml.call(lex_person.bio)
-      #lexicon-works
-        = render layout: 'lexicon/block', locals: { title: LexPerson.human_attribute_name(:works) } do
-          - LexPersonWork.work_types.each_key do |work_type|
-            - works_of_type = lex_person.works.select { |work| work.work_type == work_type }
-            - next if works_of_type.empty?
+      -# anchor for the navbar's lexicon group: kept outside the biography card so that it still
+         marks the top of the lexicon block when the entry has no biography
+      #lexicon-bio
+      - if lexicon_sections[:biography]
+        .by-card-v02
+          .by-card-content-v02
+            -# a div, not a p: see lexicon/entries/_show_person.
+               NOT bio_for_display: that strips the entry's portrait from the bio text because
+               LexEntry#show renders it separately in .lexicon-author-details. This view has no
+               such block, so the inline <img> is the only copy of the portrait and must stay.
+            #lexicon-biography!= MarkdownToHtml.call(lex_person.bio)
+      - if lexicon_sections[:works]
+        #lexicon-works
+          = render layout: 'lexicon/block', locals: { title: LexPerson.human_attribute_name(:works) } do
+            - LexPersonWork.work_types.each_key do |work_type|
+              - works_of_type = lex_person.works.select { |work| work.work_type == work_type }
+              - next if works_of_type.empty?
 
-            - if work_type != 'original'
-              %h4= LexPersonWork.human_enum_name(:work_type, work_type)
-            %ul
-              - works_of_type.sort_by(&:seqno).each do |work|
-                %li!= render_person_work(work)
-      #lexicon-about
-        = render layout: 'lexicon/block', locals: { title: t('activerecord.attributes.lex_person.about', gender_suffix: lex_person.female? ? 'ת' : '', gender_letter: lex_person.gender_letter) } do
-          - lex_person.citations.group_by(&:subject).each do |subject, list|
-            %h4= subject
-            %ul
-              - list.each do |c|
-                - cit_text = render_citation(c)
-                %li{style: cit_text.gsub('עמ\'','').any_hebrew? ? "" : "direction: ltr;"}= cit_text
-      #lexicon-links
-        = render partial: 'lexicon/entries/links', locals: { links: lex_person.links }
+              - if work_type != 'original'
+                %h4= LexPersonWork.human_enum_name(:work_type, work_type)
+              %ul
+                - works_of_type.sort_by(&:seqno).each do |work|
+                  %li!= render_person_work(work)
+      - if lexicon_sections[:about]
+        #lexicon-about
+          = render layout: 'lexicon/block', locals: { title: t('activerecord.attributes.lex_person.about', gender_suffix: lex_person.female? ? 'ת' : '', gender_letter: lex_person.gender_letter) } do
+            - grouped_and_ordered_citations(lex_person).each do |subject, list|
+              - if subject.present?
+                %h4= citations_subject_header(subject)
+              %ul
+                - list.each do |c|
+                  - cit_text = render_citation(c)
+                  %li{style: cit_text.gsub('עמ\'','').any_hebrew? ? "" : "direction: ltr;"}= cit_text
+      - if lexicon_sections[:links]
+        #lexicon-links
+          = render partial: 'lexicon/entries/links', locals: { links: lex_person.links }
+      - if lexicon_sections[:authority_control]
+        #lexicon-authority-control
+          = render layout: 'lexicon/block', locals: { title: t('lexicon.entries.show_person.authority_identifiers') } do
+            .lexicon-authority-identifiers
+              = render_external_identifiers(@lexicon_entry.external_identifiers)
+      = render partial: 'lexicon/entries/last_updated', locals: { lex_entry: @lexicon_entry }
 
   .by-card-v02#text-volunteers-desktop
     .by-card-header-v02

--- a/app/views/lexicon/entries/_last_updated.html.haml
+++ b/app/views/lexicon/entries/_last_updated.html.haml
@@ -1,0 +1,7 @@
+-# only the date ingested from the legacy PHP file counts as a manual update
+  (the migration itself does not), so show nothing when it is absent
+- if lex_entry.date_of_manual_update.present?
+  -# empty paragraph: spacing between the last card and the line below it
+  %p
+  .lexicon-last-updated
+    = t('lexicon.entries.show.last_updated', date: lex_entry.date_of_manual_update)

--- a/app/views/lexicon/entries/_navbar.html.haml
+++ b/app/views/lexicon/entries/_navbar.html.haml
@@ -2,47 +2,57 @@
 
 - lex_item = @lex_entry.lex_item
 - is_person = lex_item.is_a?(LexPerson)
+-# a section with no content is not rendered, so it gets no line here either
+- sections = lexicon_sections_present(lex_item, @lex_entry)
+- first_section = sections.keys.first
 
 %nav.navbar#genrenav
   %ul.navbar-nav.flex-column.by-card-v02#genre-nav{ 'aria-orientation' => 'vertical' }
     - if is_person
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-biography' }
-        %a.nav-link.active#translations_button{ 'aria-selected' => 'true', href: '#' }
-          .side-menu-icon
-          .side-menu-name= t('lexicon.verification.sections.biography')
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-works' }
-        %a.nav-link#works_button{ 'aria-selected' => 'false', href: '#' }
-          .side-menu-icon
-          .side-menu-name= t('lexicon.verification.sections.works_section')
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-about' }
-        - about_title = t('activerecord.attributes.lex_person.about',
-                          gender_suffix: lex_item.female? ? 'ת' : '',
-                          gender_letter: lex_item.gender_letter)
-        %a.nav-link#about_author_button{ 'aria-selected' => 'false', href: '#' }
-          .side-menu-icon
-          .side-menu-name= about_title
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-links' }
-        %a.nav-link#links_button{ 'aria-selected' => 'false', href: '#' }
-          .side-menu-icon
-          .side-menu-name= t('lexicon.verification.sections.links_section')
-      - if @lex_entry.external_identifiers.present?
+      - if sections[:biography]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-biography' }
+          %a.nav-link#translations_button{ lexicon_nav_link_attributes(:biography, first_section) }
+            .side-menu-icon
+            .side-menu-name= t('lexicon.verification.sections.biography')
+      - if sections[:works]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-works' }
+          %a.nav-link#works_button{ lexicon_nav_link_attributes(:works, first_section) }
+            .side-menu-icon
+            .side-menu-name= t('lexicon.verification.sections.works_section')
+      - if sections[:about]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-about' }
+          - about_title = t('activerecord.attributes.lex_person.about',
+                            gender_suffix: lex_item.female? ? 'ת' : '',
+                            gender_letter: lex_item.gender_letter)
+          %a.nav-link#about_author_button{ lexicon_nav_link_attributes(:about, first_section) }
+            .side-menu-icon
+            .side-menu-name= about_title
+      - if sections[:links]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-links' }
+          %a.nav-link#links_button{ lexicon_nav_link_attributes(:links, first_section) }
+            .side-menu-icon
+            .side-menu-name= t('lexicon.verification.sections.links_section')
+      - if sections[:authority_control]
         %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-authority-control' }
-          %a.nav-link#authority_control_button{ 'aria-selected' => 'false', href: '#' }
+          %a.nav-link#authority_control_button{ lexicon_nav_link_attributes(:authority_control, first_section) }
             .side-menu-icon
             .side-menu-name= t('lexicon.verification.sections.authority_control_section')
     - else
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-description' }
-        %a.nav-link.active{ 'aria-selected' => 'true', href: '#' }
-          .side-menu-icon
-          .side-menu-name= t('lexicon.verification.sections.description_section')
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-toc' }
-        %a.nav-link{ 'aria-selected' => 'false', href: '#' }
-          .side-menu-icon
-          .side-menu-name= t('lexicon.verification.sections.toc_section')
-      %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-links' }
-        %a.nav-link{ 'aria-selected' => 'false', href: '#' }
-          .side-menu-icon
-          .side-menu-name= t('lexicon.verification.sections.links_section')
+      - if sections[:description]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-description' }
+          %a.nav-link{ lexicon_nav_link_attributes(:description, first_section) }
+            .side-menu-icon
+            .side-menu-name= t('lexicon.verification.sections.description_section')
+      - if sections[:toc]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-toc' }
+          %a.nav-link{ lexicon_nav_link_attributes(:toc, first_section) }
+            .side-menu-icon
+            .side-menu-name= t('lexicon.verification.sections.toc_section')
+      - if sections[:links]
+        %li.nav-item.pointer{ 'data-scroll-target' => '#lexicon-links' }
+          %a.nav-link{ lexicon_nav_link_attributes(:links, first_section) }
+            .side-menu-icon
+            .side-menu-name= t('lexicon.verification.sections.links_section')
 
 
 :javascript

--- a/app/views/lexicon/entries/_show_person.html.haml
+++ b/app/views/lexicon/entries/_show_person.html.haml
@@ -6,6 +6,8 @@
       .col.side-menu-area
         = render partial: 'navbar'
       .col
+        -# empty sections are omitted entirely, here and in the navbar that scrolls to them
+        - sections = lexicon_sections_present(lex_person, @lex_entry)
         = render layout: 'lexicon/header' do
           .lexicon-author-details
             - if @lex_entry.profile_image.present?
@@ -25,36 +27,40 @@
           -#
             a div, not a p: the bio is multi-paragraph HTML, and a <p> wrapper would be
             auto-closed by the parser, leaving the paragraphs outside #lexicon-biography
-          #lexicon-biography!= MarkdownToHtml.call(bio_for_display(lex_person.bio, @lex_entry))
-        #lexicon-works
-          = render layout: 'lexicon/block', locals: { title: LexPerson.human_attribute_name(:works) } do
-            - LexPersonWork.work_types.each_key do |work_type|
-              - works_of_type = lex_person.works.select { |work| work.work_type == work_type }
-              - next if works_of_type.empty?
+          - if sections[:biography]
+            #lexicon-biography!= MarkdownToHtml.call(bio_for_display(lex_person.bio, @lex_entry))
+        - if sections[:works]
+          #lexicon-works
+            = render layout: 'lexicon/block', locals: { title: LexPerson.human_attribute_name(:works) } do
+              - LexPersonWork.work_types.each_key do |work_type|
+                - works_of_type = lex_person.works.select { |work| work.work_type == work_type }
+                - next if works_of_type.empty?
 
-              - if work_type != 'original'
-                %h4= LexPersonWork.human_enum_name(:work_type, work_type)
-              %ul
-                - works_of_type.sort_by(&:seqno).each do |work|
-                  %li!= render_person_work(work)
+                - if work_type != 'original'
+                  %h4= LexPersonWork.human_enum_name(:work_type, work_type)
+                %ul
+                  - works_of_type.sort_by(&:seqno).each do |work|
+                    %li!= render_person_work(work)
 
-        #lexicon-about
-          = render layout: 'lexicon/block', locals: { title: t('activerecord.attributes.lex_person.about', gender_suffix: lex_person.female? ? 'ת' : '', gender_letter: lex_person.gender_letter) } do
-            - grouped_and_ordered_citations(lex_person).each do |subject, list|
-              - if subject.present?
-                %h4= citations_subject_header(subject)
-              %ul
-                - list.each do |c|
-                  - cit_text = render_citation(c)
-                  %li{style: cit_text.gsub('עמ\'','').any_hebrew? ? "" : "direction: ltr;"}= cit_text
-        #lexicon-links
-          = render partial: 'links', locals: { links: lex_person.links }
-        - identifier_html = render_external_identifiers(@lex_entry.external_identifiers)
-        - if identifier_html
+        - if sections[:about]
+          #lexicon-about
+            = render layout: 'lexicon/block', locals: { title: t('activerecord.attributes.lex_person.about', gender_suffix: lex_person.female? ? 'ת' : '', gender_letter: lex_person.gender_letter) } do
+              - grouped_and_ordered_citations(lex_person).each do |subject, list|
+                - if subject.present?
+                  %h4= citations_subject_header(subject)
+                %ul
+                  - list.each do |c|
+                    - cit_text = render_citation(c)
+                    %li{style: cit_text.gsub('עמ\'','').any_hebrew? ? "" : "direction: ltr;"}= cit_text
+        - if sections[:links]
+          #lexicon-links
+            = render partial: 'links', locals: { links: lex_person.links }
+        - if sections[:authority_control]
           #lexicon-authority-control
             = render layout: 'lexicon/block', locals: { title: t('lexicon.entries.show_person.authority_identifiers') } do
               .lexicon-authority-identifiers
-                = identifier_html
+                = render_external_identifiers(@lex_entry.external_identifiers)
+        = render partial: 'last_updated', locals: { lex_entry: @lex_entry }
 
   .col-12.col-lg-4
     .row

--- a/app/views/lexicon/entries/_show_publication.html.haml
+++ b/app/views/lexicon/entries/_show_publication.html.haml
@@ -4,13 +4,19 @@
       .col.side-menu-area
         = render partial: 'navbar'
       .col
-        #lexicon-description
-          = render layout: 'lexicon/block', locals: { title: LexPublication.human_attribute_name(:description) } do
-            != MarkdownToHtml.call(lex_publication.description)
-        #lexicon-toc
-          = render layout: 'lexicon/block', locals: { title: LexPublication.human_attribute_name(:toc) } do
-            != MarkdownToHtml.call(lex_publication.toc)
-        #lexicon-links
-          = render partial: 'links', locals: { links: lex_publication.links }
+        -# empty sections are omitted entirely, here and in the navbar that scrolls to them
+        - sections = lexicon_sections_present(lex_publication, @lex_entry)
+        - if sections[:description]
+          #lexicon-description
+            = render layout: 'lexicon/block', locals: { title: LexPublication.human_attribute_name(:description) } do
+              != MarkdownToHtml.call(lex_publication.description)
+        - if sections[:toc]
+          #lexicon-toc
+            = render layout: 'lexicon/block', locals: { title: LexPublication.human_attribute_name(:toc) } do
+              != MarkdownToHtml.call(lex_publication.toc)
+        - if sections[:links]
+          #lexicon-links
+            = render partial: 'links', locals: { links: lex_publication.links }
+        = render partial: 'last_updated', locals: { lex_entry: @lex_entry }
   .col-12.col-lg-4
     = render partial: 'lexicon/shared/images', locals: { entry: lex_publication.entry }

--- a/app/views/lexicon/entries/show.html.haml
+++ b/app/views/lexicon/entries/show.html.haml
@@ -4,11 +4,6 @@
     = render partial: 'show_person', locals: { lex_person: lex_item }
   - elsif lex_item.is_a?(LexPublication)
     = render partial: 'show_publication', locals: { lex_publication: lex_item }
-  -# only the date ingested from the legacy PHP file counts as a manual update
-    (the migration itself does not), so show nothing when it is absent
-  - if @lex_entry.date_of_manual_update.present?
-    .lexicon-last-updated
-      = t('lexicon.entries.show.last_updated', date: @lex_entry.date_of_manual_update)
 
 -# found mistake popup
 = render partial: 'shared/proof'

--- a/app/views/shared/_newtoc_navbar.html.haml
+++ b/app/views/shared/_newtoc_navbar.html.haml
@@ -1,5 +1,7 @@
 - top_nodes = @toc_tree ? @toc_tree.top_level_nodes : GenerateTocTree.call(@author).top_level_nodes
 - first = true
+-# a lexicon section with no content is not rendered, so it gets no line here either
+- lexicon_sections = @lexicon_entry ? lexicon_sections_present(@lexicon_entry.lex_item, @lexicon_entry) : {}
 
 -# Calculate visibility for all roles upfront to share between full and thin navbars
 :ruby
@@ -117,17 +119,26 @@
       .truncate= t(:external_links)
     .book-type
       .truncate= t(:recommendations_for_work)
-  - if @lexicon_entry.present?
+  - if lexicon_sections.any?
     .nav-book-group.lexicon-background-color{ 'data-scroll-target' => '#lexicon-bio' }
       .headline-2-v02= t(:lexicon_content)
-      .book-type.pointer
-        .truncate{ 'data-scroll-target' => '#lexicon-bio' }= t('lexicon.verification.sections.biography')
-      .book-type.pointer
-        .truncate{ 'data-scroll-target' => '#lexicon-works' }= t('lexicon.verification.sections.works_section')
-      .book-type.pointer
-        .truncate{ 'data-scroll-target' => '#lexicon-about' }= t('activerecord.attributes.lex_person.about', gender_suffix: @author.person.female? ? 'ת' : '', gender_letter: @author.gender_letter)
-      .book-type.pointer
-        .truncate{ 'data-scroll-target' => '#lexicon-links' }= t('lexicon.verification.sections.links_section')
+      - if lexicon_sections[:biography]
+        .book-type.pointer
+          .truncate{ 'data-scroll-target' => '#lexicon-bio' }= t('lexicon.verification.sections.biography')
+      - if lexicon_sections[:works]
+        .book-type.pointer
+          .truncate{ 'data-scroll-target' => '#lexicon-works' }= t('lexicon.verification.sections.works_section')
+      - if lexicon_sections[:about]
+        - about_label = t('activerecord.attributes.lex_person.about', gender_suffix: @author.person.female? ? 'ת' : '', gender_letter: @author.gender_letter)
+        .book-type.pointer
+          .truncate{ 'data-scroll-target' => '#lexicon-about' }= about_label
+      - if lexicon_sections[:links]
+        .book-type.pointer
+          .truncate{ 'data-scroll-target' => '#lexicon-links' }= t('lexicon.verification.sections.links_section')
+      - if lexicon_sections[:authority_control]
+        - authority_control_label = t('lexicon.verification.sections.authority_control_section')
+        .book-type.pointer
+          .truncate{ 'data-scroll-target' => '#lexicon-authority-control' }= authority_control_label
 
 %nav.book-nav-thin.by-card-v02
   .side-nav-in-page
@@ -138,7 +149,7 @@
       .headline-2-v02= t("toc_by_role.headers.#{role}", gender_letter: @author.gender_letter)
   .nav-books.pointer{ 'data-scroll-target' => '#author-whats-new-bg' }
     .headline-2-v02= t(:additional_content)
-  - if @lexicon_entry.present?
+  - if lexicon_sections.any?
     .nav-books.lexicon-background-color.pointer{ 'data-scroll-target' => '#lexicon-bio' }
       .headline-2-v02= t(:lexicon_content)
 

--- a/spec/requests/author_toc_lexicon_content_spec.rb
+++ b/spec/requests/author_toc_lexicon_content_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The lexicon section of the Authority TOC shows the same cards as LexEntry#show; only the
+# navbar, the sidebar and the preceding Authority TOC itself differ between the two views.
+RSpec.describe 'Authority TOC lexicon content', type: :request do
+  subject(:call) { get authority_path(author) }
+
+  let(:uncollected_collection) { create(:collection, :uncollected) }
+  let(:author) { create(:authority, :published, uncollected_works_collection: uncollected_collection) }
+
+  before { author.update(lex_person: lex_entry.lex_item) }
+
+  describe 'authority identifiers card' do
+    let(:card_title) { I18n.t('lexicon.entries.show_person.authority_identifiers') }
+
+    context 'when the lexicon entry has external identifiers' do
+      let(:lex_entry) do
+        create(:lex_entry, :person, status: 'published',
+                                    external_identifiers: { 'viaf' => '36924286', 'lc' => 'n79021164' })
+      end
+
+      it 'shows the identifiers card, as LexEntry#show does' do
+        call
+        expect(response.body).to include('lexicon-authority-control')
+        expect(response.body).to include(card_title)
+        expect(response.body).to include('https://viaf.org/viaf/36924286')
+        expect(response.body).to include('https://id.loc.gov/authorities/n79021164')
+      end
+    end
+
+    context 'when the lexicon entry has no external identifiers' do
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published', external_identifiers: nil) }
+
+      it 'omits the card' do
+        call
+        expect(response.body).not_to include('lexicon-authority-control')
+      end
+    end
+
+    context 'when the lexicon entry is not published' do
+      let(:lex_entry) do
+        create(:lex_entry, :person, status: 'draft', external_identifiers: { 'viaf' => '36924286' })
+      end
+
+      it 'shows no lexicon content at all, and so no card' do
+        call
+        expect(response.body).not_to include('lexicon-authority-control')
+      end
+    end
+  end
+
+  describe 'biography card' do
+    let(:lex_person) { create(:lex_person, bio: 'פתיחה <img src="portrait.jpg"> המשך הביוגרפיה') }
+    let(:lex_entry) { create(:lex_entry, :person, status: 'published', lex_item: lex_person) }
+
+    before do
+      lex_entry.attachments.attach(io: StringIO.new('fake image data'), filename: 'portrait.jpg',
+                                   content_type: 'image/jpeg')
+      lex_entry.update!(profile_image_id: lex_entry.attachments.first.id)
+      author.update(lex_person: lex_person)
+    end
+
+    # Deliberately NOT bio_for_display, unlike LexEntry#show: that view renders the portrait
+    # separately in .lexicon-author-details and strips the inline copy, while this view has no
+    # such block, so the inline <img> is the only copy there is.
+    it 'keeps the portrait inline in the bio' do
+      call
+      expect(response.body).to include('המשך הביוגרפיה')
+      expect(response.body).to include('src="portrait.jpg"')
+    end
+  end
+
+  describe 'last updated line' do
+    context 'when the legacy PHP file carried a manual update date' do
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published', date_of_manual_update: '12 ביולי 2023') }
+
+      it 'shows the ingested date, as LexEntry#show does' do
+        call
+        expect(response.body).to include('lexicon-last-updated')
+        expect(response.body).to include('12 ביולי 2023')
+      end
+    end
+
+    context 'when the legacy PHP file carried no manual update date' do
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published', date_of_manual_update: nil) }
+
+      it 'omits the line' do
+        call
+        expect(response.body).not_to include('lexicon-last-updated')
+      end
+    end
+  end
+
+  describe 'empty sections' do
+    context 'when the entry has no works, citations, links or identifiers' do
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published') }
+
+      it 'omits those cards and their navbar lines, keeping the biography' do
+        call
+        expect(response.body).to include('id="lexicon-biography"')
+        expect(response.body).not_to include('id="lexicon-works"')
+        expect(response.body).not_to include('id="lexicon-about"')
+        expect(response.body).not_to include('id="lexicon-links"')
+        expect(response.body).not_to include('data-scroll-target="#lexicon-works"')
+        expect(response.body).not_to include('data-scroll-target="#lexicon-about"')
+        expect(response.body).not_to include('data-scroll-target="#lexicon-links"')
+      end
+    end
+
+    context 'when every lexicon section is empty' do
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published', lex_item: create(:lex_person, bio: nil)) }
+
+      # asserted on the wrapper classes rather than the heading text: the lexicon's name also
+      # appears in the "to the lexicon entry" link at the top of the authority page, which is
+      # not part of the lexicon block and stays
+      it 'drops the lexicon heading and the whole navbar group' do
+        call
+        expect(response.body).not_to include('peach2-lexicon')
+        expect(response.body).not_to include('lexicon-background-color')
+        expect(response.body).not_to include('id="lexicon-bio"')
+      end
+    end
+
+    context 'when the entry has no biography but has other sections' do
+      let(:lex_person) { create(:lex_person, bio: nil) }
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published', lex_item: lex_person) }
+
+      before { create(:lex_person_work, person: lex_person) }
+
+      it 'keeps the group anchor so the navbar still scrolls to the lexicon block' do
+        call
+        expect(response.body).not_to include('id="lexicon-biography"')
+        # the biography LINE is gone (a .truncate div), but the group's own scroll target,
+        # on the enclosing .nav-book-group, still resolves
+        expect(response.body).not_to include('<div class="truncate" data-scroll-target="#lexicon-bio">')
+        expect(response.body).to include('data-scroll-target="#lexicon-bio"')
+        expect(response.body).to include('id="lexicon-bio"')
+        expect(response.body).to include('id="lexicon-works"')
+      end
+    end
+  end
+
+  describe 'lexicon navbar group' do
+    # Asserted on the scroll-target attribute, not the label: in Hebrew the nav label
+    # (authority_control_section) and the card title (authority_identifiers) are the same
+    # string, so matching on the text alone would be satisfied by the card itself.
+    let(:nav_entry) { 'data-scroll-target="#lexicon-authority-control"' }
+
+    context 'when the lexicon entry has external identifiers' do
+      let(:lex_entry) do
+        create(:lex_entry, :person, status: 'published', external_identifiers: { 'viaf' => '36924286' })
+      end
+
+      it 'offers a scroll target for the identifiers card' do
+        call
+        expect(response.body).to include(nav_entry)
+      end
+    end
+
+    context 'when the lexicon entry has no external identifiers' do
+      let(:lex_entry) { create(:lex_entry, :person, status: 'published', external_identifiers: nil) }
+
+      it 'omits the nav entry' do
+        call
+        expect(response.body).not_to include(nav_entry)
+      end
+    end
+  end
+
+  describe 'citations card' do
+    let(:lex_person) { create(:lex_person) }
+    let(:lex_entry) { create(:lex_entry, :person, status: 'published', lex_item: lex_person) }
+    let(:person_work) { create(:lex_person_work, person: lex_person, title: 'ספר הזכרונות') }
+
+    before do
+      create(:lex_citation, person: lex_person, person_work: person_work, title: 'מאמר על הספר')
+      create(:lex_citation, person: lex_person, subject: 'נושא ידני', title: 'מאמר על הנושא')
+      author.update(lex_person: lex_person)
+    end
+
+    it 'headlines work-attached citations by the work title, as LexEntry#show does' do
+      call
+      # subject_title falls back to the person_work title; grouping by the bare subject column
+      # left these citations under one empty header instead.
+      expect(response.body).to include(I18n.t('lexicon.citations.header.subject_line', subject: 'ספר הזכרונות'))
+      expect(response.body).to include(I18n.t('lexicon.citations.header.subject_line', subject: 'נושא ידני'))
+      expect(response.body).not_to include('<h4></h4>')
+    end
+  end
+end

--- a/spec/requests/lexicon/entries_spec.rb
+++ b/spec/requests/lexicon/entries_spec.rb
@@ -157,6 +157,76 @@ describe '/lexicon/entries' do
       it { is_expected.to eq(200) }
     end
 
+    describe 'empty sections' do
+      context 'when a Person entry has no works, citations, links or identifiers' do
+        let(:entry) { create(:lex_entry, :person, status: :published) }
+
+        it 'omits those cards' do
+          expect(call).to eq(200)
+          expect(response.body).not_to include('id="lexicon-works"')
+          expect(response.body).not_to include('id="lexicon-about"')
+          expect(response.body).not_to include('id="lexicon-links"')
+          expect(response.body).not_to include('id="lexicon-authority-control"')
+        end
+
+        it 'omits their navbar lines, keeping only the biography' do
+          expect(call).to eq(200)
+          expect(response.body).to include('data-scroll-target="#lexicon-biography"')
+          expect(response.body).not_to include('data-scroll-target="#lexicon-works"')
+          expect(response.body).not_to include('data-scroll-target="#lexicon-about"')
+          expect(response.body).not_to include('data-scroll-target="#lexicon-links"')
+        end
+      end
+
+      context 'when a Person entry has works, citations and links' do
+        let(:entry) { create(:lex_entry, :person, status: :published) }
+
+        before do
+          create(:lex_person_work, person: entry.lex_item)
+          create(:lex_citation, person: entry.lex_item)
+          create(:lex_link, item: entry.lex_item)
+        end
+
+        it 'shows those cards and their navbar lines' do
+          expect(call).to eq(200)
+          expect(response.body).to include('id="lexicon-works"')
+          expect(response.body).to include('id="lexicon-about"')
+          expect(response.body).to include('id="lexicon-links"')
+          expect(response.body).to include('data-scroll-target="#lexicon-works"')
+          expect(response.body).to include('data-scroll-target="#lexicon-about"')
+          expect(response.body).to include('data-scroll-target="#lexicon-links"')
+        end
+      end
+
+      context 'when a Person entry has no biography' do
+        let(:entry) { create(:lex_entry, :person, status: :published, lex_item: create(:lex_person, bio: nil)) }
+
+        let(:active_works_link) { '<a aria-selected="true" class="nav-link active" href="#" id="works_button">' }
+
+        before { create(:lex_person_work, person: entry.lex_item) }
+
+        it 'omits the biography and starts the navbar on the first surviving section' do
+          expect(call).to eq(200)
+          expect(response.body).not_to include('id="lexicon-biography"')
+          expect(response.body).not_to include('data-scroll-target="#lexicon-biography"')
+          expect(response.body).to include(active_works_link)
+        end
+      end
+
+      context 'when a Publication entry has no table of contents' do
+        let(:entry) do
+          create(:lex_entry, :publication, status: :published, lex_item: create(:lex_publication, toc: nil))
+        end
+
+        it 'omits the toc card and its navbar line' do
+          expect(call).to eq(200)
+          expect(response.body).to include('id="lexicon-description"')
+          expect(response.body).not_to include('id="lexicon-toc"')
+          expect(response.body).not_to include('data-scroll-target="#lexicon-toc"')
+        end
+      end
+    end
+
     describe 'last updated line' do
       context 'when the legacy PHP file carried a manual update date' do
         let(:entry) { create(:lex_entry, :person, status: :published, date_of_manual_update: '12 ביולי 2023') }


### PR DESCRIPTION
## Summary

The lexicon block on an Authority's TOC and the one on the lexicon entry's own page had drifted apart, and both rendered cards that had nothing in them. This brings the two into line and drops empty sections.

## Changes

**Last-modification date (`LexEntry#show`)** — was outside the Bootstrap `.row` entirely, so it hugged the page's right edge instead of the content column. Moved into the main content column, where it right-aligns with the cards above it, with a paragraph's worth of space after the last card. Extracted to `lexicon/entries/_last_updated` since three views now render it.

**Authority-identifiers card (Authority TOC)** — was missing from the TOC's lexicon block; added, identical to the entry page's, along with a matching line in the TOC navbar's lexicon group.

**Citation grouping (Authority TOC)** — the TOC grouped citations by the bare `subject` column. `LexCitation` validates `subject` *absent* whenever `person_work` is present, so every work-attached citation had `subject == nil` and they all collapsed under one empty `<h4>`. Now uses `grouped_and_ordered_citations` + `citations_subject_header`, as `_show_person` does, which grouped by `subject_title` (falls back to the work's title) all along.

**Empty sections omitted (both views)** — a section with no content is no longer rendered as an empty card, and gets no navbar line either. With every section empty, the TOC drops the lexicon heading and navbar group entirely. All four views (two content views, two navbars) agree on what "empty" means via a single `LexiconHelper#lexicon_sections_present`. Because the biography can now be absent, the entry navbar marks whichever section is shown first as active rather than hardcoding the first item.

## Note on one deliberate difference

The TOC's biography keeps calling `MarkdownToHtml.call(lex_person.bio)` rather than `bio_for_display`. The latter strips the entry's portrait from the bio text because `LexEntry#show` renders it separately in `.lexicon-author-details`; the TOC has no such block, so the inline `<img>` is the only copy of the portrait there. There is a comment at the call site and a spec pinning it.

## Test plan

New: `spec/requests/author_toc_lexicon_content_spec.rb` (14 examples) covering the identifiers card, the citation headers, the last-updated line, the navbar entry, and section omission on the TOC. Extended `spec/requests/lexicon/entries_spec.rb` with an `empty sections` group covering both person and publication entries and the active-nav-item fallback.

Each new assertion was checked to fail without its change (by neutralising the gating helper / removing the added markup, then restoring).

```
bundle exec rspec spec/requests/lexicon/entries_spec.rb \
  spec/requests/author_toc_lexicon_content_spec.rb \
  spec/requests/lexicon/entries_ux_improvements_spec.rb \
  spec/requests/author_lex_citations_spec.rb \
  spec/requests/author_toc_filters_spec.rb \
  spec/controllers/authors_controller_spec.rb \
  spec/helpers/lexicon_helper_spec.rb
# 181 examples, 0 failures

bundle exec rspec spec/system/lexicon/entries_navbar_spec.rb \
  spec/system/lexicon/entry_navbar_sticky_offset_spec.rb \
  spec/system/lexicon/bio_image_float_spec.rb
# 14 examples, 0 failures
```

**The full suite has not been run** (40+ min) — worth doing in CI here, since the navbar partial is shared.

`rubocop` and `haml-lint` are clean on the changed files apart from pre-existing offences (and a `ViewLength` warning on `_navbar.html.haml`, now 105/100 lines, in a codebase where that partial's neighbours run to 300–800).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
