### PR TITLE
Give the tag factory an unbounded name source (by-7lw)

### DIFF
--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -3,7 +3,11 @@
 FactoryBot.define do
   factory :tag do
     status { :approved }
-    name { Faker::Lorem.unique.word }
+    # by-7lw: NOT Faker::Lorem.unique.word -- that pool is 249 words wide and is never reset, so
+    # the 250th create(:tag) in a suite run raised RetryLimitExceeded, wherever it fell. Padded so
+    # that no name is a substring of another ('tag-0001' vs 'tag-0011'), which specs searching a
+    # rendered body for a tag name would otherwise miscount.
+    sequence(:name) { |n| format('tag-%04d', n) }
     creator { create(:user) }
   end
 

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -142,10 +142,8 @@ RSpec.describe Notifications, type: :mailer do
     subject(:mail) { described_class.notification_digest(user.email, notifications) }
 
     let(:user) { create(:user) }
-    # Named explicitly rather than via the factory's Faker::Lorem.unique.word default. That pool
-    # holds 249 words for the whole suite and is never reset, so the cap example below -- which
-    # needs MAX_DIGEST_ITEMS + 3 distinct tags -- would drain it and take unrelated specs down with
-    # it. The names only have to be distinguishable in the rendered body.
+    # Named explicitly so the body assertions below search for a string that is obviously this
+    # tag; the names only have to be distinguishable from one another in the rendered body.
     let(:tag) { create(:tag, name: 'digest-tag-alpha', creator: user) }
 
     context 'with the same notification buffered several times' do

--- a/spec/models/pending_notification_spec.rb
+++ b/spec/models/pending_notification_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe PendingNotification, type: :model do
 
   # by-cnh.7: the digest used to render every buffered row in full, however repetitive.
   describe '.collapse' do
-    # Named explicitly to stay off the factory's Faker::Lorem.unique.word pool, which is only 249
-    # words wide for the whole suite and is never reset.
+    # Named explicitly so the two tags are told apart at a glance in a failure message.
     let(:tag) { create(:tag, name: 'collapse-tag-alpha') }
     let(:other_tag) { create(:tag, name: 'collapse-tag-beta') }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -19,6 +19,15 @@ describe Tag do
     expect(build(:tag)).to be_valid
   end
 
+  # by-7lw: the factory used to draw names from Faker::Lorem.unique.word, a finite 249-word pool,
+  # so past that many tags every create(:tag) in the process raised RetryLimitExceeded. 300 is
+  # deliberately over that old ceiling.
+  it 'generates factory tag names from an unbounded pool' do
+    creator = create(:user) # shared, so this measures name generation and not user creation
+    names = Array.new(300) { build(:tag, creator: creator).name }
+    expect(names.uniq.size).to eq 300
+  end
+
   it 'finds tags by creator' do
     u = create(:user)
     i = 0


### PR DESCRIPTION
Fixes **by-7lw**.

## The bug

`spec/factories/tags.rb` drew its name from `Faker::Lorem.unique.word`. That pool holds **249** words (`Faker::Lorem.translate('faker.lorem.words').size`), `Faker::UniqueGenerator` state is never cleared between examples or files (nothing in `spec/rails_helper.rb`, `spec/spec_helper.rb` or `spec/support/` resets it), and the retry limit is 10_000.

So once a suite run had created 249 tags **in one process**, every subsequent `create(:tag)` anywhere raised `Faker::UniqueGenerator::RetryLimitExceeded`. This is a suite-wide tripwire, not a property of any one spec: whichever spec happened to cross the threshold failed, and so did everything after it, wherever it lived. It surfaced on PR #1635 CI when a new mailer spec needed 33 distinct tags; that spec was given explicit names, which unblocked CI but left the limit in place with the suite still close to it.

## The fix

```ruby
sequence(:name) { |n| format('tag-%04d', n) }
```

A FactoryBot sequence, matching what the `:tag_name` factory already does. Zero-padded so that no generated name is a substring of another (`tag-0001` vs `tag-0011`) — several specs assert a tag name appears in a rendered mail body by substring search, and `notifications_spec.rb` already pads its own explicit names for exactly that reason.

Also refreshed the two comments in `pending_notification_spec.rb` and `notifications_spec.rb` that documented the pool constraint as the reason for their explicit names. The explicit names stay (recognisable strings are worth having in a rendered body); only the stale rationale is gone.

## Checked before changing the shape of the name

- No spec asserts factory tag names are real words. Specs that care about a tag's name pass it explicitly (`tags_browse_spec.rb` sorting, `taggings_controller_spec.rb` autocomplete/pagination, `tag_similarity_job_spec.rb`).
- `TagName` has a global `uniqueness` validation and `Tag#create_tag_name` mirrors the tag name into it — `tag-NNNN` collides with neither the `:tag_name` factory's `"Tag Name #{n}"` nor the explicit `"Tag001"`-style names in `taggings_controller_spec.rb`.
- `TagName#similar_to?` (70% threshold) is only ever run from `TaggingsController` on a user-proposed name, never over factory-built tags, so the sequence's mutual similarity is inert.
- `spec/models/tag_spec.rb` calls `Faker::Science.unique.science` directly, but that file clears the unique generator in a `before` hook, so it is not exposed. Left alone.

## Test plan

New regression test in `spec/models/tag_spec.rb` builds 300 tags — deliberately over the old 249 ceiling — off a shared creator and asserts all names are distinct. Verified it **fails** against the old factory (`RetryLimitExceeded`) and passes with the fix.

Specs run (all green):

```
spec/models/tag_spec.rb spec/models/pending_notification_spec.rb
spec/jobs/tag_similarity_job_spec.rb                              -> 30 examples, 0 failures
spec/controllers/admin/tags_controller_spec.rb
spec/controllers/admin/taggings_controller_spec.rb
spec/controllers/taggings_controller_spec.rb
spec/mailers/notifications_spec.rb
spec/jobs/notification_digest_job_spec.rb
spec/services/notification_service_spec.rb
spec/lib/tasks/export_catalog_rake_spec.rb                        -> 134 examples, 0 failures
spec/system/{tags_browse,tag_editing,by_tag_filtering,tag_policy_modal,
             tag_proposal_mobile,anthology_tagging}_spec.rb
spec/system/admin/tags_management_spec.rb                         -> 83 examples, 0 failures, 2 pending (pre-existing)
```

RuboCop is clean on the added lines (the remaining `RSpec/DescribedClass` offences in `tag_spec.rb` are pre-existing and untouched).

**The full suite was not run** — it takes 40+ minutes and needs explicit approval. Since this change is suite-wide by nature, a full CI run is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
