### PR TITLE
Make LexEntry#english_title editable in the entry properties forms

### DIFF
--- a/app/controllers/lexicon/people_controller.rb
+++ b/app/controllers/lexicon/people_controller.rb
@@ -58,7 +58,7 @@ module Lexicon
           :birthdate,
           :deathdate,
           :bio,
-          { entry_attributes: %i(title other_designation date_of_manual_update) }
+          { entry_attributes: %i(title english_title other_designation date_of_manual_update) }
         ]
       )
     end

--- a/app/controllers/lexicon/publications_controller.rb
+++ b/app/controllers/lexicon/publications_controller.rb
@@ -52,7 +52,7 @@ module Lexicon
           :description,
           :toc,
           :az_navbar,
-          { entry_attributes: %i(title other_designation date_of_manual_update) }
+          { entry_attributes: %i(title english_title other_designation date_of_manual_update) }
         ]
       )
     end

--- a/app/views/lexicon/people/_form.html.haml
+++ b/app/views/lexicon/people/_form.html.haml
@@ -2,6 +2,7 @@
 = simple_form_for @lex_person, url: url, remote: true do |f|
   = f.simple_fields_for :entry do |ef|
     = ef.input :title
+    = ef.input :english_title
     = ef.input :other_designation
     = ef.input :date_of_manual_update
     = ef.input :status do

--- a/app/views/lexicon/publications/_form.html.haml
+++ b/app/views/lexicon/publications/_form.html.haml
@@ -2,6 +2,7 @@
 = simple_form_for @lex_publication, url: url, remote: true do |f|
   = f.simple_fields_for :entry do |ef|
     = ef.input :title
+    = ef.input :english_title
     = ef.input :other_designation
     = ef.input :date_of_manual_update
     = ef.input :status do

--- a/spec/requests/lexicon/people_spec.rb
+++ b/spec/requests/lexicon/people_spec.rb
@@ -16,7 +16,7 @@ describe '/lexicon/people' do
   end
 
   let(:valid_attributes) do
-    valid_person_attributes.merge(entry_attributes: { title: 'Test (test)' })
+    valid_person_attributes.merge(entry_attributes: { title: 'Test (test)', english_title: 'Test Person' })
   end
 
   let(:invalid_attributes) do
@@ -42,7 +42,11 @@ describe '/lexicon/people' do
         lex_person = LexPerson.order(id: :desc).first
         expect(call).to eq(200)
         expect(lex_person).to have_attributes(valid_person_attributes)
-        expect(lex_person.entry).to have_attributes(title: 'Test (test)', sort_title: 'תתתת_Test test')
+        expect(lex_person.entry).to have_attributes(
+          title: 'Test (test)',
+          english_title: 'Test Person',
+          sort_title: 'תתתת_Test test'
+        )
         expect(flash.notice).to eq(I18n.t('lexicon.people.create.success'))
       end
     end
@@ -58,9 +62,14 @@ describe '/lexicon/people' do
   end
 
   describe 'GET /edit' do
-    subject { get "/lex/people/#{lex_person.id}/edit" }
+    subject(:call) { get "/lex/people/#{lex_person.id}/edit" }
 
     it { is_expected.to eq(200) }
+
+    it 'renders an editable english_title field' do
+      call
+      expect(response.body).to include('lex_person[entry_attributes][english_title]')
+    end
   end
 
   describe 'PATCH /update' do
@@ -69,7 +78,11 @@ describe '/lexicon/people' do
     it 'updates the record' do
       expect(call).to eq(200)
       expect(lex_person.reload).to have_attributes(valid_person_attributes)
-      expect(lex_person.entry).to have_attributes(title: 'Test (test)', sort_title: 'תתתת_Test test')
+      expect(lex_person.entry).to have_attributes(
+        title: 'Test (test)',
+        english_title: 'Test Person',
+        sort_title: 'תתתת_Test test'
+      )
     end
   end
 end

--- a/spec/requests/lexicon/publications_spec.rb
+++ b/spec/requests/lexicon/publications_spec.rb
@@ -12,7 +12,7 @@ describe '/lexicon/publications' do
   let(:valid_publication_attributes) { attributes_for(:lex_publication).except('created_at', 'updated_at', 'id') }
 
   let(:valid_attributes) do
-    valid_publication_attributes.merge(entry_attributes: { title: 'Test (test)' })
+    valid_publication_attributes.merge(entry_attributes: { title: 'Test (test)', english_title: 'Test Publication' })
   end
 
   let(:invalid_attributes) do
@@ -40,6 +40,7 @@ describe '/lexicon/publications' do
         expect(lex_publication).to have_attributes(valid_publication_attributes)
         expect(lex_publication.entry).to have_attributes(
           title: 'Test (test)',
+          english_title: 'Test Publication',
           status: 'draft',
           sort_title: 'תתתת_Test test'
         )
@@ -58,9 +59,14 @@ describe '/lexicon/publications' do
   end
 
   describe 'GET /edit' do
-    subject { get "/lex/publications/#{lex_publication.id}/edit" }
+    subject(:call) { get "/lex/publications/#{lex_publication.id}/edit" }
 
     it { is_expected.to eq(200) }
+
+    it 'renders an editable english_title field' do
+      call
+      expect(response.body).to include('lex_publication[entry_attributes][english_title]')
+    end
   end
 
   describe 'PATCH /update' do
@@ -73,6 +79,7 @@ describe '/lexicon/publications' do
       expect(lex_publication.reload).to have_attributes(valid_publication_attributes)
       expect(lex_publication.entry).to have_attributes(
         title: 'Test (test)',
+        english_title: 'Test Publication',
         sort_title: 'תתתת_Test test'
       )
     end


### PR DESCRIPTION
## Problem

`LexEntry#english_title` is populated by the ingest services and displayed in the
verification workbench, but the entry **properties** forms (`lexicon/people/_form`
and `lexicon/publications/_form`) had no input for it. An editor could not correct
or fill it in from the entry edit screen.

## Changes

- `app/views/lexicon/people/_form.html.haml`, `app/views/lexicon/publications/_form.html.haml`:
  added `= ef.input :english_title` directly below the `title` input in the nested
  entry field set.
- `app/controllers/lexicon/people_controller.rb`, `app/controllers/lexicon/publications_controller.rb`:
  permitted `english_title` in `entry_attributes`.

Labels come from the existing `activerecord.attributes.lex_entry.english_title`
key, already present in both `he` and `en` locales (used by the verification
workbench form), so no new I18n entries were needed.

## Tests

Extended the existing request specs rather than adding parallel files:

- `spec/requests/lexicon/people_spec.rb` and `spec/requests/lexicon/publications_spec.rb`:
  - `GET /edit` now asserts the `entry_attributes[english_title]` input is rendered
    (this is the assertion that fails without the view change).
  - `POST /create` and `PATCH /update` now send `english_title` and assert it
    round-trips to the entry (fails without the strong-params change).

```
bundle exec rspec spec/requests/lexicon/people_spec.rb spec/requests/lexicon/publications_spec.rb
# 12 examples, 0 failures
```

RuboCop and haml-lint clean on all changed files. The full suite (40+ min) was
**not** run — only the targeted specs above.

## Note (not changed here)

`config/locales/active_record.he.yml` translates `lex_entry.english_title` as the
literal English string `"English title"`. That's pre-existing and shared with the
verification workbench; left alone to keep this PR scoped, but worth a follow-up
if a Hebrew label (e.g. "שם באנגלית") is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
