### PR TITLE
Fix digest serialization, latency, and dangling references (by-cnh.1, .2, .5)

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -6,10 +6,9 @@ module NotificationsHelper
     data = notification.notification_data
     mailer_class = data['mailer_class'].constantize
     mailer_method = data['mailer_method'].to_sym
-    args = data['args']
 
     # Create the mailer and render its content
-    mailer = mailer_class.public_send(mailer_method, *args)
+    mailer = mailer_class.public_send(mailer_method, *notification.mailer_args)
     mailer.body.to_s.html_safe
   rescue StandardError => e
     Rails.logger.error("Failed to render notification #{notification.id}: #{e.message}")

--- a/app/jobs/notification_digest_job.rb
+++ b/app/jobs/notification_digest_job.rb
@@ -9,14 +9,6 @@ class NotificationDigestJob < ApplicationJob
       return
     end
 
-    # Calculate the cutoff time based on frequency
-    cutoff_time = case frequency
-                  when 'daily'
-                    1.day.ago
-                  when 'weekly'
-                    1.week.ago
-                  end
-
     # Get all users with this email frequency preference
     preferences_join = 'INNER JOIN base_user_preferences ' \
                        'ON base_user_preferences.base_user_id = base_users.id'
@@ -29,23 +21,40 @@ class NotificationDigestJob < ApplicationJob
       email = base_user.user&.email
       next if email.blank?
 
-      send_digest_for_user(email, cutoff_time)
+      send_digest_for_user(email)
     end
   end
 
   private
 
-  def send_digest_for_user(email, cutoff_time)
-    notifications = PendingNotification.for_recipient(email).older_than(cutoff_time)
+  # Drains everything currently buffered for the recipient, regardless of age: the once-per-period
+  # guarantee comes from the schedule in config/recurring.yml, not from an age filter. Filtering by
+  # age here only bought a full extra period of delivery latency.
+  def send_digest_for_user(email)
+    pending = PendingNotification.for_recipient(email).to_a
 
-    return if notifications.empty?
+    return if pending.empty?
+
+    renderable, unresolvable = pending.partition(&:resolvable?)
+
+    # A notification referring to a since-deleted record can never render. Drop it, so that it does
+    # not fail again on every subsequent run and block this recipient's other notifications.
+    delete_notifications(unresolvable)
+
+    return if renderable.empty?
 
     # Send digest email
-    Notifications.notification_digest(email, notifications).deliver_now
+    Notifications.notification_digest(email, renderable).deliver_now
 
     # Delete the notifications after sending
-    notifications.destroy_all
+    delete_notifications(renderable)
   rescue StandardError => e
     Rails.logger.error("Failed to send digest for #{email}: #{e.message}")
+  end
+
+  def delete_notifications(notifications)
+    return if notifications.empty?
+
+    PendingNotification.where(id: notifications.map(&:id)).delete_all
   end
 end

--- a/app/models/pending_notification.rb
+++ b/app/models/pending_notification.rb
@@ -13,4 +13,20 @@ class PendingNotification < ApplicationRecord
   def self.grouped_by_recipient
     all.group_by(&:recipient_email)
   end
+
+  # The stored mailer arguments, with GlobalID references resolved back into records.
+  # Raises ActiveJob::DeserializationError when a referenced record no longer exists.
+  def mailer_args
+    @mailer_args ||= ActiveJob::Arguments.deserialize(notification_data['args'] || [])
+  end
+
+  # False when a referenced record has since been deleted, i.e. this notification can never be
+  # rendered and should be dropped rather than left to fail on every digest run.
+  def resolvable?
+    mailer_args
+    true
+  rescue ActiveJob::DeserializationError => e
+    Rails.logger.warn("Dropping unresolvable pending notification #{id} (#{notification_type}): #{e.message}")
+    false
+  end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -25,7 +25,15 @@ class NotificationService < ApplicationService
       queue_notification(
         recipient_email: recipient_email,
         notification_type: "#{mailer_class.name}##{mailer_method}",
-        notification_data: { mailer_class: mailer_class.name, mailer_method: mailer_method.to_s, args: args }
+        notification_data: {
+          'mailer_class' => mailer_class.name,
+          'mailer_method' => mailer_method.to_s,
+          # GlobalID-based serialization (the same one ActiveJob uses for job arguments), so that
+          # ActiveRecord arguments survive the round trip through the buffer table instead of being
+          # flattened into plain hashes by the JSON coder. Raises ActiveJob::SerializationError here,
+          # at the call site, rather than silently producing an unrenderable notification.
+          'args' => ActiveJob::Arguments.serialize(args)
+        }
       )
     end
   end

--- a/spec/factories/pending_notifications.rb
+++ b/spec/factories/pending_notifications.rb
@@ -2,13 +2,20 @@
 
 FactoryBot.define do
   factory :pending_notification do
+    transient do
+      mailer_class { 'Notifications' }
+      mailer_method { 'tag_approved' }
+      # Real mailer arguments (models included) -- serialized exactly as NotificationService does.
+      args { [] }
+    end
+
     recipient_email { 'user@example.com' }
-    notification_type { 'Notifications#tag_approved' }
+    notification_type { "#{mailer_class}##{mailer_method}" }
     notification_data do
       {
-        mailer_class: 'Notifications',
-        mailer_method: 'tag_approved',
-        args: []
+        'mailer_class' => mailer_class,
+        'mailer_method' => mailer_method,
+        'args' => ActiveJob::Arguments.serialize(args)
       }
     end
     created_at { Time.current }

--- a/spec/jobs/notification_digest_job_spec.rb
+++ b/spec/jobs/notification_digest_job_spec.rb
@@ -24,21 +24,35 @@ describe NotificationDigestJob do
       end
 
       it 'sends digest email for users with pending notifications' do
-        mail_double = double('mail', deliver_now: true)
+        mail_double = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
         expect(Notifications).to receive(:notification_digest)
-          .with(user.email, kind_of(ActiveRecord::Relation))
+          .with(user.email, kind_of(Array))
           .and_return(mail_double)
         expect(mail_double).to receive(:deliver_now)
 
-        NotificationDigestJob.new.perform('daily')
+        described_class.new.perform('daily')
       end
 
-      it 'deletes sent notifications' do
-        allow(Notifications).to receive(:notification_digest).and_return(double(deliver_now: true))
+      # Regression test: the job used to select only rows older than a full period, so a
+      # notification queued since the previous run waited for the run after it -- up to ~48h for
+      # daily, against a UI that promises at most one day.
+      it 'drains notifications queued since the previous run, not just old ones' do
+        allow(Notifications).to receive(:notification_digest)
+          .and_return(instance_double(ActionMailer::MessageDelivery, deliver_now: true))
 
         expect do
-          NotificationDigestJob.new.perform('daily')
-        end.to change(PendingNotification, :count).by(-1)
+          described_class.new.perform('daily')
+        end.to change(PendingNotification, :count).by(-2)
+      end
+
+      it 'includes every pending notification in the digest' do
+        allow(Notifications).to receive(:notification_digest)
+          .and_return(instance_double(ActionMailer::MessageDelivery, deliver_now: true))
+
+        described_class.new.perform('daily')
+
+        expect(Notifications).to have_received(:notification_digest)
+          .with(user.email, contain_exactly(old_notification, new_notification))
       end
     end
 
@@ -54,27 +68,74 @@ describe NotificationDigestJob do
       end
 
       it 'sends digest email for users with weekly preference' do
-        mail_double = double('mail', deliver_now: true)
+        mail_double = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
         expect(Notifications).to receive(:notification_digest)
-          .with(user.email, kind_of(ActiveRecord::Relation))
+          .with(user.email, kind_of(Array))
           .and_return(mail_double)
         expect(mail_double).to receive(:deliver_now)
 
-        NotificationDigestJob.new.perform('weekly')
+        described_class.new.perform('weekly')
       end
     end
 
     context 'with invalid frequency' do
       it 'logs error and returns' do
         expect(Rails.logger).to receive(:error).with('Invalid frequency: invalid')
-        NotificationDigestJob.new.perform('invalid')
+        described_class.new.perform('invalid')
       end
     end
 
     context 'when user has no pending notifications' do
       it 'does not send email' do
         expect(Notifications).not_to receive(:notification_digest)
-        NotificationDigestJob.new.perform('daily')
+        described_class.new.perform('daily')
+      end
+    end
+
+    # End-to-end through the real mailer and view: this is what actually lands in the recipient's
+    # inbox, and what used to be a page of `notification_render_error` placeholders.
+    context 'with a real notification carrying a model argument' do
+      let(:tag) { create(:tag, creator: user) }
+
+      before do
+        ActionMailer::Base.deliveries.clear
+        Notifications.send_or_queue(:tag_approved, user.email, tag)
+      end
+
+      it 'renders the notification content rather than an error placeholder' do
+        described_class.new.perform('daily')
+
+        digest = ActionMailer::Base.deliveries.last
+        expect(digest.to).to eq([user.email])
+        expect(digest.body.encoded).to include(tag.name)
+        expect(digest.body.encoded).not_to include(I18n.t(:notification_render_error))
+      end
+    end
+
+    # by-cnh.5: a dangling reference must not cost the recipient their other notifications, nor
+    # survive to fail again on the next run.
+    context 'when a referenced record has been deleted' do
+      let(:doomed_tag) { create(:tag, creator: user) }
+      let(:live_tag) { create(:tag, creator: user) }
+
+      before do
+        ActionMailer::Base.deliveries.clear
+        Notifications.send_or_queue(:tag_approved, user.email, doomed_tag)
+        Notifications.send_or_queue(:tag_approved, user.email, live_tag)
+        doomed_tag.destroy!
+      end
+
+      it 'still delivers the remaining notifications' do
+        described_class.new.perform('daily')
+
+        digest = ActionMailer::Base.deliveries.last
+        expect(digest.body.encoded).to include(live_tag.name)
+      end
+
+      it 'drops the unresolvable notification instead of retrying it forever' do
+        expect do
+          described_class.new.perform('daily')
+        end.to change(PendingNotification, :count).by(-2)
       end
     end
   end

--- a/spec/models/pending_notification_spec.rb
+++ b/spec/models/pending_notification_spec.rb
@@ -5,19 +5,19 @@ require 'rails_helper'
 RSpec.describe PendingNotification, type: :model do
   describe 'validations' do
     it 'validates presence of recipient_email' do
-      notification = PendingNotification.new(notification_type: 'test', notification_data: {})
+      notification = described_class.new(notification_type: 'test', notification_data: {})
       expect(notification).not_to be_valid
       # expect(notification.errors[:recipient_email]).to include("can't be blank")
     end
 
     it 'validates presence of notification_type' do
-      notification = PendingNotification.new(recipient_email: 'test@example.com', notification_data: {})
+      notification = described_class.new(recipient_email: 'test@example.com', notification_data: {})
       expect(notification).not_to be_valid
       # expect(notification.errors[:notification_type]).to include("can't be blank")
     end
 
     it 'validates presence of notification_data' do
-      notification = PendingNotification.new(recipient_email: 'test@example.com', notification_type: 'test')
+      notification = described_class.new(recipient_email: 'test@example.com', notification_type: 'test')
       expect(notification).not_to be_valid
       # expect(notification.errors[:notification_data]).to include("can't be blank")
     end
@@ -55,6 +55,34 @@ RSpec.describe PendingNotification, type: :model do
         expect(result['user1@example.com'].count).to eq(3)
         expect(result['user2@example.com'].count).to eq(3)
       end
+    end
+  end
+
+  describe '#mailer_args' do
+    let(:tag) { create(:tag) }
+    let(:notification) { create(:pending_notification, args: [tag, 'a note', nil]).reload }
+
+    it 'resolves stored references back into records, preserving the other arguments' do
+      expect(notification.mailer_args).to eq([tag, 'a note', nil])
+    end
+
+    it 'raises when a referenced record has been deleted' do
+      tag.destroy!
+      expect { notification.mailer_args }.to raise_error(ActiveJob::DeserializationError)
+    end
+  end
+
+  describe '#resolvable?' do
+    let(:tag) { create(:tag) }
+    let(:notification) { create(:pending_notification, args: [tag]).reload }
+
+    it 'is true while every referenced record still exists' do
+      expect(notification).to be_resolvable
+    end
+
+    it 'is false once a referenced record has been deleted' do
+      tag.destroy!
+      expect(notification).not_to be_resolvable
     end
   end
 end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -7,7 +7,9 @@ describe NotificationService do
   let!(:base_user) { create(:base_user, user: user) }
   let(:mailer_class) { Notifications }
   let(:mailer_method) { :tag_approved }
-  let(:tag) { double('Tag', creator: user) }
+  # A real record, not a double: the whole point of the buffer is that models survive the round trip
+  # through the database, and a double never exercises that.
+  let(:tag) { create(:tag, creator: user) }
   let(:args) { [tag] }
 
   describe '#call' do
@@ -20,7 +22,7 @@ describe NotificationService do
         mail_double = double('mail', deliver_now: true)
         expect(mailer_class).to receive(:tag_approved).with(tag).and_return(mail_double)
         expect(mail_double).to receive(:deliver_now)
-        
+
         described_class.call(
           mailer_class: mailer_class,
           mailer_method: mailer_method,
@@ -57,6 +59,32 @@ describe NotificationService do
         notification = PendingNotification.last
         expect(notification.recipient_email).to eq(user.email)
         expect(notification.notification_type).to eq('Notifications#tag_approved')
+      end
+
+      # Regression test for the JSON-serialization defect: model arguments used to be dumped to
+      # plain attribute hashes, so the mailer replay in the digest got a Hash where it expected a
+      # record and every notification rendered as an error placeholder.
+      it 'round-trips model arguments back into records' do
+        described_class.call(
+          mailer_class: mailer_class,
+          mailer_method: mailer_method,
+          recipient_email: user.email,
+          args: args
+        )
+
+        notification = PendingNotification.last.reload
+        expect(notification.mailer_args).to eq([tag])
+      end
+
+      it 'raises at queue time on an argument it cannot serialize' do
+        expect do
+          described_class.call(
+            mailer_class: mailer_class,
+            mailer_method: mailer_method,
+            recipient_email: user.email,
+            args: [Object.new]
+          )
+        end.to raise_error(ActiveJob::SerializationError)
       end
     end
 
@@ -102,7 +130,7 @@ describe NotificationService do
         mail_double = double('mail', deliver_now: true)
         expect(mailer_class).to receive(:tag_approved).with(tag).and_return(mail_double)
         expect(mail_double).to receive(:deliver_now)
-        
+
         described_class.call(
           mailer_class: mailer_class,
           mailer_method: mailer_method,


### PR DESCRIPTION
Closes the first three children of epic **by-cnh** (email throttling / notification digest): `by-cnh.1`, `by-cnh.2`, `by-cnh.5`.

## What was broken

**by-cnh.1 — digest content was an error placeholder (P1, user-visible today)**

`PendingNotification` declares `serialize :notification_data, coder: JSON`, and `NotificationService#queue_notification` stored the mailer's raw `args` array in it. Any ActiveRecord argument was dumped to a plain attribute hash. On drain, `NotificationsHelper#render_notification` replays the mailer:

```ruby
mailer = mailer_class.public_send(mailer_method, *args)
```

so the mailer method received a `Hash` where it expected a model, raised `NoMethodError`, and the rescue swallowed it into a generic `t(:notification_render_error)` paragraph — after which `send_digest_for_user` destroyed the rows. Every live call site passes models (`proofs_controller.rb:116`, `admin_controller.rb:1263`, `external_links_controller.rb:28`, …), so in practice **every** notification for a daily/weekly user arrived as a placeholder.

**by-cnh.2 — up to ~48h delivery latency (P1, user-visible today)**

The job computed `cutoff_time = 1.day.ago` and selected `.older_than(cutoff_time)`, so the 09:00 daily run collected only rows queued more than 24h earlier. Anything queued since yesterday morning waited for the *next* run. Effective latency: ~48h daily, ~2 weeks weekly, against a preference UI (`email_frequency_daily_description`) that promises at most one day.

**by-cnh.5 — a dangling reference could wedge a recipient's queue (P2)**

Follows from .1: once args are GlobalIDs, a reference to a deleted record raises `ActiveJob::DeserializationError`. That needed somewhere to land, or one bad row would fail on every run and block that recipient's digests indefinitely.

## What changed

- **`app/services/notification_service.rb`** — serialize args with `ActiveJob::Arguments.serialize` (the same GlobalID mechanism ActiveJob uses for job arguments). Raises `ActiveJob::SerializationError` at the call site rather than silently producing an unrenderable notification.
- **`app/models/pending_notification.rb`** — new `#mailer_args` (memoized deserialize) and `#resolvable?` (false + a warning log when a referenced record is gone).
- **`app/jobs/notification_digest_job.rb`** — drop `cutoff_time` / `older_than` and drain everything buffered for the recipient. Partition on `resolvable?` first: unresolvable rows are logged and deleted, the rest are delivered.
- **`app/helpers/notifications_helper.rb`** — replay the mailer with `notification.mailer_args`.

## Deliberately not changed

- The `PendingNotification.older_than` scope stays (unused by this path, still covered by its model spec) — `by-cnh.4`'s sweeper needs it.
- The `rescue StandardError` in `send_digest_for_user` still skips the delete on a delivery failure. That is correct: failed recipients retry next run (see `by-cnh.6`).
- The per-notification `rescue` in `render_notification` stays, so an unexpected render error still degrades one block rather than the whole digest.

## Migration / backfill

None needed. Rows written under the old format deserialize to plain hashes without raising (verified against Rails 8.1), so they render as today's error placeholder and are then deleted — same behaviour as before this PR, and the queue drains itself within one period.

## Trade-off worth a reviewer's eye

Per the bead, unserializable args now **raise at queue time**. Every current call site passes only models, strings and `nil`, so nothing in the app today can trigger it — but a future bad call site will surface as a 500 in the controller rather than as a silently broken email. The alternative (log and fall back to immediate delivery) would violate the user's throttling preference instead. Flagging it as an explicit choice, not an oversight.

## Test plan

```
bundle exec rspec spec/models/pending_notification_spec.rb \
                  spec/services/notification_service_spec.rb \
                  spec/jobs/notification_digest_job_spec.rb \
                  spec/mailers \
                  spec/controllers/proofs_controller_spec.rb \
                  spec/controllers/external_links_controller_spec.rb \
                  spec/controllers/user_preferences_controller_spec.rb \
                  spec/controllers/preferences_controller_spec.rb
# 119 examples, 0 failures
```

Also ran `spec/controllers/admin_controller_spec.rb` and `spec/helpers` (315 examples, 1 failure). That one failure — `AdminController#translated_from_multiple_languages` — is an unordered-array comparison unrelated to notifications; **verified it fails identically on the base commit (47d6bd14b)** with these changes stashed.

New coverage:

- `notification_service_spec.rb` — a real `Tag` (not `double('Tag')`, which is precisely what hid this bug) round-trips back to the same record; unserializable args raise.
- `pending_notification_spec.rb` — `#mailer_args` and `#resolvable?`, present and deleted.
- `notification_digest_job_spec.rb` — a notification queued 1 hour ago is drained by the daily run (this replaces an assertion that deliberately pinned the *old* behaviour); an **end-to-end** case through the real mailer and view asserting the digest body contains the tag name and not `notification_render_error`; a dangling-reference case asserting the other notification is still delivered and the bad row is dropped.

All nine new/changed assertions were verified to fail against the pre-change code before the fix was restored.

RuboCop is clean on every line this PR adds; the offenses that remain in these files (`RSpec/MessageSpies`, `RSpec/VerifiedDoubles`, `Rails/WhereRange`, `Style/Documentation`) are pre-existing on untouched lines.

The full suite (40+ min) was **not** run — happy to kick it off if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
