### PR TITLE
Always stamp Authority#published_at when an authority is published

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -398,7 +398,7 @@ class AuthorsController < ApplicationController
                      .select { |e| e.language == 'he' } # we have few translations from Hebrew to other languages
           (o + t).uniq.each { |e| e.update(period: @author.person.period) }
         end
-        if @author.status_changed? && @author.status == 'published'
+        if @author.saved_change_to_status? && @author.published?
           @author.publish!
           Rails.cache.delete('newest_authors') # force cache refresh
           Rails.cache.delete('homepage_authors')

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -109,6 +109,9 @@ class Authority < ApplicationRecord
 
   before_save :update_other_designation, if: :name_changed?
   before_save :normalize_sort_name
+  # published_at drives the 'upload date' sort on /authors (via AuthoritiesIndex#pby_publication_date),
+  # so it must be stamped no matter which code path publishes the authority, not just Authority#publish!
+  before_save :stamp_published_at, if: -> { status_changed? && published? }
   before_save :sort_legacy_credits, if: :legacy_credits_changed?
   # editing the manual credits changes the merged list, so the cache must go (cf. Collection)
   before_save :clear_cached_credits, if: :legacy_credits_changed?
@@ -547,8 +550,7 @@ class Authority < ApplicationRecord
       m.created_at = Time.zone.now
       m.published!
     end
-    self.published_at = Time.zone.now
-    published! # finally, set this person to published
+    published! # finally, set this person to published (stamp_published_at fires on the transition)
   end
 
   def publish_if_first!
@@ -556,6 +558,14 @@ class Authority < ApplicationRecord
   end
 
   protected
+
+  # Records when the authority became visible on the site. Re-publishing after a spell of being
+  # unpublished deliberately re-stamps, matching publish!'s treatment of the works themselves,
+  # which are back-dated to now so they resurface in whatsnew. An explicit published_at supplied in
+  # the same save wins, so imports and backfills can set a historical date.
+  def stamp_published_at
+    self.published_at = Time.zone.now unless published_at_changed?
+  end
 
   def placeholder_image_url
     if person.present?

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -767,6 +767,39 @@ describe AuthorsController do
           end
         end
 
+        # Regression: this branch used to guard on status_changed?, which Rails resets to false as
+        # soon as the update succeeds, so publishing an authority from the edit form silently
+        # skipped publish! — leaving published_at NULL and the 'newest authors' caches stale.
+        context 'when the status is changed to published' do
+          let(:status) { :unpublished }
+          let(:new_period) { period }
+          let(:authority_params) do
+            authority_attributes.merge(status: 'published', person_attributes: person_attributes)
+          end
+
+          let!(:pending_work) { create(:manifestation, author: author, status: :unpublished) }
+
+          before { author.update_columns(published_at: nil) }
+
+          it 'stamps published_at' do
+            expect(request).to redirect_to authors_show_path(id: author.id)
+            expect(author.reload.published_at).to be_present
+          end
+
+          it 'publishes the pending works' do
+            request
+            expect(pending_work.reload).to be_published
+          end
+
+          # The test env uses a null_store, so a write/read round-trip would pass vacuously.
+          it 'busts the newest-authors caches' do
+            allow(Rails.cache).to receive(:delete)
+            request
+            expect(Rails.cache).to have_received(:delete).with('newest_authors')
+            expect(Rails.cache).to have_received(:delete).with('homepage_authors')
+          end
+        end
+
         context 'when corporate_body' do
           let(:author) { create(:authority, :corporate_body) }
 

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -910,6 +910,13 @@ describe Authority do
       expect(authority.reload.published_at).to be_present
     end
 
+    it 'does not override an explicitly supplied published_at on publish transition' do
+      explicit_time = Time.zone.parse('2012-05-06 07:08:09')
+      authority = create(:authority, status: :unpublished, published_at: nil)
+      authority.update!(status: :published, published_at: explicit_time)
+      expect(authority.reload.published_at).to eq(explicit_time)
+    end
+
     it 'leaves published_at alone when a published authority is edited' do
       authority = create(:authority, status: :published)
       expect { authority.update!(name: 'New Name') }.not_to(change { authority.reload.published_at })

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -884,6 +884,52 @@ describe Authority do
     end
   end
 
+  # published_at backs the 'upload date' sort on /authors (AuthoritiesIndex#pby_publication_date).
+  # It used to be written only inside #publish!, so authorities published by any other route kept a
+  # NULL and, since Elasticsearch sorts missing values last, never surfaced under 'newest first'.
+  describe 'published_at stamping' do
+    it 'stamps published_at when an unpublished authority is published directly' do
+      authority = create(:authority, status: :unpublished, published_at: nil)
+      expect { authority.update!(status: :published) }
+        .to change { authority.reload.published_at }.from(nil).to(be_present)
+    end
+
+    it 'stamps published_at when an awaiting_first authority is published' do
+      authority = create(:authority, status: :awaiting_first, published_at: nil)
+      authority.published!
+      expect(authority.reload.published_at).to be_present
+    end
+
+    it 'stamps published_at on an authority created as published' do
+      expect(create(:authority, status: :published).published_at).to be_present
+    end
+
+    it 'stamps published_at via #publish!' do
+      authority = create(:authority, status: :unpublished, published_at: nil)
+      Chewy.strategy(:atomic) { authority.publish! }
+      expect(authority.reload.published_at).to be_present
+    end
+
+    it 'leaves published_at alone when a published authority is edited' do
+      authority = create(:authority, status: :published)
+      expect { authority.update!(name: 'New Name') }.not_to(change { authority.reload.published_at })
+    end
+
+    it 'leaves published_at alone when an authority is unpublished' do
+      authority = create(:authority, status: :published)
+      expect { authority.update!(status: :unpublished) }.not_to(change { authority.reload.published_at })
+    end
+
+    # Deliberate: publish! also back-dates the works' created_at to now so they resurface in
+    # whatsnew, so a re-published authority is likewise treated as newly available.
+    it 're-stamps published_at when a previously published authority is published again' do
+      authority = create(:authority, status: :published, published_at: 2.years.ago)
+      authority.update!(status: :unpublished)
+      expect { authority.update!(status: :published) }
+        .to change { authority.reload.published_at.to_date }.to(Time.zone.today)
+    end
+  end
+
   # This number is shown to readers as 'N authors in the project' and labels a link to the
   # authorities list, so it must count exactly what that list shows.
   describe '.cached_count' do


### PR DESCRIPTION
## Problem

On `/authors`, sorting by upload date (newest first) tops out at **1.1.2026** — no authority published since then appears, even though many have been.

`published_at` backs that sort, via `AuthoritiesIndex#pby_publication_date`. **1,155 of 2,789 published authorities (41%) have `published_at = NULL`**, and Elasticsearch omits a null field and sorts missing values *last* on a `desc` sort — so 41% of the list is invisible at the top of "newest first". The visible ceiling is just the last cohort that happened to get a value: the copyright-expiration batch, which is the one remaining automated caller of `publish!`.

## Root cause

`published_at` was written in exactly one place in the codebase — `Authority#publish!` — with only four call sites. One of them was dead code:

```ruby
if @author.update(authority_params)      # ← saves here
  ...
  if @author.status_changed? && ...      # ← always false after a successful save
    @author.publish!
```

Rails clears dirty state on save, so `status_changed?` is always `false` there. Verified on this codebase:

```
after update -> status_changed?=false  saved_change_to_status?=true
```

Note that nine lines above, the period-propagation branch already uses the correct `period_previously_changed?`. Consequence: publishing an authority from the edit form stamped no `published_at`, published none of its pending works, and left the `newest_authors` / `homepage_authors` caches stale.

## Changes

- **`app/controllers/authors_controller.rb`** — `status_changed?` → `saved_change_to_status?`.
- **`app/models/authority.rb`** — stamp `published_at` in a `before_save` callback on any transition into `published`, so no publishing path can bypass it (ingestion, direct status edit, `published!`, seeds). An explicit `published_at` supplied in the same save wins, so imports and the pending backfill can set a historical date. The now-redundant assignment inside `publish!` is removed.

Re-publishing after a spell of being unpublished deliberately **re-stamps**, preserving the existing semantics of `publish!`, which likewise back-dates the works' `created_at` to now so they resurface in whatsnew.

## Also affected (not changed here)

`cached_newest_authors` (`application_controller.rb:115`) orders by the same column, so the homepage "newest authors" strip has the same blind spot. It is fixed going forward by this PR, and will be fully corrected by the backfill.

## Not in this PR

Backfilling the 1,155 existing NULLs. PaperTrail is not a usable source — only **7 of the 1,155** candidates have any version row at all, and none have `object_changes` populated. That needs its own task and a decision on the proxy date.

## Test plan

New specs, all passing:

- `spec/models/authority_spec.rb` — 7 examples covering stamping on direct publish, on `published!`, on create-as-published, via `publish!`; not stamping on an unrelated edit or on unpublishing; re-stamping on re-publish; and an explicit `published_at` winning.
- `spec/controllers/authors_controller_spec.rb` — 3 regression examples for publishing via the edit form: stamps `published_at`, publishes pending works, busts both caches.

Verified the two controller examples **fail** against the old `status_changed?` guard and pass with the fix.

```
bundle exec rspec spec/models/authority_spec.rb spec/controllers/authors_controller_spec.rb
  184 examples, 0 failures
bundle exec rspec spec/lib/tasks/copyright_expiration_rake_spec.rb spec/controllers/html_file_controller_spec.rb
  23 examples, 0 failures
```

RuboCop clean on all changed lines (remaining offenses in these files are pre-existing).

**The full suite was not run** — it takes 40+ minutes and needs explicit approval. The specs above were chosen as the ones covering every `publish!` call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
