### PR TITLE
Space out LexEntry#show sub-headings and align citation bullets

### DIFF
--- a/app/assets/stylesheets/lexicon.scss
+++ b/app/assets/stylesheets/lexicon.scss
@@ -2,6 +2,13 @@ ul.lex {
   list-style-type:disc;
 }
 
+/* Sub-headings within an entry: the work-type headings in the works section and the
+   citation-subject headings in the about section. The base .by-card-content-v02 h4 rule
+   sets no top margin, so each heading sits flush against the list above it. */
+.lexicon-entry-show h4 {
+  margin-top: 20px;
+}
+
 /* Biography images (entry show page and the migration verification workbench).
    Entries migrated from the old PHP lexicon carry the legacy HTML `align` and
    `hspace` attributes as data-align/data-hspace. Without a float such an image

--- a/app/views/lexicon/entries/_show_person.html.haml
+++ b/app/views/lexicon/entries/_show_person.html.haml
@@ -51,7 +51,11 @@
                 %ul
                   - list.each do |c|
                     - cit_text = render_citation(c)
-                    %li{style: cit_text.gsub('עמ\'','').any_hebrew? ? "" : "direction: ltr;"}= cit_text
+                    -# A Latin-script citation is isolated in a <bdi dir="ltr"> rather than
+                       given direction: ltr on the <li> itself: the latter flips the list
+                       marker to the left edge, away from its text and out of line with the
+                       bullets of the surrounding Hebrew citations.
+                    %li= cit_text.gsub('עמ\'', '').any_hebrew? ? cit_text : tag.bdi(cit_text, dir: 'ltr')
         - if sections[:links]
           #lexicon-links
             = render partial: 'links', locals: { links: lex_person.links }

--- a/app/views/lexicon/entries/show.html.haml
+++ b/app/views/lexicon/entries/show.html.haml
@@ -1,4 +1,7 @@
-.peach2-lexicon.proofable{ data: { item_id: @lex_entry.id, item_type: 'LexEntry' } }
+-#
+  .lexicon-entry-show scopes entry-page styling (see lexicon.scss). .peach2-lexicon
+  is shared with the entry list and the author TOC, so it is too broad a hook.
+.peach2-lexicon.proofable.lexicon-entry-show{ data: { item_id: @lex_entry.id, item_type: 'LexEntry' } }
   - lex_item = @lex_entry.lex_item
   - if lex_item.is_a?(LexPerson)
     = render partial: 'show_person', locals: { lex_person: lex_item }

--- a/spec/system/lexicon/entry_show_typography_spec.rb
+++ b/spec/system/lexicon/entry_show_typography_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Lexicon entry show typography', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let!(:person) { create(:lex_person, bio: 'Test biography content', works_count: 0, gender: :male) }
+  let!(:entry) { create(:lex_entry, title: 'Test Person', lex_item: person, status: :published) }
+
+  # a non-'original' work_type is what makes the works section emit an <h4> sub-heading,
+  # and a non-blank subject is what makes the about section emit one
+  let!(:work) { create(:lex_person_work, person: person, work_type: :translated, title: 'Some Work') }
+  let!(:hebrew_citation) do
+    create(:lex_citation, person: person, subject: 'Some Work', title: 'מאמר בעברית',
+                          from_publication: 'כתב עת עברי', pages: '7', authors_count: 0)
+  end
+  let!(:latin_citation) do
+    create(:lex_citation, person: person, subject: 'Some Work', title: 'An English Title',
+                          from_publication: 'An English Journal', pages: '12', authors_count: 0)
+  end
+
+  def computed(selector, property)
+    page.evaluate_script(
+      "window.getComputedStyle(document.querySelector(#{selector.to_json})).#{property}"
+    )
+  end
+
+  it 'gives the sub-headings 20px of space above them' do
+    visit lexicon_entry_path(entry)
+
+    expect(page).to have_css('#lexicon-works h4')
+    expect(page).to have_css('#lexicon-about h4')
+
+    expect(computed('#lexicon-works h4', 'marginTop')).to eq('20px')
+    expect(computed('#lexicon-about h4', 'marginTop')).to eq('20px')
+  end
+
+  it 'renders the citations as a list with standard round bullets' do
+    visit lexicon_entry_path(entry)
+
+    expect(page).to have_css('#lexicon-about ul > li', count: 2)
+
+    expect(computed('#lexicon-about ul', 'listStyleType')).to eq('disc')
+    # the markers sit outside the list item, so the list needs inline start padding to show them
+    expect(computed('#lexicon-about ul', 'paddingInlineStart').to_i).to be > 0
+  end
+
+  it 'keeps the bullet of a Latin-script citation aligned with the Hebrew ones' do
+    visit lexicon_entry_path(entry)
+
+    expect(page).to have_css('#lexicon-about ul > li', count: 2)
+
+    # A direction: ltr on the <li> would put its marker on the opposite (left) side of the
+    # list, so the two items' start edges would no longer coincide.
+    directions = page.evaluate_script(<<~JS)
+      Array.from(document.querySelectorAll('#lexicon-about ul > li'))
+           .map(function (li) { return window.getComputedStyle(li).direction; })
+    JS
+    expect(directions).to all(eq('rtl'))
+
+    # ...and the Latin text is still isolated so it reads left-to-right
+    expect(page).to have_css('#lexicon-about li bdi[dir="ltr"]', text: 'An English Title')
+  end
+end


### PR DESCRIPTION
## What changed

Two tweaks to the public lexicon entry page (`LexEntry#show`).

### 1. `h4` sub-headings get 20px of space above them

The `<h4>`s on the entry page — the work-type headings in the works section and
the citation-subject headings in the about section — inherited no top margin
(`.by-card-content-v02 h4` sets only `font-weight`), so each one sat flush
against the list above it. They now get `margin-top: 20px`.

The rule is scoped to a new `.lexicon-entry-show` class on the page wrapper.
`.peach2-lexicon` was the obvious existing hook but it is also used by the entry
list, the list top bar and `authors/_generated_toc`, so it would have leaked.

### 2. Citation bullets all line up in one column

The citation list already computes `list-style-type: disc` — but a citation with
no Hebrew in it carried an inline `direction: ltr` on its `<li>`, which flips the
list marker to the opposite (left) edge. The bullet ended up stranded at the far
left of the card, detached from its own text and out of line with the bullets of
the surrounding Hebrew citations:

```
before:                                          after:

•  מרדכי אגבאריה, Brandy of the Damned, עמ' 69      •  מרדכי אגבאריה, Brandy of the Damned, עמ' 69
•        An English Title, An English Journal, עמ' 12      •  An English Title, An English Journal, עמ' 12
↑ stray, unaligned
```

The fix isolates the Latin run in a `<bdi dir="ltr">` and leaves the `<li>` itself
RTL. `<bdi>` carries `unicode-bidi: isolate` by default, so the Latin text still
reads left-to-right and lands in exactly the same pixel positions as before —
only the marker moves.

## Test plan

New system spec `spec/system/lexicon/entry_show_typography_spec.rb` (3 examples,
all passing) asserting, via computed style in a real browser:

- `#lexicon-works h4` and `#lexicon-about h4` compute to `margin-top: 20px`
- `#lexicon-about ul` computes to `list-style-type: disc` with non-zero
  inline-start padding (markers sit outside the item, so the padding is what
  makes them visible)
- both `<li>`s compute to `direction: rtl` — i.e. their markers share a column —
  while the Latin citation is still wrapped in `<bdi dir="ltr">`

The margin assertions were confirmed to fail against `master` (`0px`) before the
CSS change.

Also re-ran the neighbouring lexicon specs — `entries_navbar_spec`,
`citation_text_links_spec`, `bio_image_float_spec`,
`entry_navbar_sticky_offset_spec`, `access_control_spec`,
`author_lex_citations_spec`, `lexicon_helper_spec` — 92 examples, 1 failure.

> [!NOTE]
> That one failure, `lexicon_helper_spec.rb:94` ("renders NLI identifier with
> correct URL"), is **pre-existing and unrelated** — verified failing on a clean
> `master`. Commit ccd2072 ("Fixed NLI URL template") changed the URL template
> without updating the spec's expectation. Not fixed here to keep this PR to its
> stated scope; worth a separate one-liner.

The full suite was **not** run (40+ min, needs your go-ahead).

## Notes

- `lexicon.scss:1` has an unused `ul.lex { list-style-type: disc; }` rule — no
  view references `ul.lex`. Left alone as orthogonal to this change, but it looks
  like a previous attempt at the same problem and is probably safe to delete.

Closes by-mz8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
