### PR TITLE
Backfill Authority#published_at for authorities that never got one

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,6 +102,11 @@ Rails/TimeZone:
 RSpec/BeforeAfterAll:
   Enabled: false
 
+RSpec/DescribeClass:
+  # Rake tasks are not classes, so their specs have nothing to name here.
+  Exclude:
+    - 'spec/lib/tasks/**/*_spec.rb'
+
 RSpec/ExampleLength:
   Max: 30
 

--- a/lib/tasks/backfill_authority_published_at.rake
+++ b/lib/tasks/backfill_authority_published_at.rake
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Authority#published_at backs the 'upload date' sort on /authors, via
+# AuthoritiesIndex#pby_publication_date. It used to be written only inside Authority#publish!, and
+# the authors#update call site guarded on status_changed?, which Rails resets to false as soon as
+# the update succeeds -- so authorities published from the edit form never got one. Elasticsearch
+# omits a null field and sorts missing values last, so those authorities were invisible at the top
+# of 'newest first'.
+#
+# The stamping itself is fixed in the model, but roughly 1,150 authorities are left carrying a NULL
+# and need a historical date. PaperTrail cannot supply it: has_paper_trail was added to Authority
+# long after most of these were published, so only a handful have any version row at all and none
+# have object_changes populated. The best available proxy is the date the authority's first work
+# went live -- publish! back-dates works' created_at to publication time, so for authorities
+# published that way it is near exact. Authorities with no published works fall back to their own
+# created_at.
+#
+# Only rows where published_at IS NULL are touched, so the task is safe to re-run.
+desc 'Backfill Authority#published_at for published authorities that never got one'
+task backfill_authority_published_at: :environment do
+  scope = Authority.published.where(published_at: nil)
+  total = scope.count
+  puts "Found #{total} published authorities with no published_at."
+
+  if total.zero?
+    puts 'Nothing to do.'
+    next
+  end
+
+  from_works = 0
+  from_created_at = 0
+  skipped = 0
+
+  scope.find_each do |authority|
+    first_work_at = authority.published_manifestations.minimum(:created_at)
+    stamp = first_work_at || authority.created_at
+
+    if stamp.nil?
+      # No works and no creation date: nothing defensible to write.
+      puts "  SKIP #{authority.id} (#{authority.name}): no work dates and no created_at"
+      skipped += 1
+      next
+    end
+
+    # update_column deliberately: this is a mechanical repair of a derived value, so it should not
+    # bump updated_at, fire the publishing callbacks, or emit a PaperTrail version per row.
+    authority.update_column(:published_at, stamp)
+
+    if first_work_at.nil?
+      from_created_at += 1
+    else
+      from_works += 1
+    end
+  end
+
+  puts "Backfilled #{from_works + from_created_at} authorities " \
+       "(#{from_works} from earliest published work, #{from_created_at} from authority created_at)."
+  puts "Skipped #{skipped}." if skipped.positive?
+
+  puts 'Reindexing AuthoritiesIndex so the upload-date sort picks up the new dates...'
+  AuthoritiesIndex.import
+  puts 'Done.'
+end

--- a/spec/lib/tasks/backfill_authority_published_at_rake_spec.rb
+++ b/spec/lib/tasks/backfill_authority_published_at_rake_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'backfill_authority_published_at rake task' do
+  subject(:run_task) { task.invoke }
+
+  before(:all) do
+    Rake.application.rake_require 'tasks/backfill_authority_published_at'
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['backfill_authority_published_at'] }
+
+  before do
+    task.reenable # allow the task to be run more than once across examples
+    allow(AuthoritiesIndex).to receive(:import) # keep the reindex out of the specs
+    allow($stdout).to receive(:puts) # the task is chatty by design
+  end
+
+  # Forces the NULL published_at this task exists to repair, regardless of whether the model is
+  # already stamping it on create.
+  def unstamped_authority(**attrs)
+    create(:authority, status: :published, **attrs).tap { |a| a.update_column(:published_at, nil) }
+  end
+
+  context 'when the authority has published works' do
+    let!(:authority) { unstamped_authority }
+    let!(:first_work) { create(:manifestation, author: authority, created_at: 3.years.ago) }
+
+    before { create(:manifestation, author: authority, created_at: 1.year.ago) }
+
+    it 'stamps published_at from the earliest published work' do
+      run_task
+      expect(authority.reload.published_at).to be_within(1.second).of(first_work.created_at)
+    end
+  end
+
+  context 'when the authority has no published works' do
+    let!(:authority) { unstamped_authority(created_at: 2.years.ago) }
+
+    it 'falls back to the authority created_at' do
+      run_task
+      expect(authority.reload.published_at).to be_within(1.second).of(authority.created_at)
+    end
+  end
+
+  context 'when the authority has only unpublished works' do
+    let!(:authority) { unstamped_authority(created_at: 2.years.ago) }
+
+    before { create(:manifestation, author: authority, status: :unpublished, created_at: 3.years.ago) }
+
+    it 'ignores them and falls back to the authority created_at' do
+      run_task
+      expect(authority.reload.published_at).to be_within(1.second).of(authority.created_at)
+    end
+  end
+
+  it 'leaves an authority that already has a published_at untouched' do
+    stamped = create(:authority, status: :published, published_at: 5.years.ago)
+    create(:manifestation, author: stamped, created_at: 1.year.ago)
+    expect { run_task }.not_to(change { stamped.reload.published_at })
+  end
+
+  it 'leaves unpublished authorities alone' do
+    unpublished = create(:authority, status: :unpublished)
+    unpublished.update_column(:published_at, nil)
+    run_task
+    expect(unpublished.reload.published_at).to be_nil
+  end
+
+  it 'reindexes the authorities index so the upload-date sort picks the dates up' do
+    unstamped_authority
+    run_task
+    expect(AuthoritiesIndex).to have_received(:import)
+  end
+
+  it 'is idempotent' do
+    authority = unstamped_authority
+    create(:manifestation, author: authority, created_at: 3.years.ago)
+    run_task
+    stamped_at = authority.reload.published_at
+
+    task.reenable
+    task.invoke
+    expect(authority.reload.published_at).to eq stamped_at
+  end
+end

--- a/spec/lib/tasks/export_catalog_rake_spec.rb
+++ b/spec/lib/tasks/export_catalog_rake_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'rake'
 require 'tempfile'
 
-RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'export_catalog rake task' do
   before(:all) do
     Rake.application.rake_require 'tasks/export_catalog'
     Rake::Task.define_task(:environment)

--- a/spec/lib/tasks/ingest_lexicon_rake_spec.rb
+++ b/spec/lib/tasks/ingest_lexicon_rake_spec.rb
@@ -5,7 +5,7 @@ require 'rake'
 require 'fileutils'
 require 'tmpdir'
 
-RSpec.describe 'ingest_lexicon rake task' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'ingest_lexicon rake task' do
   before(:all) do
     Rake.application.rake_require 'tasks/ingest_lexicon'
     Rake::Task.define_task(:environment)


### PR DESCRIPTION
Follow-up to #1642. That PR stops authorities from being published without a `published_at`; this one repairs the **1,155 existing NULLs** so they stop being invisible in the `/authors` upload-date sort.

Independent of #1642 — no overlapping files, and the specs pass on either base — but it only makes sense to run the task after #1642 is deployed, otherwise the edit form keeps minting new NULLs.

## Why not PaperTrail

My first instinct was to recover the real publication date from `versions`. It isn't there. `has_paper_trail` was added to `Authority` long after most of these were published:

- **7 of the 1,155** candidates have *any* version row at all
- **0** have `object_changes` populated

So there is no record of when the status flipped, and the date has to be approximated.

## The proxy

`MIN(created_at)` over the authority's **published** manifestations, falling back to `authorities.created_at` when it has none.

This is a better approximation than it might look: `publish!` deliberately back-dates works' `created_at` to publication time ("pretend the works were created just now, so that they appear in whatsnew"), so for authorities published through that path the earliest work date *is* essentially the publication date.

Simulated against current data — every candidate gets a date, none left unstampable:

```
candidates: 1155
would stamp from works: 954, from created_at: 201, unstampable: 0
```

Note the work date is sometimes *earlier* than the authority row itself, where works were imported before the authority record was created. That is expected and left as-is; it is still the better answer.

## Task behaviour

```
bundle exec rake backfill_authority_published_at
```

- Writes immediately (no dry-run mode), but **only touches rows where `published_at IS NULL`** — safe to re-run, and there is an idempotence spec.
- Uses `update_column`: this is a mechanical repair of a derived value, so it should not bump `updated_at`, fire the publishing callbacks, or emit 1,155 PaperTrail versions.
- Reindexes `AuthoritiesIndex` **once at the end** rather than per record, so the sort actually picks the dates up.
- Prints a breakdown of how many dates came from works vs. `created_at`.

## Incidental

`RSpec/DescribeClass` doesn't apply to rake-task specs — they have no class to name. Two existing rake specs carried per-file `# rubocop:disable` directives for it. Centralized the exemption in `.rubocop.yml` and dropped the two now-redundant disables, rather than adding a third copy.

## Test plan

```
bundle exec rspec spec/lib/tasks/backfill_authority_published_at_rake_spec.rb spec/lib/tasks/copyright_expiration_rake_spec.rb
  21 examples, 0 failures
bundle exec rubocop lib/tasks/backfill_authority_published_at.rake spec/lib/tasks/
  5 files inspected, no offenses detected
```

7 new examples: stamps from earliest published work; falls back to `created_at` with no works; ignores unpublished works; leaves already-stamped authorities untouched; leaves unpublished authorities alone; reindexes; idempotent.

**The full suite was not run** — it takes 40+ minutes and needs explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
