### PR TITLE
Show the verification workbench's bio exactly as stored, image and all

### DIFF
--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -125,7 +125,12 @@
           = t('lexicon.verification.sections.compare_button')
         %button.btn-close{type: 'button', 'data-bs-dismiss': 'alert', 'aria-label': 'Close'}
     - if item.bio.present?
-      .bio-content!= MarkdownToHtml.call(bio_for_display(item.bio, entry))
+      -#
+        Deliberately NOT bio_for_display, unlike LexEntry#show: that strips any <img> pointing at
+        the entry's profile image, because the show page renders the portrait separately in
+        .lexicon-author-details. Here the editor needs to see the bio exactly as stored -- an image
+        they just inserted with the picker must not silently vanish from this preview.
+      .bio-content!= MarkdownToHtml.call(item.bio)
     - else
       %p.text-muted= t('lexicon.verification.sections.no_biography')
   .section-actions

--- a/spec/requests/lexicon/verification_bio_image_spec.rb
+++ b/spec/requests/lexicon/verification_bio_image_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# An editor inserting an attached image into a biography with the picker used to see it disappear
+# from the workbench's bio card: the card rendered the bio through bio_for_display, which strips
+# any <img> pointing at the entry's profile image. That strip belongs to the public entry page,
+# which renders the portrait separately -- the workbench must show the bio exactly as stored.
+RSpec.describe 'Biography image in the verification workbench', type: :request do
+  let(:person) { build(:lex_person, bio: 'ביוגרפיה קצרה.') }
+  let!(:entry) { create(:lex_entry, :person, status: status, lex_item: person) }
+  let(:image_path) { entry.download_path('portrait.jpg') }
+
+  before do
+    entry.attachments.attach(
+      io: Rails.root.join('spec/fixtures/files/test_image.jpg').open('rb'),
+      filename: 'portrait.jpg',
+      content_type: 'image/jpeg'
+    )
+    entry.update!(profile_image_id: entry.attachments.first.id)
+    person.update!(bio: %(<img src="#{image_path}" data-align="left" />\n\nביוגרפיה קצרה.))
+  end
+
+  describe 'GET /lex/verification/:id' do
+    let(:status) { :draft }
+
+    before do
+      login_as_lexicon_editor
+      entry.start_verification!('test@example.com')
+    end
+
+    it 'keeps an image that is also the entry’s profile image' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(%(<img src="#{image_path}"))
+    end
+  end
+
+  describe 'GET the public entry page' do
+    let(:status) { :published }
+
+    it 'still strips the inline copy, which it renders as a portrait of its own' do
+      get lexicon_entry_path(entry)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include(%(<img src="#{image_path}"))
+      expect(response.body).to include('lexicon-author-pic')
+    end
+  end
+end

--- a/spec/requests/lexicon/verification_bio_image_spec.rb
+++ b/spec/requests/lexicon/verification_bio_image_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe 'Biography image in the verification workbench', type: :request d
   let(:image_path) { entry.download_path('portrait.jpg') }
 
   before do
-    entry.attachments.attach(
-      io: Rails.root.join('spec/fixtures/files/test_image.jpg').open('rb'),
-      filename: 'portrait.jpg',
-      content_type: 'image/jpeg'
-    )
+    File.open(Rails.root.join('spec/fixtures/files/test_image.jpg'), 'rb') do |io|
+      entry.attachments.attach(
+        io: io,
+        filename: 'portrait.jpg',
+        content_type: 'image/jpeg'
+      )
+    end
     entry.update!(profile_image_id: entry.attachments.first.id)
     person.update!(bio: %(<img src="#{image_path}" data-align="left" />\n\nביוגרפיה קצרה.))
   end


### PR DESCRIPTION
## The bug

Reported from production (lexicon entry 98, מלכה שקד): an editor used the new bio image picker,
the correct tag landed in the bio buffer —

```html
<img src="/files/lex/98/malka_shaked.jpg" alt="malka_shaked.jpg" data-border="0" data-align="left" data-hspace="10" width="261" height="336"/>
```

— but after saving, no image appeared, and inspecting the DOM showed **no `<img>` element at all**,
as if the markup had been sanitized.

## Cause

Not sanitization. `bio_for_display` (`app/helpers/lexicon_helper.rb:232`) deletes every `<img>`
whose `src` contains the entry's **profile image** filename. Entry 98 has `malka_shaked.jpg` set as
its profile image, so the tag the picker had just inserted was stripped at render time.

That strip is right for `LexEntry#show`, which renders the portrait separately in
`.lexicon-author-details` and would otherwise show it twice. The verification workbench has no such
block, so there the strip only made the editor's own insertion disappear. And since
`options_from_images` offers every image attachment — profile image included — this is the easy
case to hit, not a corner one.

Verified while diagnosing: `MarkdownToHtml` passes the tag through untouched, and the exact
`bio_for_display` regex removes the reported tag when `filename == "malka_shaked.jpg"`.

## The fix

The workbench bio card renders `item.bio` directly, so an editor verifying a migration sees exactly
what is stored. `LexEntry#show` keeps stripping, unchanged.

## Test plan

New `spec/requests/lexicon/verification_bio_image_spec.rb`, both examples on an entry whose bio
embeds its own profile image:

- workbench (`GET /lex/verification/:id`) — the `<img>` is present  ← fails on master, passes here
- public entry page — the inline copy is still stripped, `.lexicon-author-pic` still rendered

```
bundle exec rspec spec/requests/lexicon/verification_bio_image_spec.rb        # 2 examples, 0 failures
bundle exec rspec spec/helpers/lexicon_helper_spec.rb \
                  spec/requests/lexicon/verification_spec.rb \
                  spec/requests/author_toc_lexicon_content_spec.rb            # 139 examples, 0 failures
bundle exec rspec spec/system/lexicon/bio_image_float_spec.rb \
                  spec/system/lexicon/bio_insert_image_spec.rb                # 5 examples, 0 failures
```

The full suite was **not** run (40+ min; needs the maintainer's go-ahead).

## Separate issue found while diagnosing (not fixed here)

`Lexicon::AttachmentsController#create`/`#destroy` never call `clear_redirect_urls_cache`, unlike
`ManifestationController`. `FilesController` caches an entry's filename→URL map for 2 hours — and
caches it even when empty — so an image attached to a LexEntry whose map was already cached will
404 from `/files/lex/:id/:filename` until the TTL expires. Tracked as `by-bg4`'s follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
