### PR TITLE
Keep the author TOC navbar in step with the TOC body on role sections

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -772,26 +772,18 @@ class AuthorsController < ApplicationController
     InvolvedAuthority::ROLES_PRESENTATION_ORDER.each do |role|
       top_nodes = toc_tree.top_level_nodes
 
-      involved_on_collection_level = top_nodes.select { |node| node.visible?(role, authority_id, true) }
-                                              .sort_by(&:sort_term)
-      involved_on_work_level = top_nodes.select { |node| node.visible?(role, authority_id, false) }
-                                        .sort_by(&:sort_term)
-      uncollected_node = involved_on_work_level.detect { |node| node.collection.uncollected? }
-      involved_on_work_level -= [uncollected_node] if uncollected_node.present?
+      sections = helpers.toc_role_sections(top_nodes, role, authority_id)
+      uncollected_node = sections[:uncollected]
 
-      collection_level_count = involved_on_collection_level.sum do |node|
+      collection_level_count = sections[:collection_level].sum do |node|
         node.count_manifestations(role, authority_id, true)
       end
 
-      work_level_count = involved_on_work_level.sum do |node|
+      work_level_count = sections[:work_level].sum do |node|
         node.count_manifestations(role, authority_id, false)
       end
 
-      uncollected_count = if uncollected_node&.visible?(role, authority_id, false)
-                            uncollected_node.count_manifestations(role, authority_id, false)
-                          else
-                            0
-                          end
+      uncollected_count = uncollected_node ? uncollected_node.count_manifestations(role, authority_id, false) : 0
 
       total_count = collection_level_count + work_level_count + uncollected_count
 

--- a/app/helpers/authors_helper.rb
+++ b/app/helpers/authors_helper.rb
@@ -110,4 +110,29 @@ module AuthorsHelper
   def count_toc_nodes_manifestations(nodes, role, authority_id, involved_on_collection_level)
     nodes.sum { |node| node.count_manifestations(role, authority_id, involved_on_collection_level) }
   end
+
+  # Splits an authority's top-level TOC nodes into the three sections a role's TOC block is made
+  # of. Single source of truth for "which sections does this role have", shared by the TOC body
+  # (authors/_toc_by_role), the in-page navbar (shared/_newtoc_navbar) and the controller's count
+  # calculation, so the three cannot drift apart on which roles they show.
+  #
+  # Note this is deliberately about node PRESENCE, not manifestation counts: an unpublished
+  # manifestation is still rendered (unlinked) in the TOC while counting as 0, so a role can
+  # legitimately have sections to show and a total count of zero.
+  def toc_role_sections(top_nodes, role, authority_id)
+    collection_level = top_nodes.select { |node| node.visible?(role, authority_id, true) }
+                                .sort_by(&:sort_term)
+    work_level = top_nodes.select { |node| node.visible?(role, authority_id, false) }
+                          .sort_by(&:sort_term)
+    uncollected = work_level.detect { |node| node.collection.uncollected? }
+    work_level -= [uncollected] if uncollected.present?
+
+    { collection_level: collection_level, work_level: work_level, uncollected: uncollected }
+  end
+
+  # Whether a role has any TOC content at all, i.e. whether its heading should be rendered
+  def toc_role_present?(sections)
+    sections[:collection_level].present? || sections[:work_level].present? ||
+      sections[:uncollected].present?
+  end
 end

--- a/app/views/authors/_toc_by_role.html.haml
+++ b/app/views/authors/_toc_by_role.html.haml
@@ -1,18 +1,16 @@
 :ruby
-  involved_on_collection_level = top_nodes.select { |node| node.visible?(role, authority_id, true) }
-                                          .sort_by(&:sort_term)
-  involved_on_work_level = top_nodes.select { |node| node.visible?(role, authority_id, false) }
-                                    .sort_by(&:sort_term)
-  uncollected_node = involved_on_work_level.detect { |node| node.collection.uncollected? }
-  involved_on_work_level -= [uncollected_node] if uncollected_node.present?
+  sections = toc_role_sections(top_nodes, role, authority_id)
+  involved_on_collection_level = sections[:collection_level]
+  involved_on_work_level = sections[:work_level]
+  uncollected_node = sections[:uncollected]
 
   # Calculate counts for each section
   collection_level_count = count_toc_nodes_manifestations(involved_on_collection_level, role, authority_id, true)
   work_level_count = count_toc_nodes_manifestations(involved_on_work_level, role, authority_id, false)
-  uncollected_count = uncollected_node&.visible?(role, authority_id, false) ? uncollected_node.count_manifestations(role, authority_id, false) : 0
+  uncollected_count = uncollected_node ? uncollected_node.count_manifestations(role, authority_id, false) : 0
   total_count = collection_level_count + work_level_count + uncollected_count
 
-- if involved_on_collection_level.present? || involved_on_work_level.present? || (uncollected_node.present? && !uncollected_node.visible?(role, authority_id, false))
+- if toc_role_present?(sections)
   .headline-books
     = title
     - if total_count > 0
@@ -39,7 +37,7 @@
                 locals: { role: role, authority_id: authority_id, editable: editable,
                           nonce: "#{nonce}-work-level", uncollected: false,
                           involved_on_collection_level: false }
-  - if uncollected_node&.visible?(role, authority_id, false)
+  - if uncollected_node.present?
     %div{ id: "works-#{role}-uncollected", role: 'tabpanel' }
       .headline-2-v02
         = t('toc_by_role.uncollected_works')

--- a/app/views/shared/_newtoc_navbar.html.haml
+++ b/app/views/shared/_newtoc_navbar.html.haml
@@ -12,20 +12,24 @@
   roles_data = {}
 
   InvolvedAuthority::ROLES_PRESENTATION_ORDER.each do |role|
-    role_counts = @toc_counts ? @toc_counts[role] : nil
-    next unless role_counts && role_counts[:total] > 0
+    # Which sections the TOC body renders for this role. Gating on the same node presence the
+    # TOC body uses (rather than on the manifestation counts) is what keeps the two in step:
+    # unpublished works are shown in the TOC but count as 0, so a role can have a section to
+    # scroll to while its total count is zero.
+    sections = toc_role_sections(top_nodes, role, authority_id)
+    next unless toc_role_present?(sections)
 
-    all_collection_level_nodes = top_nodes.select { |node| node.visible?(role, authority_id, true) }
+    role_counts = (@toc_counts && @toc_counts[role]) ||
+                  { collection_level: 0, work_level: 0, uncollected: 0, total: 0 }
+
+    all_collection_level_nodes = sections[:collection_level]
     involved_on_collection_level = all_collection_level_nodes
                                    .select { |node| sidebar_collection_types.include?(node.collection.collection_type) }
-                                   .sort_by(&:sort_term)
     filtered_collection_level_count = involved_on_collection_level.sum do |node|
       node.count_manifestations(role, authority_id, true)
     end
-    all_work_level_nodes = top_nodes.select { |node| node.visible?(role, authority_id, false) }
-                                    .sort_by(&:sort_term)
-    uncollected_node = all_work_level_nodes.detect { |node| node.collection.uncollected? }
-    non_uncollected = all_work_level_nodes - [uncollected_node].compact
+    non_uncollected = sections[:work_level]
+    uncollected_node = sections[:uncollected]
     involved_on_work_level = non_uncollected.select do |node|
       sidebar_collection_types.include?(node.collection.collection_type)
     end
@@ -33,14 +37,16 @@
       node.count_manifestations(role, authority_id, false)
     end
 
-    # Determine the first visible scroll target for this role (for thin navbar)
-    first_scroll_target = if role_counts[:collection_level] > 0
-                           "#works-#{role}-collection-level"
-                          elsif role_counts[:work_level] > 0
-                           "#works-#{role}-work-level"
-                          elsif role_counts[:uncollected] > 0
-                           "#works-#{role}-uncollected"
-                          end
+    # First section of this role that the TOC body actually anchors, for the thin navbar to
+    # scroll to. Presence-based for the same reason as the gate above.
+    first_scroll_target =
+      if all_collection_level_nodes.present?
+        "#works-#{role}-collection-level"
+      elsif non_uncollected.present?
+        "#works-#{role}-work-level"
+      elsif uncollected_node.present?
+        "#works-#{role}-uncollected"
+      end
 
     visible_roles << role
     roles_data[role] = {
@@ -80,7 +86,8 @@
         %div{ class: first ? "book-type selected pointer" : "book-type pointer" }
           .truncate{'data-bs-toggle' => 'collapse', 'data-bs-target' => "#collection-#{role}-collapse", 'data-scroll-target' => "#works-#{role}-collection-level"}
             = t('toc_by_role.involved_on_collection_level', gender_letter: @author.gender_letter)
-            %span.count-badge= " (#{filtered_collection_level_count})"
+            - if filtered_collection_level_count > 0
+              %span.count-badge= " (#{filtered_collection_level_count})"
             %span.collapse-arrow ↓
         %ul{ id: "collection-#{role}-collapse", class: ul_class, 'aria-label' => 'file-navigator', role: 'tree' }
           = render partial: 'shared/navbar/toc_node', collection: involved_on_collection_level, locals: { role: role, authority_id: authority_id, nonce: "#{role}-collection", uncollected: false, involved_on_collection_level: true }
@@ -92,7 +99,8 @@
         %div{ class: first ? "book-type selected pointer" : "book-type pointer" }
           .truncate{ 'data-bs-toggle' => 'collapse', 'data-bs-target' => "#work-#{role}-collapse", 'data-scroll-target' => "#works-#{role}-work-level" }
             = t('toc_by_role.involved_on_work_level')
-            %span.count-badge= " (#{filtered_work_level_count})"
+            - if filtered_work_level_count > 0
+              %span.count-badge= " (#{filtered_work_level_count})"
             %span.collapse-arrow ↓
         %ul{ id: "work-#{role}-collapse", class: ul_class, 'aria-label' => 'file-navigator', role: 'tree' }
           = render partial: 'shared/navbar/toc_node', collection: involved_on_work_level, locals: { role: role, authority_id: authority_id, nonce: "#{role}-work", uncollected: false, involved_on_collection_level: false }
@@ -100,11 +108,12 @@
             %button.section-collapse-link{ type: 'button', 'aria-label': t(:collapse_section) }
               ▲
         - first = false
-      - if role_counts[:uncollected] > 0
+      - if uncollected_node.present?
         %div{ class: first ? "book-type selected pointer" : "book-type pointer" }
           .truncate{ 'data-scroll-target' => "#works-#{role}-uncollected" }
             = t('toc_by_role.uncollected_works')
-            %span.count-badge= " (#{role_counts[:uncollected]})"
+            - if role_counts[:uncollected] > 0
+              %span.count-badge= " (#{role_counts[:uncollected]})"
         %ul.navbar-nav{ 'aria-label' => 'file-navigator', role: 'tree' }
           = render partial: 'shared/navbar/toc_node', collection: [uncollected_node], locals: { role: role, authority_id: authority_id, uncollected: false, involved_on_collection_level: false }
         - first = false

--- a/spec/requests/author_toc_role_sections_spec.rb
+++ b/spec/requests/author_toc_role_sections_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Authority TOC body and the in-page navbar beside it must agree on which roles have a
+# section: every role heading in the TOC needs a navbar entry, and every navbar entry needs a
+# TOC anchor to scroll to. The two used to be gated differently (nodes present vs. manifestation
+# count > 0), which made them disagree in both directions.
+RSpec.describe 'Authority TOC role sections', type: :request do
+  subject(:call) { get authority_path(author) }
+
+  let(:author) { create(:authority, :published, uncollected_works_collection: uncollected_collection) }
+  let(:uncollected_collection) { create(:collection, :uncollected) }
+  let(:original_works_header) { I18n.t('toc_by_role.headers.author', gender_letter: author.gender_letter) }
+
+  context "when the authority's only original works are unpublished ones in others' collections" do
+    # Reproduces benyehuda.org/author/2776: the works are visible in the TOC (rendered unlinked)
+    # but count as 0, so a count-based gate dropped the role from the navbar only.
+    let(:other_authority) { create(:authority) }
+    let(:volume) do
+      create(:collection, title: 'Somebody Else Volume', collection_type: :volume, authors: [other_authority])
+    end
+
+    before do
+      Chewy.strategy(:atomic) do
+        manifestation = create(:manifestation, author: author, status: :nonpd, title: 'An Unpublished Work')
+        create(:collection_item, collection: volume, item: manifestation)
+      end
+      call
+    end
+
+    it 'renders the original-works section in the TOC body' do
+      expect(response.body).to include(original_works_header)
+      expect(response.body).to include('id="works-author-work-level"')
+    end
+
+    it 'renders the original-works group in the navbar too' do
+      navbar = navbar_fragment(response.body)
+      expect(navbar).to include(original_works_header)
+      expect(navbar).to include('data-scroll-target="#works-author-work-level"')
+    end
+
+    it 'shows no count badge for the section, since nothing in it is published' do
+      expect(response.body).not_to include('<span class="count-badge"> (0)</span>')
+    end
+  end
+
+  context 'when the authority has only uncollected works in a role' do
+    # Reproduces benyehuda.org/author/26: the TOC body rendered nothing at all, while the navbar
+    # still offered an 'uncollected works' entry pointing at an anchor that did not exist.
+    before do
+      Chewy.strategy(:atomic) do
+        manifestation = create(:manifestation, author: author, status: :published, title: 'A Lone Work')
+        create(:collection_item, collection: uncollected_collection, item: manifestation)
+      end
+      call
+    end
+
+    it 'renders the uncollected section in the TOC body' do
+      expect(response.body).to include(original_works_header)
+      expect(response.body).to include('id="works-author-uncollected"')
+      expect(response.body).to include('A Lone Work')
+    end
+
+    it 'points the navbar at that section' do
+      navbar = navbar_fragment(response.body)
+      expect(navbar).to include(original_works_header)
+      expect(navbar).to include('data-scroll-target="#works-author-uncollected"')
+    end
+  end
+
+  context 'when a role has published works' do
+    let(:volume) { create(:collection, title: 'Own Volume', collection_type: :volume, authors: [author]) }
+
+    before do
+      Chewy.strategy(:atomic) do
+        manifestation = create(:manifestation, author: author, status: :published, title: 'A Published Work')
+        create(:collection_item, collection: volume, item: manifestation)
+      end
+      call
+    end
+
+    it 'still shows the section with its count badge' do
+      expect(response.body).to include(original_works_header)
+      expect(response.body).to include('id="works-author-collection-level"')
+      expect(response.body).to include('<span class="count-badge"> (1)</span>')
+    end
+  end
+
+  # The in-page navbar, without the TOC body that follows it
+  def navbar_fragment(body)
+    body[body.index('book-nav-full')...body.index('mobile-navbar-backdrop')]
+  end
+end


### PR DESCRIPTION
## The bug

On https://benyehuda.org/author/2776 the main ToC renders a **יצירות מקור** (original works)
section listing two collections, but the sidebar navbar omits that heading entirely.

## Root cause

The ToC body and the navbar beside it use two different gates for *"does this role have a
section"*:

| | gate |
| --- | --- |
| `authors/_toc_by_role` (ToC body) | node **presence** |
| `shared/_newtoc_navbar` (navbar) | `@toc_counts[role][:total] > 0` |

`ManifestationNode#count_manifestations` returns 0 for an unpublished manifestation, while
`CollectionNode#visible?` still returns true for it — so a role can legitimately have nodes to
show and a total count of zero. Authority 2776's only original works are unpublished ones sitting
in other people's collections, which is exactly that case: the ToC shows them (unlinked), the
navbar drops the whole role.

### A second instance of the same drift, in the opposite direction

While tracing this I found the ToC body's gate carries a stray `!`:

```ruby
uncollected_node.present? && !uncollected_node.visible?(role, authority_id, false)
```

`uncollected_node` is `detect`ed from the *already-visible* list, so that clause is always false.
The consequence: an authority whose works in a role are **only** uncollected renders an entirely
**empty** ToC body, while the navbar still offers an "uncollected works" entry pointing at an
anchor that does not exist. Confirmed live on
[/author/26](https://benyehuda.org/author/26), [/author/136](https://benyehuda.org/author/136)
and [/author/199](https://benyehuda.org/author/199) — all three render nothing under the ToC.

Fixing only the navbar's gate would have meant matching this latent ToC bug and making those
authors' pages lose their heading too, so both sides are fixed here.

## The fix

- New `AuthorsHelper#toc_role_sections` / `#toc_role_present?` — one place that decides which
  sections a role has. Used by `_toc_by_role`, `_newtoc_navbar` **and**
  `AuthorsController#calculate_toc_counts`, which had a third copy of the same selection logic,
  so the three cannot drift apart again.
- Navbar gates roles on section presence rather than on the counts.
- Dropped the stray `!` from the ToC body's uncollected clause.
- Navbar's thin-bar `first_scroll_target` is presence-based too, so it can no longer be `nil`
  for a role that is displayed.
- Navbar count badges are suppressed at zero, matching what the ToC body already did (otherwise
  the newly-shown sections would read `(0)`).

Counting behaviour is deliberately unchanged: unpublished works still count as 0.

## Test plan

New `spec/requests/author_toc_role_sections_spec.rb` covers both directions plus a
published-works regression guard. Verified the two new assertions fail on `master` and pass here.

Ran (all green):

```
spec/requests/author_toc_role_sections_spec.rb                    6 examples
spec/helpers/authors_helpers_spec.rb
spec/requests/author_toc_lexicon_content_spec.rb
spec/requests/navbar_works_about_author_i18n_spec.rb
spec/controllers/authors_controller_spec.rb                     105 examples
spec/system/author_navbar_*.rb spec/system/author_toc_*.rb       39 examples
spec/system/author_*.rb (remainder) + author request specs        49 examples
spec/system/manage_toc_draggable_spec.rb                          1 example
```

Also verified against the local dev copy of production data: `/author/26` now renders its
uncollected section (it rendered nothing before), and `GenerateTocTree` for authority 2776
confirms the `author` role has one work-level node with a count of 0.

**The full suite was not run** — it takes 40+ minutes and needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
