### PR TITLE
Collapse duplicates and bound the size of the notification digest (by-cnh.7)

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -15,6 +15,14 @@ module NotificationsHelper
     content_tag(:p, t(:notification_render_error))
   end
 
+  # An exact duplicate is folded away by PendingNotification.collapse; this is the line that tells
+  # the recipient it happened. Nothing to say when the notification arrived only once.
+  def notification_repetition_notice(occurrences)
+    return if occurrences < 2
+
+    tag.p(t(:notification_repeated, count: occurrences))
+  end
+
   # Generate email footer with preferences link for registered users
   def email_footer_html(recipient_email = nil)
     base_footer = t(:email_footer_html)

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -1,6 +1,9 @@
 class Notifications < ActionMailer::Base
   default from: "editor@benyehuda.org" # TODO: un-hardcode
 
+  # How many distinct notifications a digest renders in full before summarising the rest as a count.
+  MAX_DIGEST_ITEMS = 30
+
   # Send or queue notification based on recipient's email preferences
   def self.send_or_queue(method_name, recipient_email, *args)
     NotificationService.call(
@@ -179,7 +182,12 @@ class Notifications < ActionMailer::Base
   #   he.notifications.notification_digest.subject
   def notification_digest(recipient_email, notifications)
     @greeting = t(:hello_anon)
-    @notifications = notifications
+    collapsed = PendingNotification.collapse(notifications)
+    # A recipient who accumulated hundreds of rows would otherwise get a multi-megabyte email that
+    # their provider may truncate or reject outright, costing them the whole digest rather than
+    # its tail.
+    @notifications = collapsed.first(MAX_DIGEST_ITEMS)
+    @omitted_count = collapsed.drop(MAX_DIGEST_ITEMS).sum(&:last)
     @recipient_email = recipient_email
     mail to: recipient_email
   end

--- a/app/models/pending_notification.rb
+++ b/app/models/pending_notification.rb
@@ -14,6 +14,17 @@ class PendingNotification < ApplicationRecord
     all.group_by(&:recipient_email)
   end
 
+  # Collapses exact duplicates into [notification, occurrences] pairs, preserving order.
+  #
+  # Exact means same type *and* same payload. Grouping on the type alone would be lossy: two
+  # different tags approved are both 'Notifications#tag_approved' but are two different things to
+  # tell the recipient about. Only a repeat of the identical notification -- a moderator
+  # batch-processing the same suggestion, a re-approval -- is noise worth folding away.
+  def self.collapse(notifications)
+    notifications.group_by { |n| [n.notification_type, n.notification_data] }
+                 .map { |_payload, occurrences| [occurrences.first, occurrences.size] }
+  end
+
   # The stored mailer arguments, with GlobalID references resolved back into records.
   # Raises ActiveJob::DeserializationError when a referenced record no longer exists.
   def mailer_args

--- a/app/views/notifications/notification_digest.html.haml
+++ b/app/views/notifications/notification_digest.html.haml
@@ -3,9 +3,14 @@
 
   %p= t(:notification_digest_intro)
 
-  - @notifications.each do |notification|
+  - @notifications.each do |notification, occurrences|
     %hr
     = render_notification(notification)
+    = notification_repetition_notice(occurrences)
+
+  - if @omitted_count.positive?
+    %hr
+    %p= t(:notification_digest_omitted, count: @omitted_count)
 
   %hr
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -898,6 +898,12 @@ en:
   notification_digest_intro: Here is a summary of the notifications we have collected
     for you
   notification_render_error: Error rendering notification
+  notification_repeated: "(this notification arrived %{count} times)"
+  notification_digest_omitted:
+    one: And one more notification not shown here, to keep this message a reasonable
+      size.
+    other: And %{count} more notifications not shown here, to keep this message a reasonable
+      size.
   dictionary_entries: Dictionary Entries
   works: Works
   volumes: Volumes

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2433,6 +2433,10 @@ he:
   email_footer_signup_invitation: אם תרצה/י לשלוט בתדירות קבלת הודעות הדואל, תוכל/י להירשם לאתר ולהגדיר את ההעדפות שלך.
   notification_digest_intro: להלן סיכום ההודעות שצברנו עבורך
   notification_render_error: שגיאה בעיבוד הודעה
+  notification_repeated: "(הודעה זו התקבלה %{count} פעמים)"
+  notification_digest_omitted:
+    one: ועוד הודעה אחת שלא נכללה כאן, כדי לשמור על גודל סביר של המכתב.
+    other: ועוד %{count} הודעות שלא נכללו כאן, כדי לשמור על גודל סביר של המכתב.
   unrecognized_format: תבנית קובץ לא מוכרת
   collection_item_operation_error: 'אירעה שגיאה: %{error}. הדף ייטען מחדש.'
   next_match: המופע הבא

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -135,4 +135,66 @@ RSpec.describe Notifications, type: :mailer do
       end
     end
   end
+
+  # by-cnh.7: the digest used to render every buffered row in full, so a repetitive or long-
+  # accumulated buffer produced a wall of near-identical blocks, or an email too big to deliver.
+  describe '#notification_digest' do
+    subject(:mail) { described_class.notification_digest(user.email, notifications) }
+
+    let(:user) { create(:user) }
+    let(:tag) { create(:tag, creator: user) }
+
+    context 'with the same notification buffered several times' do
+      let(:notifications) { create_list(:pending_notification, 3, recipient_email: user.email, args: [tag]) }
+
+      it 'renders the notification once' do
+        expect(mail.body.encoded.scan(tag.name).size).to eq(1)
+      end
+
+      it 'says how many times it arrived' do
+        expect(mail.body.encoded).to include(ERB::Util.html_escape(I18n.t(:notification_repeated, count: 3)))
+      end
+    end
+
+    context 'with distinct notifications of the same type' do
+      let(:other_tag) { create(:tag, creator: user) }
+      let(:notifications) do
+        [create(:pending_notification, recipient_email: user.email, args: [tag]),
+         create(:pending_notification, recipient_email: user.email, args: [other_tag])]
+      end
+
+      it 'renders both, since they are two different things to report' do
+        expect(mail.body.encoded).to include(tag.name).and include(other_tag.name)
+      end
+
+      it 'does not claim either one repeated' do
+        expect(mail.body.encoded).not_to include(ERB::Util.html_escape(I18n.t(:notification_repeated, count: 2)))
+      end
+    end
+
+    context 'with more distinct notifications than the cap' do
+      let(:notifications) do
+        Array.new(Notifications::MAX_DIGEST_ITEMS + 3) do
+          create(:pending_notification, recipient_email: user.email, args: [create(:tag, creator: user)])
+        end
+      end
+
+      it 'renders only up to the cap' do
+        rendered = notifications.first(Notifications::MAX_DIGEST_ITEMS).map { |n| n.mailer_args.first.name }
+        expect(rendered.count { |name| mail.body.encoded.include?(name) }).to eq(Notifications::MAX_DIGEST_ITEMS)
+      end
+
+      it 'summarises the remainder as a count' do
+        expect(mail.body.encoded).to include(ERB::Util.html_escape(I18n.t(:notification_digest_omitted, count: 3)))
+      end
+    end
+
+    context 'with fewer notifications than the cap' do
+      let(:notifications) { [create(:pending_notification, recipient_email: user.email, args: [tag])] }
+
+      it 'says nothing about omitted notifications' do
+        expect(mail.body.encoded).not_to include(ERB::Util.html_escape(I18n.t(:notification_digest_omitted, count: 1)))
+      end
+    end
+  end
 end

--- a/spec/models/pending_notification_spec.rb
+++ b/spec/models/pending_notification_spec.rb
@@ -58,6 +58,35 @@ RSpec.describe PendingNotification, type: :model do
     end
   end
 
+  # by-cnh.7: the digest used to render every buffered row in full, however repetitive.
+  describe '.collapse' do
+    let(:tag) { create(:tag) }
+    let(:other_tag) { create(:tag) }
+
+    it 'folds identical notifications into one entry carrying the count' do
+      duplicates = create_list(:pending_notification, 3, args: [tag])
+
+      expect(described_class.collapse(duplicates)).to eq([[duplicates.first, 3]])
+    end
+
+    # Grouping on the type alone would silently drop content: two tags approved are two things to
+    # tell the recipient about, not one thing said twice.
+    it 'keeps same-type notifications with different payloads apart' do
+      first = create(:pending_notification, args: [tag])
+      second = create(:pending_notification, args: [other_tag])
+
+      expect(described_class.collapse([first, second])).to eq([[first, 1], [second, 1]])
+    end
+
+    it 'preserves the order of first appearance' do
+      first = create(:pending_notification, args: [tag])
+      second = create(:pending_notification, args: [other_tag])
+      third = create(:pending_notification, args: [tag])
+
+      expect(described_class.collapse([first, second, third])).to eq([[first, 2], [second, 1]])
+    end
+  end
+
   describe '#mailer_args' do
     let(:tag) { create(:tag) }
     let(:notification) { create(:pending_notification, args: [tag, 'a note', nil]).reload }


### PR DESCRIPTION
Stacked on **#1635** (`fix/digest-delivery-lifecycle`), which is its base branch. Merge that one first.

Closes the last child of the `by-cnh` epic.

## What

`app/views/notifications/notification_digest.html.haml` iterated `@notifications` unconditionally and rendered every buffered row in full, with an `<hr>` between. Two consequences:

1. **No deduplication.** Ten identical notifications (a moderator batch-processing the same suggestion, a tag approved and re-approved) produced ten near-identical blocks.
2. **No size bound.** A recipient who had accumulated hundreds of rows — very possible before by-cnh.4 — got a multi-megabyte email that a provider may truncate or reject outright, costing them the whole digest rather than its tail.

## How

**`PendingNotification.collapse`** folds duplicates into `[notification, occurrences]` pairs, preserving order of first appearance.

⚠️ **Interpretation worth a look.** The bead says "grouping by type — or by type plus payload", and its acceptance criterion says "duplicate notifications *of the same type* collapse". I implemented **type + payload**, because type alone is lossy: two different tags approved are both `Notifications#tag_approved`, and collapsing them into one block with "×2" would silently drop content — which contradicts the epic's "summary of everything" promise. Only an exact repeat is noise worth folding away, and the recipient is told it repeated. Say the word if you wanted the looser grouping.

**`Notifications::MAX_DIGEST_ITEMS = 30`** caps how many distinct notifications are rendered in full. The remainder is summarised as a count of *notifications* (not groups), which is what a reader thinks in.

The bead suggested the "and N more" line carry "a link into the site". There is no notifications inbox to link to, so I did not invent one — the line is text only. The footer already links to the email-preferences page.

**New strings**, in both `he.yml` and `en.yml`:
- `notification_repeated` — "(הודעה זו התקבלה %{count} פעמים)". Not pluralised: the view only renders it for `count >= 2`.
- `notification_digest_omitted` — pluralised `one`/`other`, since exactly one notification can be omitted. `rails-i18n` gives Hebrew a one/other rule, matching the existing `items_count`-style keys in `he.yml`.

The `- if occurrences > 1` in the template moved into `notification_repetition_notice` in `NotificationsHelper` — it keeps `haml-lint`'s RuboCop pass from firing `Style/Next` on the loop body, and reads better anyway.

## Test plan

```
bundle exec rspec spec/mailers/notifications_spec.rb spec/models/pending_notification_spec.rb \
  spec/jobs/notification_digest_job_spec.rb
# 52 examples, 0 failures
```

Covering the beads' acceptance criteria:
- three copies of the same notification render once, with the repeat count
- two *different* tag approvals both render, and neither is labelled a repeat
- past the cap, only `MAX_DIGEST_ITEMS` render and the remainder is summarised
- under the cap, nothing is said about omissions
- `.collapse` preserves order of first appearance

Verified the new specs fail against the old code (stashed the four app files: 4 of 7 fail).

`bundle exec rubocop` and `bundle exec haml-lint` on the changed files report only pre-existing offences (`Style/Documentation` on the helper module, `SpaceInsideHashAttributes` on line 1 of the template) — nothing on changed lines, so Pronto stays quiet.

Full suite **not** run — per `.claude/rules/full-test-suite-runtime.md` that needs your go-ahead.

Bead: by-cnh.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
