### PR TITLE
Add a parity spec for lexicon citation sub-section headings

### DIFF
--- a/spec/requests/author_toc_lexicon_content_spec.rb
+++ b/spec/requests/author_toc_lexicon_content_spec.rb
@@ -93,6 +93,43 @@ RSpec.describe 'Authority TOC lexicon content', type: :request do
     end
   end
 
+  # Reported against benyehuda.org/author/2360 vs. /lex/entries/64: every citation was present on
+  # the TOC, but the sub-section headings of the work-attached ones were not. Grouping by the bare
+  # `subject` column collapsed all three of them into a single empty <h4> (LexCitation validates
+  # `subject` absent whenever `person_work` is set), and the remaining legacy subjects were shown
+  # raw, without the 'על ״...״' wrapper the entry page gives them.
+  describe 'citation sub-section headings' do
+    let(:lex_person) { create(:lex_person) }
+    let(:lex_entry) { create(:lex_entry, :person, status: 'published', lex_item: lex_person) }
+    let(:work_titles) { ['נערת גומי לעוסה', 'חיים כמעט מתוקים', 'פגומות'] }
+    let(:raw_subjects) { ['הנה 6, קונטרס לשירה', 'מעבר לקוני ויליס'] }
+
+    def about_headings(body)
+      Nokogiri::HTML(body).css('#lexicon-about h4').map { |node| node.text.strip }
+    end
+
+    before do
+      work_titles.each_with_index do |title, index|
+        work = create(:lex_person_work, person: lex_person, title: title, seqno: index + 1)
+        create(:lex_citation, person: lex_person, person_work: work)
+      end
+      raw_subjects.each { |subject| create(:lex_citation, person: lex_person, subject: subject) }
+    end
+
+    it 'headlines every sub-section exactly as the entry page does' do
+      call
+      toc_headings = about_headings(response.body)
+
+      get lexicon_entry_path(lex_entry)
+      entry_headings = about_headings(response.body)
+
+      expect(toc_headings).to eq(entry_headings)
+      expect(toc_headings).to eq((work_titles + raw_subjects).map do |subject|
+        I18n.t('lexicon.citations.header.subject_line', subject: subject)
+      end)
+    end
+  end
+
   describe 'empty sections' do
     context 'when the entry has no works, citations, links or identifiers' do
       let(:lex_entry) { create(:lex_entry, :person, status: 'published') }


### PR DESCRIPTION
## Summary

Investigation of the reported difference between the citations on
[/lex/entries/64](https://benyehuda.org/lex/entries/64) and
[/author/2360](https://benyehuda.org/author/2360). **The underlying bug was already fixed by
#1632**, which merged after the report; this PR adds the regression test that pins the exact
reported symptom, since #1632's citation spec covered the mechanism but not the two views'
output side by side.

## What was wrong

Scraping the two live pages shows it precisely — the `<h4>` sub-section headings inside
`#lexicon-about`:

| `/lex/entries/64` (7 headings) | `/author/2360` (5 headings) |
| --- | --- |
| `על ״נערת גומי לעוסה״` | `` (empty) |
| `על ״חיים כמעט מתוקים״` | `הנה 6, קונטרס לשירה` |
| `על ״פגומות״` | `שפתיים בלונדיניות ושער דובדבן` |
| `על ״הנה 6, קונטרס לשירה״` | `סילביה פלאת' : מוזה אפלה` |
| `על ״מעבר לקוני ויליס״` | `מעבר לקוני ויליס` |
| `על ״סילביה פלאת' : מוזה אפלה״` | |
| `על ״שפתיים בלונדיניות ושער דובדבן״` | |

Two distinct faults, both from the TOC grouping citations by the bare `subject` column:

1. `LexCitation` validates `subject` **absent** whenever `person_work` is set, so every
   work-attached citation had `subject == nil` and all of them collapsed into a single empty
   `<h4>` — the three missing headings.
2. The remaining legacy subjects were emitted raw, without the `על ״...״` wrapper that
   `citations_subject_header` gives them on the entry page.

`grouped_and_ordered_citations` groups by `subject_title`, which falls back to the work's title,
and orders general → work-attached (by seqno) → custom. #1632 switched the TOC to it.

## The test

Renders one person through both views and asserts the `#lexicon-about` headings are identical,
using the reported shape: three work-attached citations plus two carrying a legacy raw subject.

Verified it reproduces the live failure: reverting the TOC to the old grouping makes it fail with
`["", "הנה 6, קונטרס לשירה", "מעבר לקוני ויליס"]` — the same shape as the live page.

```
bundle exec rspec spec/requests/author_toc_lexicon_content_spec.rb spec/requests/lexicon/entries_spec.rb
# 35 examples, 0 failures
```

Full suite not run (40+ min); this PR is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
