### PR TITLE
Add Japanese ('ja') to the list of supported languages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1751,11 +1751,7 @@ en:
   item: Item
   item_type: Item Type
   items: Items
-  ? |-
-    japane
-
-    se
-  : Japanese
+  japanese: Japanese
   kovetz: Collection
   kudos: Thank You!
   label: Label

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1589,6 +1589,7 @@ he:
   georgian: גאורגית
   ladino: לדינו
   chinese: סינית
+  japanese: יפנית
   aramaic: ארמית
   spanish: ספרדית
   arabic: ערבית

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -662,6 +662,8 @@ year = year.tr(GERESH_CHARS, '')
       return I18n.t(:aramaic)
     when 'zh'
       return I18n.t(:chinese)
+    when 'ja'
+      return I18n.t(:japanese)
     when 'pl'
       return I18n.t(:polish)
     when 'ro'
@@ -966,7 +968,7 @@ year = year.tr(GERESH_CHARS, '')
 
   def get_langs
     return %w(he en fr de ru yi pl ar el la grc hu cs da no sv nl it pt fa fi
-              is es ro arc lad zh ka bg sa ta sux egy unk)
+              is es ro arc lad zh ja ka bg sa ta sux egy unk)
   end
 
   def get_genres_by_row(row) # just one row at a time

--- a/spec/lib/bybe_utils_spec.rb
+++ b/spec/lib/bybe_utils_spec.rb
@@ -458,6 +458,27 @@ describe BybeUtils do
     end
   end
 
+  describe '#textify_lang' do
+    it 'names Japanese in Hebrew' do
+      I18n.with_locale(:he) { expect(instance.textify_lang('ja')).to eq('יפנית') }
+    end
+
+    it 'names Japanese in English' do
+      I18n.with_locale(:en) { expect(instance.textify_lang('ja')).to eq('Japanese') }
+    end
+
+    it 'names every supported language, save the explicit unknown code' do
+      unnamed = (instance.get_langs - ['unk']).select { |iso| instance.textify_lang(iso) == I18n.t(:unknown) }
+      expect(unnamed).to be_empty
+    end
+  end
+
+  describe '#get_langs' do
+    it "includes Japanese ('ja')" do
+      expect(instance.get_langs).to include('ja')
+    end
+  end
+
   describe '#orig_lang_label' do
     context 'when original language is unknown' do
       it 'returns the unknown-language I18n string for nil' do


### PR DESCRIPTION
## Summary

Adds Japanese (`ja`, Hebrew `יפנית`) to the list of supported languages.

The language list is centralised in `lib/bybe_utils.rb` — `get_langs` (the codes)
and `textify_lang` (code → display name). Every consumer derives from those, so
adding `ja` in both places makes Japanese available in:

- the `orig_lang` / `language` selects in `html_file`, `ingestibles`,
  `manifestation/edit_metadata`, and `admin/mass_updates`
- the search language facet (`shared/filters/_languages`), which sorts by
  translated name
- the `get_langs.count + 1` aggregation sizes in `authors_controller` and
  `manifestation_controller`
- the `xlat` ("all non-Hebrew") expansion in `manifestation_controller`

## Drive-by fix

`config/locales/en.yml` already contained a Japanese translation, but under a
**corrupted multi-line YAML key**:

```yaml
? |-
  japane

  se
: Japanese
```

That parses to the key `"japane\n\nse"`, which `I18n.t(:japanese)` can never
reach. Replaced it with a plain `japanese: Japanese`. `he.yml` had no entry at
all; added `japanese: יפנית`.

## Test plan

New examples in `spec/lib/bybe_utils_spec.rb`:

- `textify_lang('ja')` returns `יפנית` under `:he` and `Japanese` under `:en`
- `get_langs` includes `'ja'`
- a guard that **every** code in `get_langs` (except the explicit `unk`) has a
  real name in `textify_lang` — this would have caught a code added to one list
  but not the other

Ran:

```
bundle exec rspec spec/lib/bybe_utils_spec.rb spec/helpers/   # 242 examples, 0 failures
bundle exec rubocop lib/bybe_utils.rb spec/lib/bybe_utils_spec.rb
```

RuboCop reports no new offences in the changed lines (the remaining ones are
pre-existing, e.g. `Naming/AccessorMethodName` on `get_langs` itself).

**The full suite was not run** — it takes 40+ minutes and needs your go-ahead.

Closes by-347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
