### PR TITLE
Relabel lexicon entry autocomplete and disambiguate identically-titled entries

### DIFF
--- a/app/controllers/lexicon/entries_controller.rb
+++ b/app/controllers/lexicon/entries_controller.rb
@@ -22,7 +22,7 @@ module Lexicon
         %i(title),
         filter: filter
       )
-      render json: json_for_autocomplete(items, :title)
+      render json: autocomplete_json(items)
     end
 
     # GET /lex_entries or /lex_entries.json
@@ -154,6 +154,17 @@ scope = LexEntry.where.not(lex_item: nil).includes(:lex_item)
     end
 
     private
+
+    # Several entries can share a title (e.g. a person and a book both named "נתן אלתרמן"), so the
+    # suggestion menu appends the entry type: "נתן אלתרמן (אדם)". Only the label carries the type —
+    # the value inserted into the field stays the bare title, since callers such as the citation
+    # author and linked person forms store it verbatim as the displayed name.
+    def autocomplete_json(items)
+      json_for_autocomplete(items, :title, [:entry_type]).each do |item|
+        entry_type = item.delete(:entry_type)
+        item[:label] = "#{item[:label]} (#{t("lexicon.entry_types.#{entry_type}")})" if entry_type.present?
+      end
+    end
 
     # Use callbacks to share common setup or constraints between actions.
     def set_lex_entry

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2622,11 +2622,11 @@ he:
         title: עריכת קישור
     text_links:
       text_placeholder: טקסט שיהפוך לקישור
-      target_entry: ערך במילון
+      target_entry: ערך בלקסיקון
       target_url: כתובת יעד (URL)
-      entry_placeholder: חיפוש ערך במילון...
+      entry_placeholder: חיפוש ערך בלקסיקון...
       url_placeholder: "https://example.com/page.html"
-      target_hint: יש למלא יעד אחד בלבד – ערך במילון או כתובת URL.
+      target_hint: יש למלא יעד אחד בלבד – ערך בלקסיקון או כתובת URL.
       entry_not_found: ערך לא נמצא
       text_not_found: הטקסט אינו מופיע כאן
   lex_issues:

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -18,6 +18,10 @@ en:
   classified: Classified
   unclassified: Unclassified
   lexicon:
+    # Shown in parentheses after an entry's title to tell identically-titled entries apart
+    entry_types:
+      person: Person
+      publication: Publication
     layout:
       entries: Entries
       files: Files

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -19,6 +19,10 @@ he:
   unclassified: לא זוהה סוג הערך
   galron_entries: ערכים בלקסיקון הספרות העברית החדשה
   lexicon:
+    # Shown in parentheses after an entry's title to tell identically-titled entries apart
+    entry_types:
+      person: אדם
+      publication: כותר
     layout:
       entries: ערכי הלקסיקון
       files: קבצים להסבה

--- a/spec/requests/lexicon/entries_autocomplete_spec.rb
+++ b/spec/requests/lexicon/entries_autocomplete_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '/lex/entries/autocomplete' do
+  subject(:suggestions) do
+    get '/lex/entries/autocomplete', params: params
+    response.parsed_body
+  end
+
+  # A person and a book sharing a title: the whole point of the type suffix.
+  let!(:person) { create(:lex_entry, :person, title: 'נתן אלתרמן') }
+  let!(:publication) { create(:lex_entry, :publication, title: 'נתן אלתרמן') }
+  let(:params) { { term: 'נתן' } }
+
+  before do
+    login_as_lexicon_editor
+    Chewy.massacre
+    import_and_await(LexEntriesAutocompleteIndex, LexEntry.all)
+  end
+
+  after { Chewy.massacre }
+
+  it 'suffixes each suggestion label with the entry type' do
+    expect(suggestions.pluck('label')).to contain_exactly('נתן אלתרמן (אדם)', 'נתן אלתרמן (כותר)')
+  end
+
+  it 'keeps the bare title as the value inserted into the field' do
+    expect(suggestions.pluck('value')).to all(eq('נתן אלתרמן'))
+  end
+
+  it 'returns the entry ids' do
+    expect(suggestions.pluck('id')).to contain_exactly(person.id.to_s, publication.id.to_s)
+  end
+
+  it 'does not leak the raw entry type alongside the label' do
+    expect(suggestions.first.keys).to contain_exactly('id', 'label', 'value')
+  end
+
+  context 'when an entry has no discernible type' do
+    let!(:person) { create(:lex_entry, title: 'נתן אלתרמן', status: :raw) }
+
+    it 'falls back to the bare title' do
+      expect(suggestions.pluck('label')).to include('נתן אלתרמן')
+    end
+  end
+
+  context 'when filtering by entry type' do
+    let(:params) { { term: 'נתן', entry_type: 'person' } }
+
+    it 'still labels the surviving suggestion' do
+      expect(suggestions.pluck('label')).to eq(['נתן אלתרמן (אדם)'])
+    end
+  end
+end

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -294,6 +294,12 @@ describe '/lexicon/person_works' do
     it 'returns 200' do
       expect(get("/lex/works/#{work.id}/title_links", xhr: true)).to eq(200)
     end
+
+    it 'calls the link target a lexicon entry, not a dictionary entry' do
+      get "/lex/works/#{work.id}/title_links", xhr: true
+      expect(response.body).to include('ערך בלקסיקון')
+      expect(response.body).not_to include('ערך במילון')
+    end
   end
 
   describe 'POST /lex/works/:id/add_title_link' do


### PR DESCRIPTION
## What

Two fixes to the LexEntry autocomplete used by the link editors.

### 1. Mislabelled entry picker

The "add link" sections of the LexPersonWork editor (title links, comment links)
and the LexCitation editor labelled their entry autocomplete **ערך במילון**
("dictionary entry") instead of **ערך בלקסיקון** ("lexicon entry").

Checked as asked: the migration-verification modal and the regular LexEntry
editing screen both render the same `lexicon/person_works/_form` →
`lexicon/shared/_text_links_editor` partial and share the same
`lexicon.text_links.*` I18n keys, so the mislabel was identical in both and one
fix covers both. `grep "ערך במילון"` finds no other occurrence in the codebase.

Three strings updated in `he.yml`: `target_entry`, `entry_placeholder`,
`target_hint`.

### 2. Identically-titled entries were indistinguishable

`/lex/entries/autocomplete` could return several entries with the same title
(e.g. a person and a book both called "נתן אלתרמן") with no way to pick the
right one. The suggestion menu now appends the entry type:

```
נתן אלתרמן (אדם)
נתן אלתרמן (כותר)
```

**Only the menu `label` carries the type; the `value` inserted into the field
stays the bare title.** That distinction matters: the same endpoint also feeds
`lexicon/citation_authors/_form` and `lexicon/linked_people/_form`, whose
`name` values are *persisted* — putting the type into `value` there would write
"נתן אלתרמן (אדם)" into the database as the author's name.

Entries with no discernible type (`LexEntry#entry_type` returns `nil` for raw
entries and for bib/other legacy files) fall back to the bare title.

New I18n keys `lexicon.entry_types.person` / `.publication` in both
`lexicon.he.yml` and `lexicon.en.yml`. The Hebrew for `publication` is "כותר",
matching the existing `activerecord.models.lex_publication: כותר בלקסיקון`.

## Test plan

New `spec/requests/lexicon/entries_autocomplete_spec.rb` (6 examples) covers:
labels carry the type suffix, values stay bare, ids are returned, the raw
`entry_type` is not leaked into the JSON, untyped entries degrade gracefully,
and the `entry_type` filter still works alongside the labelling.

New regression example in `spec/requests/lexicon/person_works_spec.rb` asserting
the title-links editor says ערך בלקסיקון and no longer says ערך במילון.

Ran:

```
bundle exec rspec spec/requests/lexicon/entries_autocomplete_spec.rb \
  spec/requests/lexicon/person_works_spec.rb spec/requests/lexicon/citations_spec.rb \
  spec/requests/lexicon/entries_spec.rb spec/requests/lexicon/citation_authors_spec.rb \
  spec/requests/lexicon/linked_people_spec.rb
# 134 examples, 0 failures

bundle exec rspec spec/system/lexicon/person_work_title_links_spec.rb \
  spec/system/lexicon/person_work_comment_links_spec.rb \
  spec/system/lexicon/citation_text_links_spec.rb \
  spec/system/lexicon/verification_works_modal_spec.rb
# 17 examples, 0 failures
```

RuboCop and haml-lint clean on the changed regions (the pre-existing offences in
`entries_controller.rb` at lines 30–304 are untouched). **The full suite was not
run** — it takes 40+ minutes and needs explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
