### PR TITLE
Find the lexicon works header wherever the legacy file nests it

### DIFF
--- a/app/services/lexicon/bio_comparison.rb
+++ b/app/services/lexicon/bio_comparison.rb
@@ -13,9 +13,6 @@ module Lexicon
   class BioComparison < ApplicationService
     include HtmlUtils
 
-    # Mirrors Lexicon::IngestPerson::WORKS_HEADER -- the anchor that ends the bio.
-    WORKS_HEADER = 'Books'
-
     # A difference of more than this many words is flagged as a discrepancy.
     WORD_DIFF_TOLERANCE = 2
 
@@ -53,41 +50,16 @@ module Lexicon
 
     private
 
-    # Extracts the bio HTML from the legacy file by walking siblings of the
-    # heading table up to the "Books" header, mirroring the boundary logic in
-    # Lexicon::IngestPerson#create_lex_item (including the wrapping-span fallback).
+    # Extracts the bio HTML from the legacy file using the same boundary logic the migration
+    # itself uses (HtmlUtils#bio_elements), so the two sides of the comparison always agree on
+    # where the biography ends.
     def extract_legacy_bio_html(source_content)
       return '' if source_content.blank?
 
-      html_doc = Nokogiri::HTML(source_content)
-      heading_table = html_doc.at_css('table[width="100%"]')
+      heading_table = Nokogiri::HTML(source_content).at_css('table[width="100%"]')
       return '' if heading_table.nil?
 
-      next_elem = heading_table.next_element
-      at_span_level = false
-      if next_elem.nil? && heading_table.parent.name == 'span'
-        next_elem = heading_table.parent.next_element
-        at_span_level = true
-      end
-
-      bio, next_elem = collect_bio_until_works(next_elem)
-
-      # Bio was inside the wrapping span but the works header is outside it.
-      if next_elem.nil? && !at_span_level && heading_table.parent.name == 'span'
-        extra_bio, = collect_bio_until_works(heading_table.parent.next_element)
-        bio += extra_bio
-      end
-
-      bio.join("\n")
-    end
-
-    def collect_bio_until_works(elem)
-      bio = []
-      while elem.present? && !header?(elem, WORKS_HEADER)
-        bio << elem.to_html
-        elem = elem.next_element
-      end
-      [bio, elem]
+      bio_elements(heading_table).map(&:to_html).join("\n")
     end
 
     def words_from_html(html)

--- a/app/services/lexicon/html_utils.rb
+++ b/app/services/lexicon/html_utils.rb
@@ -12,6 +12,18 @@ module Lexicon
     # even when it has no text.
     VISIBLE_EMPTY_ELEMENTS = 'img, hr, iframe, embed, object, video, audio, input'
 
+    # The named anchors that open a section of a legacy person entry, in document order.
+    WORKS_ANCHOR = 'Books'
+    CITATIONS_ANCHOR = 'Bib.'
+    LINKS_ANCHOR = 'links'
+    SECTION_ANCHORS = [WORKS_ANCHOR, CITATIONS_ANCHOR, LINKS_ANCHOR].freeze
+    SECTION_ANCHOR_SELECTOR = SECTION_ANCHORS.map { |name| %(a[name="#{name}"]) }.join(', ')
+
+    # Inline elements a section anchor is wrapped in. The wrapper carrying the section's
+    # content as its following siblings is the outermost of these, so we climb out of all
+    # of them when locating a header.
+    HEADER_WRAPPERS = %w(p font b i u).freeze
+
     # Parses a legacy lexicon PHP file, honouring the charset it declares (a handful of
     # the oldest files are genuinely windows-1255) but defaulting to UTF-8 instead of
     # libxml2's Latin-1 when no charset is declared.
@@ -39,6 +51,75 @@ module Lexicon
     # Pandoc keeps them as raw HTML, so they survive migration as markup noise.
     def content_free_table?(elem)
       elem.name == 'table' && elem.text.blank? && elem.at_css(VISIBLE_EMPTY_ELEMENTS).nil?
+    end
+
+    # The works section header, wherever it sits in the document: the outermost <p>/<font>
+    # around the a[name="Books"] anchor, or the bare anchor itself in the handful of files
+    # whose wrapper tag was never opened.
+    #
+    # We search the whole document rather than the heading table's siblings because the
+    # legacy files nest the section in every imaginable way: ~400 of them wrap the works and
+    # bibliography in a <blockquote> (occasionally two), and a few keep the heading table
+    # inside a <p> the works section is not part of. Walking siblings misses all of those and
+    # silently turns the entire works block into biography text.
+    #
+    # Returning the *outermost* wrapper matters: ExtractPersonWorks reads the works lists from
+    # the header's following siblings, so the header has to be the element those lists follow.
+    def works_header_element(html_doc)
+      node = html_doc.at_css(%(a[name="#{WORKS_ANCHOR}"]))
+      return nil if node.nil?
+
+      node = node.parent while header_wrapper?(node)
+      node
+    end
+
+    # Whether +node+'s parent is another wrapper of the same section header, i.e. whether
+    # locating the header should climb one level further out.
+    #
+    # A <span> counts only when +node+ has nothing after it: a <span dir="rtl"> that already
+    # holds the works lists as siblings of the header is a section container, not a wrapper,
+    # and climbing into it would leave ExtractPersonWorks with no lists to read.
+    def header_wrapper?(node)
+      parent = node.parent
+      return false if parent.nil?
+      return true if HEADER_WRAPPERS.include?(parent.name)
+
+      parent.name == 'span' && node.next_element.nil?
+    end
+
+    # Elements holding the biography: everything after the heading table, up to the element
+    # that carries (or contains) the first section anchor.
+    def bio_elements(heading_table)
+      elements = []
+      elem = next_element_ascending(heading_table)
+      while elem.present? && !section_header?(elem)
+        elements << elem
+        elem = next_element_ascending(elem)
+      end
+      elements
+    end
+
+    # Whether +elem+ is, or wraps, the header of a section (works, bibliography or links).
+    def section_header?(elem)
+      return true if elem.name == 'a' && SECTION_ANCHORS.include?(elem['name'])
+
+      elem.at_css(SECTION_ANCHOR_SELECTOR).present?
+    end
+
+    # The next element in document order that is not a descendant of +elem+: its next sibling,
+    # or - once a nesting level is exhausted - the next sibling of the nearest ancestor that has
+    # one. Climbing is what lets a bio walk started inside a wrapping <span dir="rtl"> reach the
+    # sections that follow the span.
+    def next_element_ascending(elem)
+      node = elem
+      while node.present? && %w(body html).exclude?(node.name)
+        sibling = node.next_element
+        return sibling if sibling.present?
+
+        node = node.parent
+      end
+
+      nil
     end
 
     def next_element_skipping_blank(elem)

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -5,9 +5,6 @@ module Lexicon
   class IngestPerson < IngestBase
     include HtmlUtils
 
-    WORKS_HEADER = 'Books'
-    CITATIONS_HEADER = 'Bib.'
-
     # The links section is normally introduced by an <a name="links"> anchor, but a handful of
     # legacy files spell the anchor differently (e.g. `name="links."`) or omit it entirely and
     # carry only the Hebrew "קישורים:" heading. Patterns are tried in order, so the anchor always
@@ -64,41 +61,14 @@ module Lexicon
         end
       end
 
-      # Bio content may be inside a wrapping span (as siblings of the heading table),
-      # or outside the span (as siblings of the span itself). We first iterate table
-      # siblings; if exhausted, we fall through to span siblings to find remaining bio
-      # and the works header.
-      next_elem = heading_table.next_element
-      at_span_level = false
-
-      # When the table has no siblings inside its wrapping span, jump directly
-      # to the span's siblings where bio content lives.
-      if next_elem.nil? && heading_table.parent.name == 'span'
-        next_elem = heading_table.parent.next_element
-        at_span_level = true
-      end
-
-      bio = []
-      while next_elem.present? && !header?(next_elem, WORKS_HEADER)
-        bio << bio_html(next_elem)
-        next_elem = next_elem.next_element
-      end
-
-      # Bio was inside the wrapping span but the works header is outside it.
-      # Continue from span siblings to find the works header.
-      if next_elem.nil? && !at_span_level && heading_table.parent.name == 'span'
-        next_elem = heading_table.parent.next_element
-        while next_elem.present? && !header?(next_elem, WORKS_HEADER)
-          bio << bio_html(next_elem)
-          next_elem = next_elem.next_element
-        end
-      end
-
+      # Bio content is whatever lies between the heading table and the first section header,
+      # across whatever nesting the file happens to use (a wrapping <span dir="rtl"> around the
+      # heading, a <blockquote> around the sections, both, or neither).
+      bio = bio_elements(heading_table).map { |elem| bio_html(elem) }
       lex_person.bio = HtmlToMarkdown.call(bio.compact.join("\n"))
 
-      if next_elem.present? && header?(next_elem, WORKS_HEADER)
-        Lexicon::ExtractPersonWorks.call(next_elem, lex_person)
-      end
+      works_header = works_header_element(html_doc)
+      Lexicon::ExtractPersonWorks.call(works_header, lex_person) if works_header.present?
 
       lex_person.gender = @female ? :female : :male
 

--- a/spec/fixtures/files/lexicon/works_header_without_wrapper.php
+++ b/spec/fixtures/files/lexicon/works_header_without_wrapper.php
@@ -1,0 +1,32 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>סופרת לדוגמה</title>
+</head>
+<!-- page header --><?php
+include "header.php";
+?><span dir="rtl">
+<body dir="rtl">
+
+<table border="0" width="100%" id="table4">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">סופרת לדוגמה</font><font size="4" color="#FF0000"> (1963)</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Example Author</font></td>
+  </tr>
+</table>
+<p class="margin" align="justify">ביוגרפיה קצרה של הסופרת לדוגמה. נולדה בשנת 1963.</p></p>
+		<a name="Books">ספריה:</a></font></p>
+<ul style='margin-top:0in' type=circle>
+<li>ספר ראשון : שירים (תל אביב : הוצאה לדוגמה, 1990)</li>
+<li>ספר שני : פרוזה (תל אביב : הוצאה אחרת, 1995)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<!-- page footer --><?php
+include "footer.php";
+?>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/works_in_blockquote.php
+++ b/spec/fixtures/files/lexicon/works_in_blockquote.php
@@ -1,0 +1,36 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>סופרת לדוגמה</title>
+</head>
+<!-- page header --><?php
+include "header.php";
+?><span dir="rtl">
+<body dir="rtl">
+
+<table border="0" width="100%" id="table4">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">סופרת לדוגמה</font><font size="4" color="#FF0000"> (1936)</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Example Author</font></td>
+  </tr>
+</table>
+</span>
+<p class="margin" align="justify">ביוגרפיה קצרה של הסופרת לדוגמה. נולדה בשנת 1936 וכתבה ספרים רבים.</p>
+<blockquote>
+  <p align="right" dir="rtl"><font size="4" color="#0000FF">
+  <a name="Books">ספריה:</a></font></p>
+  <ul style="MARGIN-TOP: 0in" type="circle">
+    <li>ספר ראשון : שירים (תל אביב : הוצאה לדוגמה, 1980)</li>
+    <li>ספר שני : פרוזה (תל אביב : הוצאה אחרת, 1990)</li>
+  </ul><font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
+  <p>לא נמצאו מקורות.</p>
+</blockquote>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font></p>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<hr><font size="2">[עודכן לאחרונה: 27 בפברואר 2017] </font>
+<!-- page footer --><?php
+include "footer.php";
+?>
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/works_outside_heading_wrapper.php
+++ b/spec/fixtures/files/lexicon/works_outside_heading_wrapper.php
@@ -1,0 +1,42 @@
+<html>
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="lexicon2.css" type="text/css">
+<title>סופר לדוגמה</title>
+</head>
+		<!-- page header -->
+			<?
+			// include page header
+			include "header.php";
+			?><span dir="rtl">
+<body dir="rtl">
+		<table border="0" width="100%" id="table5">
+			<tr>
+				<td><p align="center"><font size="5" color="#FF0000">סופר לדוגמה</font><font size="4" color="#FF0000"> (1906–1966)</font></td>
+				<td><p align="center" dir="ltr"><font size="5" color="#FF0000">Example Author</font></td>
+			</tr>
+		</table>
+		</span>
+		<p class="margin" align="justify">ביוגרפיה קצרה של הסופר לדוגמה. נולד בשנת 1906 ונפטר בשנת 1966.</p>
+		<p align="right" dir="rtl"><font size="4" color="#0000FF">
+		<a name="Books">ספריו:</a></font></p>
+		<span dir="rtl">
+		<ul style="MARGIN-TOP: 0in" type="circle">
+		<li>ספר ראשון : שירים (תל אביב : הוצאה לדוגמה, 1930)</li>
+		<li>ספר שני : פרוזה (תל אביב : הוצאה אחרת, 1940)</li>
+		</ul>
+		</span>
+		<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+		<p>לא נמצאו מקורות.</p>
+		<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+		<ul style="MARGIN-TOP: 0in" type="circle">
+		</ul>
+		<hr><font size="2">[עודכן לאחרונה: 3 במרס 2020] </font>
+<!-- page footer -->
+			<?
+			// include page footer
+			include "footer.php";
+			?>
+</body>
+</html>

--- a/spec/services/lexicon/html_utils_spec.rb
+++ b/spec/services/lexicon/html_utils_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 describe Lexicon::HtmlUtils do
+  let(:fixtures_dir) { Rails.root.join('spec/fixtures/files/lexicon') }
+
   describe '.parse_file' do
     subject(:doc) { described_class.parse_file(file) }
-
-    let(:fixtures_dir) { Rails.root.join('spec/fixtures/files/lexicon') }
 
     # The Hebrew entry title, as it appears in the first cell of the header table
     def title_text
@@ -34,6 +34,75 @@ describe Lexicon::HtmlUtils do
 
       it 'honours the declared encoding rather than forcing UTF-8' do
         expect(title_text).to start_with('נורית זרחי')
+      end
+    end
+  end
+
+  describe '#works_header_element and #bio_elements' do
+    subject(:helper) { Class.new { include Lexicon::HtmlUtils }.new }
+
+    let(:doc) { described_class.parse_file(fixtures_dir.join(file)) }
+    let(:heading_table) { doc.at_css('table[width="100%"]') }
+    let(:works_header) { helper.works_header_element(doc) }
+    let(:bio_text) { helper.bio_elements(heading_table).map(&:text).join(' ').squish }
+
+    context 'when the works section is a sibling of the bio' do
+      let(:file) { '00002.php' }
+
+      it 'returns the <p> wrapping the anchor, which the works lists follow' do
+        expect(works_header.name).to eq('p')
+        expect(works_header.at_css('a[name="Books"]')).to be_present
+      end
+
+      it 'ends the bio before the works section' do
+        expect(bio_text).to include('סופרת, משוררת ועורכת')
+        expect(bio_text).not_to include('ספריה:')
+      end
+    end
+
+    context 'when the works section is wrapped in a blockquote' do
+      let(:file) { 'works_in_blockquote.php' }
+
+      it 'finds the header inside the blockquote' do
+        expect(works_header.name).to eq('p')
+        expect(works_header.parent.name).to eq('blockquote')
+      end
+
+      it 'keeps the blockquote out of the bio' do
+        expect(bio_text).to eq('ביוגרפיה קצרה של הסופרת לדוגמה. נולדה בשנת 1936 וכתבה ספרים רבים.')
+      end
+    end
+
+    context 'when the heading table is wrapped in a paragraph the works section is outside of' do
+      let(:file) { 'works_outside_heading_wrapper.php' }
+
+      it 'climbs out of the wrapper to collect the bio' do
+        expect(bio_text).to eq('ביוגרפיה קצרה של הסופר לדוגמה. נולד בשנת 1906 ונפטר בשנת 1966.')
+      end
+
+      it 'finds the header at the outer nesting level' do
+        expect(works_header.text.squish).to eq('ספריו:')
+      end
+    end
+
+    context 'when the header anchor has no <p>/<font> wrapper' do
+      let(:file) { 'works_header_without_wrapper.php' }
+
+      it 'falls back to the bare anchor, which the works list follows' do
+        expect(works_header.name).to eq('a')
+        expect(works_header['name']).to eq('Books')
+      end
+
+      it 'ends the bio at the bare anchor' do
+        expect(bio_text).to eq('ביוגרפיה קצרה של הסופרת לדוגמה. נולדה בשנת 1963.')
+      end
+    end
+
+    context 'when the entry has no works section' do
+      let(:file) { 'no_links.php' }
+
+      it 'returns no works header' do
+        expect(works_header).to be_nil
       end
     end
   end

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -138,6 +138,88 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when the works and bibliography are wrapped in a blockquote' do
+    # Regression test for 00067.php and ~370 siblings: the Books header sits inside a
+    # <blockquote>, so walking the heading table's siblings never reached it and the whole
+    # works + bibliography block was migrated as biography text, with no works at all.
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'סופרת לדוגמה',
+          fname: 'works_in_blockquote.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/works_in_blockquote.php')
+        }
+      )
+    end
+
+    it 'migrates the works and leaves them out of the bio' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.works.map(&:title)).to contain_exactly('ספר ראשון : שירים', 'ספר שני : פרוזה')
+      expect(person.bio).to include('ביוגרפיה קצרה')
+      expect(person.bio).not_to include('ספריה:')
+      expect(person.bio).not_to include('ספר ראשון')
+      expect(person.bio).not_to include('על המחברת ויצירתה')
+    end
+  end
+
+  context 'when the heading table is wrapped in a paragraph the works section is outside of' do
+    # Regression test for 00696.php and friends: the heading table ends up inside a <p> of its
+    # own, so the walk ran out of siblings before reaching any bio at all - the entry migrated
+    # with an empty bio and no works.
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'סופר לדוגמה',
+          fname: 'works_outside_heading_wrapper.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/works_outside_heading_wrapper.php')
+        }
+      )
+    end
+
+    it 'migrates both the bio and the works' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.bio).to include('ביוגרפיה קצרה')
+      expect(person.bio).not_to include('ספריו:')
+      expect(person.works.map(&:title)).to contain_exactly('ספר ראשון : שירים', 'ספר שני : פרוזה')
+    end
+  end
+
+  context 'when the works header anchor lost its <p>/<font> wrapper' do
+    # Regression test for 00146.php and 01778.php: an unbalanced </font></p> in the source
+    # leaves a bare <a name="Books"> that the p/font-only header check never recognised.
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'סופרת לדוגמה',
+          fname: 'works_header_without_wrapper.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/works_header_without_wrapper.php')
+        }
+      )
+    end
+
+    it 'treats the bare anchor as the works header' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.bio).to include('ביוגרפיה קצרה')
+      expect(person.bio).not_to include('ספריה:')
+      expect(person.works.map(&:title)).to contain_exactly('ספר ראשון : שירים', 'ספר שני : פרוזה')
+    end
+  end
+
   context 'when the bio contains tables with rows and cells but no visible content' do
     # Regression test for 00458.php and friends: a layout-only <table id="table6"> sits between
     # the bio paragraphs. Pandoc has no Markdown representation for it, so it used to be emitted


### PR DESCRIPTION
## The problem

`lexicon/00067.php` migrates with its entire works + bibliography block as biography text and **zero works**. The cause is structural, not specific to that file.

`Lexicon::IngestPerson` looked for the works header (`a[name="Books"]`) by walking the *flat siblings* of the heading table, with a one-level fallback into the wrapping `<span dir="rtl">`. That assumption breaks in **403 legacy files**:

| variant | files | example |
| --- | --- | --- |
| works + bibliography wrapped in a `<blockquote>` (occasionally two) | ~375 | `00067.php` |
| heading table left inside a `<p>` the works section is not part of | ~21 | `00696.php` |
| unbalanced `</font></p>` leaves a bare `<a name="Books">` with no `<p>`/`<font>` wrapper | ~5 | `00146.php`, `01778.php` |

Nothing stops the bio walk when the header is missed, so the works, the bibliography, the links and the footer all end up in the bio, and `ExtractPersonWorks` is never called. In the `00696` shape the walk ran out of siblings before reaching *any* content, so those entries migrated with an **empty bio** as well.

## The fix

- **Locate the header document-wide** (`HtmlUtils#works_header_element`), then climb out of the inline wrappers (`p`, `font`, `b`, `i`, `u`) around the anchor, so the element returned is the one the works `<ul>`s actually follow — which is what `ExtractPersonWorks` reads. A `<span>` is climbed only when there is nothing after the node, so a `<span dir="rtl">` that *holds* the works lists is not mistaken for a wrapper. Files with no wrapper at all fall back to the bare anchor.
- **Collect the bio by walking forward without descending** (`HtmlUtils#bio_elements`): next sibling, or — once a nesting level is exhausted — the next sibling of the nearest ancestor that has one, stopping at the first element that is or contains a section anchor (`Books`, `Bib.`, `links`). This replaces the two ad-hoc span fallbacks.
- `BioComparison` had its own copy of the old boundary logic; it now calls the shared `bio_elements` so both sides of the comparison always agree on where the bio ends.
- Removed `IngestPerson::WORKS_HEADER` / `CITATIONS_HEADER` and `BioComparison::WORKS_HEADER`, superseded by `HtmlUtils::WORKS_ANCHOR` / `CITATIONS_ANCHOR` (`CITATIONS_HEADER` had no readers at all).

## Measured impact

Every one of the 4044 `person` `LexFile`s was re-parsed with the old and new code and the results diffed:

| outcome | entries |
| --- | --- |
| header and bio byte-identical | 3993 |
| works section now found, bio was empty and is now populated | 21 |
| works section now found, works removed from the bio | 12 |
| bio no longer swallows the bibliography/links sections | 18 |
| header lost or changed | **0** |

**508 works recovered** across those 33 entries (`00067.php` alone: 82). The remaining 370 of the 403 affected files are `text`/`bib` entries, which go through `IngestPublication` and are untouched by this change.

## Test plan

New fixtures, one per failure mode, each verified to reproduce the old failure and be fixed by the new code:

- `works_in_blockquote.php` — the `00067` shape
- `works_outside_heading_wrapper.php` — the `00696` shape (old code produced an empty bio *and* no works)
- `works_header_without_wrapper.php` — the bare-anchor shape

Specs added to `ingest_person_spec.rb` (end-to-end: works migrated, bio excludes the works and bibliography) and `html_utils_spec.rb` (unit coverage of `works_header_element` / `bio_elements`, including the unchanged flat-sibling case and the no-works-section case).

```
bundle exec rspec spec/services/lexicon spec/models/lex_person_spec.rb spec/models/lex_entry_spec.rb \
                  spec/models/lex_file_spec.rb spec/controllers/lexicon spec/helpers/lexicon
# 459 examples, 0 failures
```

RuboCop clean on all changed files. **The full suite has not been run** — it takes 40+ minutes and needs your go-ahead.

Closes by-ph2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
