### PR TITLE
Batch large citation lists across multiple LLM calls (by-dyv)

### DIFF
--- a/app/services/lexicon/parse_citations.rb
+++ b/app/services/lexicon/parse_citations.rb
@@ -66,10 +66,45 @@ module Lexicon
   ```
 PROMPT
 
+    # Above this many <li> a whole bibliography no longer fits in one model response: the model
+    # emits every subject header but only the first work or two of the later groups, silently
+    # losing most of the citations (00540.php: 202 items in, ~66 out). Beyond the threshold the
+    # section is split at its subject headings and one request is issued per heading.
+    MAX_SINGLE_REQUEST_CITATIONS = 120
+
     def call(html)
       Rails.logger.info('Parsing citations HTML with LLM API started.')
       @source_items = []
+      # Preprocessing, and the two recovery passes below, deliberately run over the whole section
+      # rather than per batch: @source_items must stay complete, and the "assign each citation at
+      # most once" bookkeeping must see every citation, for aggregation to be safe.
       html = preprocess_source_items(html)
+      batches = split_into_batches(html)
+      Rails.logger.info("Parsing citations in #{batches.size} request(s).")
+      result = batches.flat_map { |batch| parse_batch(batch) }
+
+      # The LLM is unreliable at copying data-file-link into backup_url, so we
+      # recover it deterministically from the asterisk links we captured.
+      recover_backup_urls(result)
+      # The LLM only reports one link per citation, so inline links sitting in other parts of the
+      # record (typically the publication the citation appeared in) are recovered separately.
+      assign_text_links(result)
+
+      Rails.logger.info('Parsing citations complete.')
+      result
+    end
+
+    # A bracketed descriptor standing where a title belongs, e.g. "[ביקורת]" (review) or
+    # "[מחבר לא מזוהה]" (unidentified author). Kept with its brackets, matching how the same
+    # placeholder is already stored when the <li> does have an author to precede it.
+    PLACEHOLDER_TITLE = /\A\[.+\]\.?\z/m
+
+    private
+
+    # Parses one request's worth of HTML into LexCitations. A batch that comes back unparseable
+    # raises, aborting the entry exactly as a bad single request does today — a silently partial
+    # bibliography is the bug being fixed here.
+    def parse_batch(html)
       chat = RubyLLM.chat(model: 'gpt-4.1-mini')
       chat.with_instructions(SYSTEM_PROMPT).with_params(response_format: { type: :json_object })
 
@@ -118,23 +153,50 @@ PROMPT
         end
       end
 
-      # The LLM is unreliable at copying data-file-link into backup_url, so we
-      # recover it deterministically from the asterisk links we captured.
-      recover_backup_urls(result)
-      # The LLM only reports one link per citation, so inline links sitting in other parts of the
-      # record (typically the publication the citation appeared in) are recovered separately.
-      assign_text_links(result)
-
-      Rails.logger.info('Parsing citations complete.')
       result
     end
 
-    # A bracketed descriptor standing where a title belongs, e.g. "[ביקורת]" (review) or
-    # "[מחבר לא מזוהה]" (unidentified author). Kept with its brackets, matching how the same
-    # placeholder is already stored when the <li> does have an author to precede it.
-    PLACEHOLDER_TITLE = /\A\[.+\]\.?\z/m
+    # Splits the section into the HTML of one request per subject heading, or returns it whole
+    # when a single request can be trusted with it.
+    def split_into_batches(html)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      total = doc.css('li').size
+      return [html] if total <= MAX_SINGLE_REQUEST_CITATIONS
 
-    private
+      batches = subject_batches(doc)
+      # Batching must never lose a citation the single request would have kept: a bare <li>
+      # outside any <ul> belongs to no batch, and ExtractCitations does admit such markup.
+      return [html] unless batches.any? && batches.sum { |batch| batch[:count] } == total
+
+      batches.pluck(:html)
+    end
+
+    # One batch per non-empty top-level list, its heading nodes prepended. Lists nested inside an
+    # <li> are left out: they are sub-citations of the work that contains them and must travel
+    # with it (see the 00156.php regression).
+    def subject_batches(doc)
+      lists = doc.css('ul').reject { |list| list.ancestors('li').any? }
+      lists.filter_map do |list|
+        count = list.css('li').size
+        next if count.zero?
+
+        { html: (heading_nodes_for(list, lists) << list).map(&:to_html).join("\n"), count: count }
+      end
+    end
+
+    # The subject of a list is written in the nodes just before it (typically a <font>), so those
+    # travel with it. Walks back to the previous top-level list — including the empty <ul></ul>
+    # separators legacy pages put between sections, which is precisely why empty lists are kept in
+    # `lists` — skipping blank filler such as <hr> and <font></font> on the way.
+    def heading_nodes_for(list, lists)
+      nodes = []
+      node = list.previous_element
+      while node.present? && lists.exclude?(node)
+        nodes.unshift(node) if node.text.present?
+        node = node.previous_element
+      end
+      nodes
+    end
 
     # True when the work's single author is a bracketed placeholder rather than a real name.
     # Only consulted once the title is known to be blank, so a bracketed author accompanying a

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe LexiconHelper, type: :helper do
     it 'renders NLI identifier with correct URL' do
       result = helper.render_external_identifiers({ 'nli' => '000123456' })
       expect(result).to include('NLI –')
-      expect(result).to include('http://uli.nli.org.il/authorities/000123456')
+      expect(result).to include('https://www.nli.org.il/he/authorities/000123456')
     end
 
     it 'renders Wikidata identifier with correct URL' do

--- a/spec/services/lexicon/parse_citations_spec.rb
+++ b/spec/services/lexicon/parse_citations_spec.rb
@@ -5,6 +5,25 @@ require 'rails_helper'
 describe Lexicon::ParseCitations do
   subject(:result) { described_class.call(html) }
 
+  # `sent` collects the HTML actually handed to the LLM, so specs can assert on it. Each
+  # successive request is answered with the next of `groups` — the batched path issues one
+  # request per subject heading, so one group per heading.
+  def stub_llm_groups(groups, sent = [])
+    chat_double = instance_double(RubyLLM::Chat)
+    allow(RubyLLM).to receive(:chat).and_return(chat_double)
+    allow(chat_double).to receive_messages(with_instructions: chat_double, with_params: chat_double)
+    pending = groups.dup
+    allow(chat_double).to receive(:ask) do |html_arg|
+      sent << html_arg
+      instance_double(RubyLLM::Message, content: { result: [pending.shift].compact }.to_json)
+    end
+  end
+
+  # The single-request form: the one request is answered with a single unnamed group of `works`.
+  def stub_llm_capturing(works, sent = [])
+    stub_llm_groups([{ subject: nil, works: works }], sent)
+  end
+
   context 'when html is provided', vcr: { cassette_name: 'lexicon/parse_citations/00024_snippet' } do
     let(:html) do
       <<~HTML
@@ -321,17 +340,6 @@ describe Lexicon::ParseCitations do
       ]
     end
 
-    # `sent` collects the HTML actually handed to the LLM, so specs can assert on it.
-    def stub_llm_capturing(works, sent = [])
-      chat_double = instance_double(RubyLLM::Chat)
-      allow(RubyLLM).to receive(:chat).and_return(chat_double)
-      allow(chat_double).to receive_messages(with_instructions: chat_double, with_params: chat_double)
-      allow(chat_double).to receive(:ask) do |html_arg|
-        sent << html_arg
-        instance_double(RubyLLM::Message, content: { result: [{ subject: nil, works: works }] }.to_json)
-      end
-    end
-
     it 'assigns backup_url only to the nested citation the asterisk belongs to' do
       stub_llm_capturing(works)
 
@@ -525,6 +533,247 @@ describe Lexicon::ParseCitations do
       stub_llm([works.first.merge(authors: [{ name: '[סדן, דב]', link: '02402.php' }])])
 
       expect(result).to be_empty
+    end
+  end
+
+  # Regression: a bibliography too long for one model response (00540.php has 202 records) came
+  # back with every subject header but only the first work or two of the later groups, so most of
+  # it was lost. Past the threshold the section is split at its subject headings, one request per
+  # heading, and the results aggregated.
+  describe 'batching a long bibliography' do
+    # The shape legacy pages use: an empty <ul> separator and an <hr> between sections, with the
+    # subject in a <font> immediately before its list.
+    def bibliography_html(sections)
+      sections.map do |heading, items|
+        <<~HTML
+          <font color="#FF0000"></font>
+          <ul style="MARGIN-TOP: 0in" type="disc"></ul>
+          <hr>
+          <font color="#FF0000">#{heading}</font>
+          <ul style="MARGIN-TOP: 0in" type="disc">
+          #{items.map { |item| "<li>#{item}</li>" }.join("\n")}
+          </ul>
+        HTML
+      end.join("\n")
+    end
+
+    # Numbered so each title is unique and comfortably longer than the eight characters the
+    # title-containment fallback in match_by_text requires.
+    def title_for(heading, index)
+      "כותרת ייחודית #{heading} מספר #{index}"
+    end
+
+    def plain_items(heading, count)
+      (1..count).map { |i| "<b>מחבר, שם.</b> #{title_for(heading, i)}. עיתון, 2024, עמ' #{i}." }
+    end
+
+    def work(title, **overrides)
+      { title: title, authors: [], from_publication: 'עיתון, 2024', pages: '1',
+        link: nil, backup_url: nil, notes: nil }.merge(overrides)
+    end
+
+    def group(heading, count)
+      { subject: heading, works: (1..count).map { |i| work(title_for(heading, i)) } }
+    end
+
+    def li_texts(batch_html)
+      Nokogiri::HTML::DocumentFragment.parse(batch_html).css('li').map { |li| li.text.squish }
+    end
+
+    context 'when the bibliography is within the single-request threshold' do
+      let(:sections) { { 'על השירה' => 40, 'על הפרוזה' => 40, 'על המחזות' => 40 } }
+      let(:html) { bibliography_html(sections.transform_values { |count| plain_items('על השירה', count) }) }
+
+      it 'issues exactly one request, carrying the whole section' do
+        sent = []
+        stub_llm_capturing(group('על השירה', 40)[:works], sent)
+
+        described_class.call(html)
+
+        expect(sent.size).to eq(1)
+        expect(li_texts(sent.first).size).to eq(120)
+      end
+    end
+
+    context 'when the bibliography exceeds the threshold' do
+      let(:sections) { { 'על השירה' => 50, 'על הפרוזה' => 50, 'על המחזות' => 30 } }
+      let(:html) { bibliography_html(sections.to_h { |heading, count| [heading, plain_items(heading, count)] }) }
+      let(:groups) { sections.map { |heading, count| group(heading, count) } }
+      let(:all_titles) { sections.flat_map { |heading, count| (1..count).map { |i| title_for(heading, i) } } }
+
+      it 'issues one request per subject heading' do
+        sent = []
+        stub_llm_groups(groups, sent)
+
+        described_class.call(html)
+
+        expect(sent.size).to eq(3)
+      end
+
+      it 'sends each heading only its own citations, with none dropped or duplicated' do
+        sent = []
+        stub_llm_groups(groups, sent)
+
+        described_class.call(html)
+
+        batches = sent.map { |batch| li_texts(batch) }
+        expect(batches.map(&:size)).to eq([50, 50, 30])
+        expect(batches.flatten.uniq.size).to eq(130)
+        expect(sent.first).to include(title_for('על השירה', 1))
+        expect(sent.first).not_to include('על הפרוזה')
+      end
+
+      it 'returns the citations of every batch, in batch order' do
+        stub_llm_groups(groups)
+
+        expect(result.map(&:title)).to eq(all_titles)
+      end
+
+      it 'carries each batch subject onto its citations' do
+        stub_llm_groups(groups)
+
+        expect(result.map(&:subject).tally).to eq('על השירה' => 50, 'על הפרוזה' => 50, 'על המחזות' => 30)
+      end
+
+      it 'restarts seqno within each subject' do
+        stub_llm_groups(groups)
+
+        expect(result.map(&:seqno)).to eq([*1..50, *1..50, *1..30])
+      end
+
+      it 'skips a blank-titled citation without disturbing the other batches' do
+        blanked = groups.dup
+        blanked[1] = { subject: 'על הפרוזה',
+                       works: groups[1][:works].map.with_index { |w, i| i == 3 ? w.merge(title: nil) : w } }
+        stub_llm_groups(blanked)
+
+        expect(result.size).to eq(129)
+        expect(result.map(&:subject).tally['על הפרוזה']).to eq(49)
+      end
+    end
+
+    # recover_backup_urls and assign_text_links run once over the aggregate rather than per batch,
+    # so both have to find citations that were parsed by a request other than the first.
+    context 'when an asterisk link sits in a later batch' do
+      let(:sections) { { 'על השירה' => 60, 'על הפרוזה' => 60, 'על המחזות' => 10 } }
+      let(:groups) { sections.map { |heading, count| group(heading, count) } }
+      let(:html) do
+        items = sections.to_h { |heading, count| [heading, plain_items(heading, count)] }
+        items['על המחזות'][6] += ' <a href="/files/lex/5013/00022200.pdf">*</a>'
+        bibliography_html(items)
+      end
+
+      it 'recovers backup_url for the citation in that batch' do
+        stub_llm_groups(groups)
+
+        expect(result.size).to eq(130)
+        expect(result.select(&:backup_url).map(&:title)).to eq([title_for('על המחזות', 7)])
+        expect(result.find(&:backup_url).backup_url).to eq('/files/lex/5013/00022200.pdf')
+      end
+    end
+
+    context 'when inline links sit in citations of different batches' do
+      let(:sections) { { 'על השירה' => 60, 'על הפרוזה' => 60, 'על המחזות' => 10 } }
+      let(:groups) { sections.map { |heading, count| group(heading, count) } }
+      let(:html) do
+        items = sections.to_h { |heading, count| [heading, plain_items(heading, count)] }
+        items['על השירה'][0] += ' <a href="https://example.com/first">כתב-עת ראשון</a>'
+        items['על המחזות'][0] += ' <a href="https://example.com/last">כתב-עת אחרון</a>'
+        bibliography_html(items)
+      end
+
+      it 'assigns each text link to the citation it came from' do
+        stub_llm_groups(groups)
+
+        expect(result.find { |c| c.title == title_for('על השירה', 1) }.text_links)
+          .to eq([{ 'url' => 'https://example.com/first', 'text' => 'כתב-עת ראשון' }])
+        expect(result.find { |c| c.title == title_for('על המחזות', 1) }.text_links)
+          .to eq([{ 'url' => 'https://example.com/last', 'text' => 'כתב-עת אחרון' }])
+        expect(result.count { |c| c.text_links.present? }).to eq(2)
+      end
+    end
+
+    # ExtractCitations admits a bare <li>, which belongs to no subject list and so would be lost
+    # by batching. Rather than drop it, fall back to the single request.
+    context 'when a bare <li> sits outside any list' do
+      let(:html) do
+        "#{bibliography_html('על השירה' => plain_items('על השירה', 121))}\n<li>ציטוט יתום ארוך דיו</li>"
+      end
+
+      it 'falls back to a single request' do
+        sent = []
+        stub_llm_capturing(group('על השירה', 121)[:works], sent)
+
+        described_class.call(html)
+
+        expect(sent.size).to eq(1)
+        expect(sent.first).to include('ציטוט יתום ארוך דיו')
+      end
+    end
+
+    context 'when the bibliography has no list at all' do
+      let(:html) { (1..121).map { |i| "<li>כותרת ייחודית מספר #{i}</li>" }.join("\n") }
+
+      it 'falls back to a single request' do
+        sent = []
+        stub_llm_capturing([work('כותרת ייחודית מספר 1')], sent)
+
+        described_class.call(html)
+
+        expect(sent.size).to eq(1)
+        expect(li_texts(sent.first).size).to eq(121)
+      end
+    end
+
+    # A sub-list of citations nested inside the <li> of the work they are about (00156.php) must
+    # travel with that <li>, not become a batch of its own.
+    context 'when a citation contains a nested sub-list' do
+      let(:nested_item) do
+        <<~HTML.squish
+          <b>גרץ, נורית.</b> <b>על דעת עצמו</b> (תל־אביב : עם עובד, 2008)
+          <font color="#FF0000">על הספר:</font>
+          <ul>
+            <li><b>גלסנר, אריק.</b> כותרת ייחודית מקוננת ראשונה. מעריב, 2008, עמ' 28.</li>
+            <li><b>Keydar, Renana.</b> כותרת ייחודית מקוננת שנייה. Jewish social studies, 2012, pp. 212-224.
+              <a href="/files/lex/5181/00156200.pdf">*</a></li>
+          </ul>
+        HTML
+      end
+
+      let(:html) do
+        bibliography_html('על השירה' => plain_items('על השירה', 60),
+                          'על הפרוזה' => plain_items('על הפרוזה', 60),
+                          'על הספרים' => [nested_item])
+      end
+
+      let(:groups) do
+        [group('על השירה', 60), group('על הפרוזה', 60),
+         { subject: 'על הספרים',
+           works: [work('על דעת עצמו'), work('כותרת ייחודית מקוננת ראשונה'), work('כותרת ייחודית מקוננת שנייה')] }]
+      end
+
+      it 'keeps the outer <li> and its nested citations in one batch' do
+        sent = []
+        stub_llm_groups(groups, sent)
+
+        result = described_class.call(html)
+
+        expect(sent.size).to eq(3)
+        expect(li_texts(sent.last).size).to eq(3)
+        expect(result.select(&:backup_url).map(&:title)).to eq(['כותרת ייחודית מקוננת שנייה'])
+      end
+
+      it 'still tags data-file-link on the nested <li> only' do
+        sent = []
+        stub_llm_groups(groups, sent)
+
+        described_class.call(html)
+
+        tagged = Nokogiri::HTML::DocumentFragment.parse(sent.last).css('li[data-file-link]')
+        expect(tagged.size).to eq(1)
+        expect(tagged.first.css('li')).to be_empty
+        expect(tagged.first.text).to include('Keydar, Renana')
+      end
     end
   end
 end

--- a/spec/services/lexicon/parse_citations_spec.rb
+++ b/spec/services/lexicon/parse_citations_spec.rb
@@ -7,7 +7,9 @@ describe Lexicon::ParseCitations do
 
   # `sent` collects the HTML actually handed to the LLM, so specs can assert on it. Each
   # successive request is answered with the next of `groups` — the batched path issues one
-  # request per subject heading, so one group per heading.
+  # request per subject heading, so one group per heading. A request beyond the groups stubbed
+  # raises rather than answering with nothing, so a spec cannot pass while the code issues more
+  # requests than it expects.
   def stub_llm_groups(groups, sent = [])
     chat_double = instance_double(RubyLLM::Chat)
     allow(RubyLLM).to receive(:chat).and_return(chat_double)
@@ -15,7 +17,9 @@ describe Lexicon::ParseCitations do
     pending = groups.dup
     allow(chat_double).to receive(:ask) do |html_arg|
       sent << html_arg
-      instance_double(RubyLLM::Message, content: { result: [pending.shift].compact }.to_json)
+      raise "unexpected LLM request ##{sent.size}: only #{groups.size} group(s) stubbed" if pending.empty?
+
+      instance_double(RubyLLM::Message, content: { result: [pending.shift] }.to_json)
     end
   end
 
@@ -567,6 +571,15 @@ describe Lexicon::ParseCitations do
       (1..count).map { |i| "<b>מחבר, שם.</b> #{title_for(heading, i)}. עיתון, 2024, עמ' #{i}." }
     end
 
+    # `sections` is { heading => citation count } throughout; each heading gets its own titles.
+    def items_for(sections)
+      sections.to_h { |heading, count| [heading, plain_items(heading, count)] }
+    end
+
+    def titles_for(sections)
+      sections.flat_map { |heading, count| (1..count).map { |i| title_for(heading, i) } }
+    end
+
     def work(title, **overrides)
       { title: title, authors: [], from_publication: 'עיתון, 2024', pages: '1',
         link: nil, backup_url: nil, notes: nil }.merge(overrides)
@@ -576,30 +589,35 @@ describe Lexicon::ParseCitations do
       { subject: heading, works: (1..count).map { |i| work(title_for(heading, i)) } }
     end
 
+    def groups_for(sections)
+      sections.map { |heading, count| group(heading, count) }
+    end
+
     def li_texts(batch_html)
       Nokogiri::HTML::DocumentFragment.parse(batch_html).css('li').map { |li| li.text.squish }
     end
 
     context 'when the bibliography is within the single-request threshold' do
       let(:sections) { { 'על השירה' => 40, 'על הפרוזה' => 40, 'על המחזות' => 40 } }
-      let(:html) { bibliography_html(sections.transform_values { |count| plain_items('על השירה', count) }) }
+      let(:html) { bibliography_html(items_for(sections)) }
 
       it 'issues exactly one request, carrying the whole section' do
         sent = []
-        stub_llm_capturing(group('על השירה', 40)[:works], sent)
+        stub_llm_capturing(titles_for(sections).map { |title| work(title) }, sent)
 
-        described_class.call(html)
+        result = described_class.call(html)
 
         expect(sent.size).to eq(1)
         expect(li_texts(sent.first).size).to eq(120)
+        expect(result.map(&:title)).to eq(titles_for(sections))
       end
     end
 
     context 'when the bibliography exceeds the threshold' do
       let(:sections) { { 'על השירה' => 50, 'על הפרוזה' => 50, 'על המחזות' => 30 } }
-      let(:html) { bibliography_html(sections.to_h { |heading, count| [heading, plain_items(heading, count)] }) }
-      let(:groups) { sections.map { |heading, count| group(heading, count) } }
-      let(:all_titles) { sections.flat_map { |heading, count| (1..count).map { |i| title_for(heading, i) } } }
+      let(:html) { bibliography_html(items_for(sections)) }
+      let(:groups) { groups_for(sections) }
+      let(:all_titles) { titles_for(sections) }
 
       it 'issues one request per subject heading' do
         sent = []
@@ -656,9 +674,9 @@ describe Lexicon::ParseCitations do
     # so both have to find citations that were parsed by a request other than the first.
     context 'when an asterisk link sits in a later batch' do
       let(:sections) { { 'על השירה' => 60, 'על הפרוזה' => 60, 'על המחזות' => 10 } }
-      let(:groups) { sections.map { |heading, count| group(heading, count) } }
+      let(:groups) { groups_for(sections) }
       let(:html) do
-        items = sections.to_h { |heading, count| [heading, plain_items(heading, count)] }
+        items = items_for(sections)
         items['על המחזות'][6] += ' <a href="/files/lex/5013/00022200.pdf">*</a>'
         bibliography_html(items)
       end
@@ -674,9 +692,9 @@ describe Lexicon::ParseCitations do
 
     context 'when inline links sit in citations of different batches' do
       let(:sections) { { 'על השירה' => 60, 'על הפרוזה' => 60, 'על המחזות' => 10 } }
-      let(:groups) { sections.map { |heading, count| group(heading, count) } }
+      let(:groups) { groups_for(sections) }
       let(:html) do
-        items = sections.to_h { |heading, count| [heading, plain_items(heading, count)] }
+        items = items_for(sections)
         items['על השירה'][0] += ' <a href="https://example.com/first">כתב-עת ראשון</a>'
         items['על המחזות'][0] += ' <a href="https://example.com/last">כתב-עת אחרון</a>'
         bibliography_html(items)
@@ -697,7 +715,7 @@ describe Lexicon::ParseCitations do
     # by batching. Rather than drop it, fall back to the single request.
     context 'when a bare <li> sits outside any list' do
       let(:html) do
-        "#{bibliography_html('על השירה' => plain_items('על השירה', 121))}\n<li>ציטוט יתום ארוך דיו</li>"
+        "#{bibliography_html(items_for('על השירה' => 121))}\n<li>ציטוט יתום ארוך דיו</li>"
       end
 
       it 'falls back to a single request' do
@@ -741,9 +759,7 @@ describe Lexicon::ParseCitations do
       end
 
       let(:html) do
-        bibliography_html('על השירה' => plain_items('על השירה', 60),
-                          'על הפרוזה' => plain_items('על הפרוזה', 60),
-                          'על הספרים' => [nested_item])
+        bibliography_html(items_for('על השירה' => 60, 'על הפרוזה' => 60).merge('על הספרים' => [nested_item]))
       end
 
       let(:groups) do


### PR DESCRIPTION
## The bug

Entries with very long bibliographies lose most of their citations. `00540.php`
(יצחק לאור) has **202** records in its `Bib.` section but only **~66** survive
migration.

## Root cause

The loss is entirely in the single `gpt-4.1-mini` request, not anywhere else in
the pipeline:

- `ExtractCitations` captures all 202 `<li>` and `preprocess_source_items`
  preserves them (64,616 bytes of HTML).
- Post-processing drops nothing: 0 blank titles, 0 fields over the
  `varchar(255)` limit.
- A local single call *did* succeed once — 203 works / 27 groups, 25,982 output
  tokens, i.e. **79% of the model's 32,768 `max_output_tokens`**, `finish_reason`
  `"stop"`. Right at the edge.
- Production reproducibly returns ~66, and the last two migrated citations are
  the **first** `<li>` of the last two subject groups (which hold 7 and 17 works
  in the good run).

So the model emits every subject header but only the first work or two of the
later groups: output-budget compression. Not an extraction cut, not a JSON parse
failure, not a validation drop, not a transient outage. Secondary benefit:
these giant requests are also slow enough to hit Faraday's default read timeout
(`Net::ReadTimeout` seen locally), which batching relieves too.

## The fix

`Lexicon::ParseCitations` now splits at subject headings above a threshold:

- `MAX_SINGLE_REQUEST_CITATIONS = 120`. **At or below it nothing changes** — one
  request — so ordinary entries with several headings but few items do not pay
  for a request per heading.
- Above it, one request per subject heading, results aggregated in batch order.
- The per-request body moved into a private `#parse_batch`; a fresh
  `RubyLLM.chat` per batch keeps conversation history from accumulating.

What deliberately stays whole-section: `preprocess_source_items`,
`recover_backup_urls` and `assign_text_links`. That is what makes aggregation
safe — `@source_items` stays complete and the "assign each citation at most
once" bookkeeping still sees every citation, so a `data-file-link` or inline
link in batch 27 still finds its citation.

**Safety net:** if the `<li>` accounted for by the subject batches do not equal
every `<li>` in the section, the whole section goes out as a single request
instead. This covers the bare `<li>` outside any `<ul>` that
`ExtractCitations::CITATIONS_START_TAGS` admits, and guarantees batching can
never lose a citation the single-request path would have kept.

Lists nested inside an `<li>` are sub-citations of the work containing them and
travel with it (the `00156.php` regression already covered by the spec).

`seqno` is unchanged (index within its returned group; one heading per batch
means one group per response, so numbering is identical to today). Failure
handling is unchanged: a bad batch raises and aborts the entry, exactly as a bad
single request does — a silently partial bibliography is the bug being fixed, so
per-batch errors are not swallowed.

## Verified against the real file

Running the splitter over the actual `00540.php` section (no API calls):

```
section bytes: 64616, total <li>: 202
batches: 27
   1:   3 li,   1100 bytes, heading=ספרים
   2:  34 li,  14380 bytes, heading=מאמרים
   ...
  26:   7 li,   1159 bytes, heading=על המחזה ״רקוויאם למהפכה קטנה״…
  27:  17 li,   5577 bytes, heading=על כתב-העת ״מטעם״
sum of batch <li>: 202 (equals total: true)
max batch bytes: 14380
```

27 batches, at most 34 records each, every citation accounted for — and the last
two batches hold exactly the 7 and 17 works the successful local run reported.

## Test plan

`spec/services/lexicon/parse_citations_spec.rb` gains 13 examples, all with the
LLM stubbed (no cassette for a 202-item file). The existing `stub_llm_capturing`
was promoted to the describe level and re-expressed on top of a new
`stub_llm_groups`, which answers each successive request with the next group.

- **Threshold**: ≤120 `<li>` → exactly one request; 121+ → one request per heading.
- **Aggregation**: all batches' citations returned in batch order; each batch
  receives only its own heading's `<li>`, with none dropped or duplicated; the
  per-batch subject is carried onto its citations; `seqno` restarts within each
  subject; a blank-titled citation in one batch is skipped without disturbing
  the others.
- **Cross-batch recovery** (the regression risk of keeping the recovery passes
  outside the loop): an asterisk link in a later batch still yields the right
  `backup_url`; inline links in different batches each land on their own
  citation, with the "assign at most once" bookkeeping unconfused by
  similarly-titled items.
- **Safety net**: a bare `<li>` outside any list, and a section with no `<ul>` at
  all, both fall back to a single request.
- **Nested sub-lists**: the outer `<li>` and its nested citations stay in one
  batch, and `data-file-link` is still tagged on the nested `<li>` only.

Mutation-checked: with the threshold raised so batching never triggers, 9 of the
new examples fail; with the `<li>`-count guard removed, the bare-`<li>` fallback
example fails.

```
bundle exec rspec spec/services/lexicon/          # 289 examples, 0 failures
bundle exec rubocop app/services/lexicon/parse_citations.rb \
                    spec/services/lexicon/parse_citations_spec.rb   # no offenses
```

The full suite takes 40+ minutes and was **not** run — it needs your approval
(`.claude/rules/full-test-suite-runtime.md`).

Closes by-dyv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
