### PR TITLE
Link an unattached Collection to the chosen Publication on LexPersonWork save

### DIFF
--- a/app/models/lex_person_work.rb
+++ b/app/models/lex_person_work.rb
@@ -5,9 +5,11 @@ class LexPersonWork < ApplicationRecord
   belongs_to :person, class_name: 'LexPerson', foreign_key: :lex_person_id, inverse_of: :works
   belongs_to :lex_publication, class_name: 'LexPublication', optional: true
 
-  # Association with BYP Publication and Collection
+  # Association with BYP Publication and Collection.
+  # The collection is autosaved because picking a publication may link the collection to it, see
+  # #link_collection_to_publication below.
   belongs_to :publication, optional: true
-  belongs_to :collection, optional: true
+  belongs_to :collection, optional: true, autosave: true
 
   # Citations about this work
   has_many :citations_about,
@@ -20,6 +22,8 @@ class LexPersonWork < ApplicationRecord
            class_name: 'LexLinkedPerson',
            dependent: :destroy
 
+  before_validation :link_collection_to_publication
+
   validates :title, :work_type, presence: true
   validate :collection_belongs_to_publication
   validates :seqno, presence: true, numericality: { only_integer: true, greater_than: 0 }
@@ -28,10 +32,21 @@ class LexPersonWork < ApplicationRecord
 
   private
 
+  # When both a publication and a collection are chosen but the collection isn't linked to any
+  # publication yet, link the two rather than rejecting the save. A collection already claimed by a
+  # *different* publication is left alone, and still fails validation below: re-pointing it would
+  # silently strip the other publication of its volume.
+  def link_collection_to_publication
+    return if publication_id.blank? || collection.blank?
+    return if collection.publication_id.present?
+
+    collection.publication_id = publication_id
+  end
+
   def collection_belongs_to_publication
     return unless collection_id.present? && publication_id.present?
     return unless collection.publication_id != publication_id
 
-    errors.add(:collection, 'must belong to the selected publication')
+    errors.add(:collection, :belongs_to_other_publication)
   end
 end

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -141,11 +141,20 @@
 
       publicationSelect.addEventListener('change', function() {
         const publicationId = this.value;
+        const volume = publicationId ? collectionsData[publicationId] : null;
 
-        if (publicationId && collectionsData[publicationId]) {
-          const collection = collectionsData[publicationId];
-          collectionSelect.value = collection.id;
-        } else {
+        if (volume) {
+          collectionSelect.value = volume.id;
+          return;
+        }
+
+        // The chosen publication has no volume of its own. A collection that is not linked to any
+        // publication stays selected -- saving will link the two. Only a collection belonging to
+        // some *other* publication is dropped, since that pairing cannot be saved.
+        const belongsToAnotherPublication = Object.keys(collectionsData).some(function(pubId) {
+          return String(collectionsData[pubId].id) === collectionSelect.value;
+        });
+        if (belongsToAnotherPublication) {
           collectionSelect.value = '';
         }
       });

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -70,6 +70,10 @@ en:
           attributes:
             person_entry:
               not_a_person: must be a Person entry
+        lex_person_work:
+          attributes:
+            collection:
+              belongs_to_other_publication: already belongs to a different publication
     attributes:
       authority:
         other_designation: Other designation

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -74,6 +74,10 @@ he:
           attributes:
             person_entry:
               not_a_person: must be a Person entry
+        lex_person_work:
+          attributes:
+            collection:
+              belongs_to_other_publication: משויך כבר לכותר אחר בביבליוגרפיה
     attributes:
       authority:
         other_designation: כינויים אחרים

--- a/spec/models/lex_person_work_spec.rb
+++ b/spec/models/lex_person_work_spec.rb
@@ -13,4 +13,53 @@ describe LexPersonWork do
       expect(work.reload.comment).to eq long_comment
     end
   end
+
+  describe 'linking the chosen collection to the chosen publication' do
+    subject(:save_work) { work.save }
+
+    let(:publication) { create(:publication) }
+    let(:work) { build(:lex_person_work, publication: publication, collection: collection) }
+
+    context 'when the collection is not linked to any publication' do
+      let(:collection) { create(:collection, publication: nil) }
+
+      it 'links the collection to the publication instead of failing validation' do
+        expect(save_work).to be true
+        expect(collection.reload.publication).to eq publication
+        expect(work.reload).to have_attributes(publication: publication, collection: collection)
+      end
+    end
+
+    context 'when the collection is already linked to the chosen publication' do
+      let(:collection) { create(:collection, publication: publication) }
+
+      it 'saves without touching the collection' do
+        expect { save_work }.not_to(change { collection.reload.updated_at })
+        expect(work.reload).to have_attributes(publication: publication, collection: collection)
+      end
+    end
+
+    context 'when the collection belongs to a different publication' do
+      let(:other_publication) { create(:publication) }
+      let(:collection) { create(:collection, publication: other_publication) }
+
+      it 'is rejected, leaving the other publication its volume' do
+        expect(save_work).to be false
+        expect(work.errors[:collection]).to be_present
+        expect(collection.reload.publication).to eq other_publication
+      end
+    end
+
+    context 'when the work fails validation for an unrelated reason' do
+      let(:collection) { create(:collection, publication: nil) }
+      let(:work) do
+        build(:lex_person_work, title: '', publication: publication, collection: collection)
+      end
+
+      it 'does not link the collection' do
+        expect(save_work).to be false
+        expect(collection.reload.publication).to be_nil
+      end
+    end
+  end
 end

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -73,6 +73,18 @@ describe '/lexicon/person_works' do
         expect(work.publication).to eq(publication)
         expect(work.collection).to eq(collection)
       end
+
+      context 'when the chosen collection is not linked to any publication' do
+        let(:collection) { create(:collection, publication: nil) }
+
+        it 'links the collection to the publication rather than erroring out' do
+          expect { call }.to change { person.works.count }.by(1)
+          expect(call).to eq(200)
+
+          expect(LexPersonWork.last).to have_attributes(publication: publication, collection: collection)
+          expect(collection.reload.publication).to eq publication
+        end
+      end
     end
   end
 
@@ -172,6 +184,28 @@ describe '/lexicon/person_works' do
         work.reload
         expect(work.publication).to eq(publication)
         expect(work.collection).to eq(collection)
+      end
+
+      context 'when the chosen collection is not linked to any publication' do
+        let(:collection) { create(:collection, publication: nil) }
+
+        it 'links the collection to the publication rather than erroring out' do
+          expect(call).to eq(200)
+
+          expect(work.reload).to have_attributes(publication: publication, collection: collection)
+          expect(collection.reload.publication).to eq publication
+        end
+      end
+
+      context 'when the chosen collection belongs to a different publication' do
+        let(:other_publication) { create(:publication, authority: authority) }
+        let(:collection) { create(:collection, publication: other_publication) }
+
+        it 're-renders the edit form and leaves the collection alone' do
+          expect(call).to eq(422)
+          expect(call).to render_template(:edit)
+          expect(collection.reload.publication).to eq other_publication
+        end
       end
     end
 

--- a/spec/system/lexicon/person_work_publication_collection_spec.rb
+++ b/spec/system/lexicon/person_work_publication_collection_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'LexPersonWork publication/collection pickers in edit modal', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:authority) { create(:authority, name: 'Test Author') }
+  let!(:person) { create(:lex_person, authority: authority, birthdate: '1970', gender: :female) }
+
+  let!(:entry) do
+    create(:lex_entry, title: 'Test Author', lex_item: person, status: :draft)
+  end
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_pub_coll_author.php')
+    File.write(file_path, '<html><body><h1>Test Author</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_pub_coll_author.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  # A publication of the authority that has no volume of its own.
+  let!(:publication) { create(:publication, authority: authority, title: 'Bibliography Entry') }
+
+  let!(:work) { create(:lex_person_work, person: person, work_type: :original, title: 'Some Work') }
+
+  after { FileUtils.rm_f(Rails.root.join('tmp/test_pub_coll_author.php')) }
+
+  # Opens the per-work edit modal from the entry edit page's Works tab.
+  def open_work_edit_modal
+    visit "/lex/entries/#{entry.id}/edit"
+    find('#works_tab').click
+    expect(page).to have_css('#works .edit-person-work', wait: 10)
+    find("#work_#{work.id} .edit-person-work").click
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+  end
+
+  context 'when the chosen collection is not linked to any publication' do
+    let!(:unlinked_volume) do
+      create(:collection, collection_type: :volume, title: 'Unlinked Volume', publication: nil,
+                          authors: [authority])
+    end
+
+    it 'keeps the collection selected after a publication is chosen, so both can be saved' do
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        select 'Unlinked Volume', from: 'lex_person_work_collection_id'
+        select 'Bibliography Entry', from: 'lex_person_work_publication_id'
+
+        expect(page).to have_select('lex_person_work_collection_id', selected: 'Unlinked Volume')
+      end
+    end
+  end
+
+  context 'when the chosen collection belongs to a different publication' do
+    let!(:other_volume) do
+      create(:collection, collection_type: :volume, title: 'Volume Of Another Publication',
+                          publication: create(:publication, authority: create(:authority)),
+                          authors: [authority])
+    end
+
+    it 'clears the collection, since that pairing cannot be saved' do
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        select 'Volume Of Another Publication', from: 'lex_person_work_collection_id'
+        select 'Bibliography Entry', from: 'lex_person_work_publication_id'
+
+        expect(page).to have_select('lex_person_work_collection_id',
+                                    selected: I18n.t('lexicon.person_works.form.select_collection'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

When editing a `LexPersonWork`, selecting both a Publication and a Collection that weren't already
linked to each other used to be rejected by the `collection_belongs_to_publication` validation.
Now the two get linked instead, and the work is associated with both.

## Behaviour

| Selected collection | Before | After |
| --- | --- | --- |
| Belongs to no publication | validation error | `collection.publication` is set to the chosen publication, work saved with both |
| Already belongs to the chosen publication | saved | saved (unchanged) |
| Belongs to a **different** publication | validation error | validation error (unchanged) |

The last row is deliberately left as an error: `Publication has_one :volume`, so silently
re-pointing the collection would strip the *other* publication of its volume. That message is now
I18n'd in `active_record.he.yml` / `active_record.en.yml` instead of a hardcoded English string.

## Implementation

- `LexPersonWork`: a `before_validation` hook sets `collection.publication_id` when the collection
  has none, and `belongs_to :collection` gains `autosave: true` so the collection is persisted in
  the same transaction as the work (and not at all if the work fails validation for another reason).
- `_form.html.haml`: the publication `change` handler used to blank the collection dropdown whenever
  the chosen publication had no volume of its own — which made the new pairing unreachable from the
  UI. It now keeps an unattached collection selected and only clears a collection that belongs to
  another publication.

## Test plan

- `spec/models/lex_person_work_spec.rb` — 4 new examples: links an unattached collection; no-op when
  already linked; rejects a collection owned by another publication; does not link when the work is
  invalid for an unrelated reason.
- `spec/requests/lexicon/person_works_spec.rb` — new examples on both POST (create) and PATCH
  (update) covering the link-on-save path and the still-rejected cross-publication case.
- `spec/system/lexicon/person_work_publication_collection_spec.rb` (new, `js: true`) — covers the
  dropdown behaviour in the edit modal, both directions.

All of the above pass, along with the full `spec/requests/lexicon/` directory and
`spec/models/collection_spec.rb` (467 examples, 0 failures). **The full suite was not run** — it
takes 40+ minutes and needs your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
