### PR TITLE
Offer to match plaintext citation authors to existing person entries

### DIFF
--- a/app/controllers/lexicon/citation_authors_controller.rb
+++ b/app/controllers/lexicon/citation_authors_controller.rb
@@ -46,12 +46,17 @@ module Lexicon
     # An entry-linked author may not also carry a link, so any leftover link is dropped -- the same
     # thing ParseCitations#update_link does when it links an author during ingestion.
     def update
-      @author.assign_attributes(lex_entry_id: match_params[:lex_entry_id].presence, link: nil)
+      # The record is looked up rather than the id assigned straight through, so a submission naming
+      # an entry that does not exist is rejected here. Two ordinary cases reach this: the
+      # autocomplete clears its hidden id field as soon as the editor edits the text, and the
+      # autocomplete index can still offer an entry that has since been deleted (a stale document
+      # outlives the row it described, since the index is only pruned when a destroy runs through
+      # the model). Without the lookup the second case sails past validation -- `entry` is nil, so
+      # `entry_must_be_person` never runs -- and fails on the lex_entries foreign key with a 500.
+      @author.assign_attributes(entry: LexEntry.find_by(id: match_params[:lex_entry_id]), link: nil)
 
-      if @author.lex_entry_id.blank?
-        # The autocomplete clears its hidden id field as soon as the editor edits the text, so a
-        # submission with free text and no selected entry is an ordinary mistake, not an attack.
-        @author.errors.add(:lex_entry_id, :blank)
+      if @author.entry.nil?
+        @author.errors.add(:lex_entry_id, :entry_not_found)
       elsif @author.save
         return head :ok
       end

--- a/app/controllers/lexicon/citation_authors_controller.rb
+++ b/app/controllers/lexicon/citation_authors_controller.rb
@@ -9,7 +9,7 @@ module Lexicon
       require_editor('edit_lexicon')
     end
     before_action :set_citation, only: %i(index create)
-    before_action :set_author, only: %i(destroy)
+    before_action :set_author, only: %i(match update destroy)
     before_action :try_to_lock_record
 
     layout false
@@ -37,6 +37,28 @@ module Lexicon
       render status: status
     end
 
+    # Modal offering to link a plaintext author imported from a legacy PHP file to an existing
+    # person entry, pre-filled with the name the match was found by (see LexCitationAuthor.normalize_name).
+    def match; end
+
+    # Links the author to the chosen person entry. The imported name is deliberately left untouched,
+    # so the citation keeps displaying it as "lastname, firstname" exactly as the legacy file had it.
+    # An entry-linked author may not also carry a link, so any leftover link is dropped -- the same
+    # thing ParseCitations#update_link does when it links an author during ingestion.
+    def update
+      @author.assign_attributes(lex_entry_id: match_params[:lex_entry_id].presence, link: nil)
+
+      if @author.lex_entry_id.blank?
+        # The autocomplete clears its hidden id field as soon as the editor edits the text, so a
+        # submission with free text and no selected entry is an ordinary mistake, not an attack.
+        @author.errors.add(:lex_entry_id, :blank)
+      elsif @author.save
+        return head :ok
+      end
+
+      render :match, status: :unprocessable_content
+    end
+
     def destroy
       @author.destroy!
     end
@@ -45,6 +67,12 @@ module Lexicon
 
     def author_params
       params.expect(lex_citation_author: %i(name link lex_entry_id))
+    end
+
+    # Only the entry reference is accepted: the modal's autocomplete box also submits the title the
+    # editor searched by, but the imported name must survive the match unchanged.
+    def match_params
+      params.expect(lex_citation_author: %i(lex_entry_id))
     end
 
     def set_citation

--- a/app/helpers/lexicon/verification_helper.rb
+++ b/app/helpers/lexicon/verification_helper.rb
@@ -25,6 +25,22 @@ module Lexicon
       css
     end
 
+    # The authors of a citation as shown on its verification card. An author already linked to a
+    # lexicon entry renders as a link to it; a plaintext author imported from a legacy PHP file
+    # renders as text, followed by a button offering to link it whenever a person entry titled
+    # exactly like its normalized name exists. `matchable_names` comes from
+    # LexCitationAuthor.matchable_names, resolved once for the whole page.
+    def citation_authors_for_verification(citation, matchable_names)
+      parts = citation.authors.map do |author|
+        next link_to(author.display_name, lexicon_entry_path(author.entry)) if author.entry.present?
+        next author.display_name unless matchable_names.include?(author.normalized_name&.downcase)
+
+        safe_join([author.display_name, citation_author_match_button(author)], ' ')
+      end
+
+      safe_join(parts, ', ')
+    end
+
     # Returns the CSS classes for a link card, including broken-link (or the neutral
     # unverifiable-link, when the check reached no verdict) if needed.
     def link_card_css(link, links_checklist)
@@ -79,6 +95,15 @@ module Lexicon
     end
 
     private
+
+    # Opens the match modal for a plaintext citation author, reloading the page on confirmation so
+    # the card re-renders the author as a link to the entry it was just matched to.
+    def citation_author_match_button(author)
+      button_tag t('lexicon.citation_authors.match.title'),
+                 type: 'button',
+                 class: 'btn btn-sm btn-outline-primary py-0 px-1 match-citation-author',
+                 onclick: "openModal('#{match_lexicon_citation_author_path(author)}', function() { reloadPage(); })"
+    end
 
     # Diffy emits a trailing empty <li> when one side has more lines than the
     # other; drop any list item with no visible text so empty rows don't render.

--- a/app/models/lex_citation_author.rb
+++ b/app/models/lex_citation_author.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# One author of a LexCitation: either a reference to the person's own lexicon entry, or the
+# plaintext name the legacy PHP file carried when no entry could be resolved for it.
 class LexCitationAuthor < ApplicationRecord
   belongs_to :citation, class_name: 'LexCitation', inverse_of: :authors, foreign_key: 'lex_citation_id'
   belongs_to :entry, optional: true, class_name: 'LexEntry', foreign_key: 'lex_entry_id'
@@ -11,6 +13,35 @@ class LexCitationAuthor < ApplicationRecord
 
   def display_name
     name.presence || entry&.title
+  end
+
+  # The name to look an existing entry up by (see .normalize_name).
+  def normalized_name
+    self.class.normalize_name(name)
+  end
+
+  # Legacy PHP files write citation authors as "lastname, firstname", which is never how a lexicon
+  # entry is titled, so the surname is moved to the end and the comma dropped before looking the
+  # name up. Names without a comma are returned as they stand.
+  def self.normalize_name(name)
+    return nil if name.blank?
+
+    surname, given = name.split(',', 2)
+    return surname.squish if given.blank?
+
+    "#{given} #{surname}".squish
+  end
+
+  # The normalized names (downcased) of those among `authors` that are not linked to an entry yet
+  # and for which at least one person-type LexEntry is titled exactly that. Resolved in a single
+  # query, so a citation-heavy verification page costs one lookup rather than one per author.
+  def self.matchable_names(authors)
+    names = authors.reject { |author| author.entry.present? }
+                   .filter_map(&:normalized_name)
+                   .uniq
+    return Set.new if names.empty?
+
+    LexEntry.person_type.where(title: names).pluck(:title).to_set(&:downcase)
   end
 
   private

--- a/app/models/lex_citation_author.rb
+++ b/app/models/lex_citation_author.rb
@@ -35,8 +35,10 @@ class LexCitationAuthor < ApplicationRecord
   # The normalized names (downcased) of those among `authors` that are not linked to an entry yet
   # and for which at least one person-type LexEntry is titled exactly that. Resolved in a single
   # query, so a citation-heavy verification page costs one lookup rather than one per author.
+  # Linked authors are recognised by their foreign key rather than by #entry, so the count stays
+  # one whether or not the caller preloaded the association.
   def self.matchable_names(authors)
-    names = authors.reject { |author| author.entry.present? }
+    names = authors.select { |author| author.lex_entry_id.nil? }
                    .filter_map(&:normalized_name)
                    .uniq
     return Set.new if names.empty?

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -53,6 +53,14 @@ class LexEntry < ApplicationRecord
   # reachable via internal links from another entry.
   scope :main, -> { where(main: true) }
 
+  # SQL counterpart of `#entry_type == :person`: entries backed by a LexPerson item, plus entries
+  # not migrated yet whose legacy file is a person file.
+  scope :person_type, lambda {
+    left_joins(:lex_file)
+      .where(lex_item_type: 'LexPerson')
+      .or(LexEntry.left_joins(:lex_file).where(lex_files: { entrytype: LexFile.entrytypes[:person] }))
+  }
+
   update_index('lex_entries') { self }
   update_index('lex_entries_autocomplete') { self }
 

--- a/app/views/lexicon/citation_authors/match.html.haml
+++ b/app/views/lexicon/citation_authors/match.html.haml
@@ -1,0 +1,25 @@
+%h1= t('.title')
+%p.text-muted
+  = t('.imported_name')
+  %strong{ dir: text_dir(@author.name.to_s) }= @author.name
+= simple_form_for @author, url: lexicon_citation_author_path(@author), method: :patch, remote: true do |f|
+  = f.hidden_field :lex_entry_id
+  = f.input :name,
+            label: t('.entry_label'),
+            id_element: '#lex_citation_author_lex_entry_id',
+            url: autocomplete_lexicon_entries_path(entry_type: :person),
+            input_html: { value: @author.normalized_name },
+            as: :autocomplete
+  -# display validation errors for :entry and :lex_entry_id together since they are related
+  .text-danger
+    = f.error :entry
+    = f.error :lex_entry_id
+  %p.text-muted.small= t('.name_kept_notice')
+  = f.submit t('.confirm'), class: 'btn btn-primary'
+  %button.btn.btn-secondary.ms-1{ type: 'button', onclick: 'closeModal();' }= t(:cancel)
+-# fix to make autocomplete menu the same width as the input field (Consider moving this layout js?)
+:javascript
+  $.ui.autocomplete.prototype._resizeMenu = function () {
+    const ul = this.menu.element;
+    ul.outerWidth(this.element.outerWidth());
+  }

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -210,7 +210,7 @@
     - all_citations = item.citations.includes(authors: :entry)
     - cit_size = all_citations.size
     -# Resolved once for the whole section: which plaintext authors have an existing person entry
-    -# to offer a match against (see LexCitationAuthor.matchable_names).
+      to offer a match against (see LexCitationAuthor.matchable_names).
     - matchable_author_names = LexCitationAuthor.matchable_names(all_citations.flat_map(&:authors))
     - if php_counts[:citations] && php_counts[:citations] != cit_size
       .alert.alert-warning.alert-dismissible.fade.show.count-mismatch-warning{role: 'alert'}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -209,6 +209,9 @@
   .section-content
     - all_citations = item.citations.includes(authors: :entry)
     - cit_size = all_citations.size
+    -# Resolved once for the whole section: which plaintext authors have an existing person entry
+    -# to offer a match against (see LexCitationAuthor.matchable_names).
+    - matchable_author_names = LexCitationAuthor.matchable_names(all_citations.flat_map(&:authors))
     - if php_counts[:citations] && php_counts[:citations] != cit_size
       .alert.alert-warning.alert-dismissible.fade.show.count-mismatch-warning{role: 'alert'}
         = t('lexicon.verification.sections.count_mismatch', php_count: php_counts[:citations], migrated_count: cit_size)
@@ -226,7 +229,7 @@
                   %br
                   %span.text-muted
                     #{citation.authors.count > 1 ? t(:authors) : t(:author)}:
-                    = safe_join(citation.authors.map { |a| a.entry ? link_to(a.display_name, lexicon_entry_path(a.entry)) : a.display_name }, ', ')
+                    = citation_authors_for_verification(citation, matchable_author_names)
                 - if citation.from_publication.present?
                   %br
                   %span.text-muted

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -66,6 +66,8 @@ en:
               link_with_entry_error: link can only be specified if we don't have a Lexicon entry for author
             entry:
               not_a_person: must be a Person entry
+            lex_entry_id:
+              entry_not_found: please pick an existing entry from the suggestion list
         lex_linked_person:
           attributes:
             person_entry:

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -70,6 +70,8 @@ he:
               link_with_entry_error: לא ניתן לציין קישור כאשר קיים ערך לקסיקון עבור המחבר
             entry:
               not_a_person: הערך חייב להיות ערך מסוג אדם
+            lex_entry_id:
+              entry_not_found: נא לבחור ערך קיים מתוך רשימת ההשלמה
         lex_linked_person:
           attributes:
             person_entry:

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -113,6 +113,12 @@ en:
     citation_authors:
       form:
         add_author: Add author
+      match:
+        title: Match to an existing entry
+        imported_name: 'Name as imported:'
+        entry_label: Lexicon entry (person)
+        name_kept_notice: The imported name is kept as-is; only the link to the entry is added.
+        confirm: Confirm match
     citations:
       header:
         subject_line: About "%{subject}"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -114,6 +114,12 @@ he:
     citation_authors:
       form:
         add_author: הוספת יוצר/ת
+      match:
+        title: התאמה לערך קיים
+        imported_name: 'השם כפי שיובא:'
+        entry_label: ערך לקסיקון (אדם)
+        name_kept_notice: השם המיובא יישמר כלשונו; רק הקישור לערך יתווסף.
+        confirm: אישור ההתאמה
     citations:
       header:
         subject_line: על ״%{subject}״

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,11 @@ Bybeconv::Application.routes.draw do
       end
     end
 
-    resources :citation_authors, only: %i(update destroy)
+    resources :citation_authors, only: %i(update destroy) do
+      member do
+        get :match
+      end
+    end
     resources :linked_people, only: %i(destroy) do
       member do
         post :reorder

--- a/spec/models/lex_citation_author_spec.rb
+++ b/spec/models/lex_citation_author_spec.rb
@@ -168,6 +168,22 @@ describe LexCitationAuthor do
       end
     end
 
+    context 'when the authors were loaded without preloading their entries' do
+      let(:linked_entry) { create(:lex_entry, :person, title: 'חיים נחמן ביאליק') }
+      let(:authors) { LexCitationAuthor.where(lex_citation_id: citation.id).to_a }
+
+      before do
+        create(:lex_entry, :person, title: 'גילי איזיקוביץ')
+        author_named('איזיקוביץ, גילי')
+        create(:lex_citation_author, citation: citation, entry: linked_entry, name: 'ביאליק, חיים נחמן', link: nil)
+      end
+
+      it 'recognises the linked author by its foreign key, without loading the association' do
+        expect(matches).to contain_exactly('גילי איזיקוביץ')
+        expect(authors.map { |author| author.association(:entry).loaded? }).to all(be false)
+      end
+    end
+
     context 'with several authors' do
       before do
         create(:lex_entry, :person, title: 'גילי איזיקוביץ')

--- a/spec/models/lex_citation_author_spec.rb
+++ b/spec/models/lex_citation_author_spec.rb
@@ -76,4 +76,121 @@ describe LexCitationAuthor do
       end
     end
   end
+
+  describe '.normalize_name' do
+    subject { described_class.normalize_name(name) }
+
+    context 'when the name is in "lastname, firstname" form' do
+      let(:name) { 'איזיקוביץ, גילי' }
+
+      it { is_expected.to eq('גילי איזיקוביץ') }
+    end
+
+    context 'when the surname is followed by several given names' do
+      let(:name) { 'ביאליק, חיים נחמן' }
+
+      it { is_expected.to eq('חיים נחמן ביאליק') }
+    end
+
+    context 'when the name has no comma' do
+      let(:name) { 'מירה הרשקו' }
+
+      it { is_expected.to eq('מירה הרשקו') }
+    end
+
+    context 'when the name has a trailing comma and nothing after it' do
+      let(:name) { 'ביאליק,' }
+
+      it { is_expected.to eq('ביאליק') }
+    end
+
+    context 'when the name carries stray whitespace' do
+      let(:name) { "  איזיקוביץ,\n גילי  " }
+
+      it { is_expected.to eq('גילי איזיקוביץ') }
+    end
+
+    context 'when the name is blank' do
+      let(:name) { '' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.matchable_names' do
+    subject(:matches) { described_class.matchable_names(authors) }
+
+    let(:lex_person) { create(:lex_entry, :person).lex_item }
+    let(:citation) { create(:lex_citation, person: lex_person, authors_count: 0) }
+
+    def author_named(name)
+      create(:lex_citation_author, citation: citation, name: name, link: nil)
+    end
+
+    context 'when a person entry is titled exactly like the normalized name' do
+      before { create(:lex_entry, :person, title: 'גילי איזיקוביץ') }
+
+      let(:authors) { [author_named('איזיקוביץ, גילי')] }
+
+      it { is_expected.to contain_exactly('גילי איזיקוביץ') }
+    end
+
+    context 'when the only entry with that title is a publication' do
+      before { create(:lex_entry, :publication, title: 'גילי איזיקוביץ') }
+
+      let(:authors) { [author_named('איזיקוביץ, גילי')] }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the entry is a not-yet-migrated person file' do
+      before { create(:lex_file, :person, entry_status: :raw, title: 'גילי איזיקוביץ') }
+
+      let(:authors) { [author_named('איזיקוביץ, גילי')] }
+
+      it { is_expected.to contain_exactly('גילי איזיקוביץ') }
+    end
+
+    context 'when no entry carries that title' do
+      let(:authors) { [author_named('איזיקוביץ, גילי')] }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the author is already linked to an entry' do
+      let(:entry) { create(:lex_entry, :person, title: 'גילי איזיקוביץ') }
+      let(:authors) do
+        [create(:lex_citation_author, citation: citation, entry: entry, name: 'איזיקוביץ, גילי', link: nil)]
+      end
+
+      it 'does not offer a match for it' do
+        expect(matches).to be_empty
+      end
+    end
+
+    context 'with several authors' do
+      before do
+        create(:lex_entry, :person, title: 'גילי איזיקוביץ')
+        create(:lex_entry, :person, title: 'חיים נחמן ביאליק')
+      end
+
+      let(:authors) do
+        [author_named('איזיקוביץ, גילי'), author_named('ביאליק, חיים נחמן'), author_named('לא, קיים')]
+      end
+
+      it 'reports only the names an entry exists for' do
+        expect(matches).to contain_exactly('גילי איזיקוביץ', 'חיים נחמן ביאליק')
+      end
+    end
+
+    context 'with no authors at all' do
+      let(:authors) { [] }
+
+      it 'returns an empty set without hitting the database' do
+        allow(LexEntry).to receive(:person_type)
+        expect(matches).to be_empty
+        expect(LexEntry).not_to have_received(:person_type)
+      end
+    end
+  end
 end

--- a/spec/requests/lexicon/citation_authors_spec.rb
+++ b/spec/requests/lexicon/citation_authors_spec.rb
@@ -60,6 +60,75 @@ describe '/lexicon/citation_authors' do
     end
   end
 
+  describe 'GET /lexicon/citation_authors/:id/match' do
+    subject(:call) { get "/lex/citation_authors/#{author.id}/match" }
+
+    let!(:citation) { create(:lex_citation, person: person, authors_count: 0) }
+    let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+
+    it 'renders the match modal pre-filled with the normalized name' do
+      expect(call).to eq(200)
+      expect(response.body).to include('גילי איזיקוביץ')
+    end
+  end
+
+  describe 'PATCH /lexicon/citation_authors/:id' do
+    subject(:call) do
+      patch "/lex/citation_authors/#{author.id}",
+            params: { lex_citation_author: { name: 'גילי איזיקוביץ', lex_entry_id: entry_id } },
+            xhr: true
+    end
+
+    let!(:citation) { create(:lex_citation, person: person, authors_count: 0) }
+    let(:matched_entry) { create(:lex_entry, :person, title: 'גילי איזיקוביץ') }
+    let(:entry_id) { matched_entry.id }
+
+    context 'with a plaintext author' do
+      let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+
+      it 'links the entry without rewriting the imported name' do
+        expect(call).to eq(200)
+        expect(author.reload.entry).to eq(matched_entry)
+        expect(author.name).to eq('איזיקוביץ, גילי')
+        expect(author.display_name).to eq('איזיקוביץ, גילי')
+      end
+    end
+
+    context 'when the author still carries a legacy link' do
+      let!(:author) do
+        create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: 'http://example.com/gili')
+      end
+
+      it 'drops the link, which may not coexist with an entry' do
+        expect(call).to eq(200)
+        expect(author.reload.entry).to eq(matched_entry)
+        expect(author.link).to be_nil
+        expect(author.name).to eq('איזיקוביץ, גילי')
+      end
+    end
+
+    context 'when no entry was selected in the autocomplete' do
+      let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+      let(:entry_id) { '' }
+
+      it 're-renders the modal and leaves the author untouched' do
+        expect(call).to eq(422)
+        expect(author.reload.entry).to be_nil
+        expect(author.name).to eq('איזיקוביץ, גילי')
+      end
+    end
+
+    context 'when the selected entry is not a person' do
+      let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+      let(:matched_entry) { create(:lex_entry, :publication, title: 'גילי איזיקוביץ') }
+
+      it 're-renders the modal and leaves the author untouched' do
+        expect(call).to eq(422)
+        expect(author.reload.entry).to be_nil
+      end
+    end
+  end
+
   describe 'DELETE /lexicon/citation_authors/:id' do
     subject(:call) { delete "/lex/citation_authors/#{author.id}", xhr: true }
 

--- a/spec/requests/lexicon/citation_authors_spec.rb
+++ b/spec/requests/lexicon/citation_authors_spec.rb
@@ -118,6 +118,19 @@ describe '/lexicon/citation_authors' do
       end
     end
 
+    # The autocomplete index is only pruned when a destroy runs through the model, so it can still
+    # offer an entry whose row is gone. Picking one must not reach the lex_entries foreign key.
+    context 'when the selected entry no longer exists' do
+      let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+      let(:entry_id) { matched_entry.id.tap { matched_entry.destroy! } }
+
+      it 're-renders the modal instead of failing on the foreign key' do
+        expect(call).to eq(422)
+        expect(author.reload.entry).to be_nil
+        expect(author.name).to eq('איזיקוביץ, גילי')
+      end
+    end
+
     context 'when the selected entry is not a person' do
       let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
       let(:matched_entry) { create(:lex_entry, :publication, title: 'גילי איזיקוביץ') }

--- a/spec/requests/lexicon/citation_authors_spec.rb
+++ b/spec/requests/lexicon/citation_authors_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe '/lexicon/citation_authors' do
+describe '/lex/citation_authors' do
   before do
     login_as_lexicon_editor
   end
@@ -13,13 +13,13 @@ describe '/lexicon/citation_authors' do
 
   let(:invalid_attrs) { { name: '' } }
 
-  describe 'GET /lexicon/citations/:citation_id/authors' do
+  describe 'GET /lex/citations/:citation_id/authors' do
     subject { get "/lex/citations/#{citation.id}/authors" }
 
     it { is_expected.to eq(200) }
   end
 
-  describe 'POST /lexicon/citations/:citation_id/authors' do
+  describe 'POST /lex/citations/:citation_id/authors' do
     subject(:call) { post "/lex/citations/#{citation.id}/authors", params: { lex_citation_author: attrs }, xhr: true }
 
     context 'with valid params' do
@@ -60,7 +60,7 @@ describe '/lexicon/citation_authors' do
     end
   end
 
-  describe 'GET /lexicon/citation_authors/:id/match' do
+  describe 'GET /lex/citation_authors/:id/match' do
     subject(:call) { get "/lex/citation_authors/#{author.id}/match" }
 
     let!(:citation) { create(:lex_citation, person: person, authors_count: 0) }
@@ -72,7 +72,7 @@ describe '/lexicon/citation_authors' do
     end
   end
 
-  describe 'PATCH /lexicon/citation_authors/:id' do
+  describe 'PATCH /lex/citation_authors/:id' do
     subject(:call) do
       patch "/lex/citation_authors/#{author.id}",
             params: { lex_citation_author: { name: 'גילי איזיקוביץ', lex_entry_id: entry_id } },
@@ -142,7 +142,7 @@ describe '/lexicon/citation_authors' do
     end
   end
 
-  describe 'DELETE /lexicon/citation_authors/:id' do
+  describe 'DELETE /lex/citation_authors/:id' do
     subject(:call) { delete "/lex/citation_authors/#{author.id}", xhr: true }
 
     it 'destroys the requested author' do

--- a/spec/system/lexicon/verification_citation_author_match_spec.rb
+++ b/spec/system/lexicon/verification_citation_author_match_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Matching an imported citation author to an existing entry', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  # Chewy indices are not rolled back with the database, so entries imported for the autocomplete
+  # would otherwise pile up across examples and turn one expected suggestion into several.
+  after { Chewy.massacre }
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+  let!(:citation) { create(:lex_citation, person: person, title: 'מאמר על המשוררת', authors_count: 0) }
+  # Imported from the legacy PHP file as "lastname, firstname", which is never how an entry is titled
+  let!(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+
+  let(:match_button_label) { I18n.t('lexicon.citation_authors.match.title') }
+
+  context 'when a person entry is titled like the normalized name' do
+    let!(:matching_entry) { create(:lex_entry, :person, title: 'גילי איזיקוביץ') }
+
+    before { import_and_await(LexEntriesAutocompleteIndex, [matching_entry]) }
+
+    it 'offers the match button next to the plaintext author' do
+      visit lexicon_verification_path(entry)
+
+      within("#citation-#{citation.id}") do
+        expect(page).to have_content('איזיקוביץ, גילי')
+        expect(page).to have_button(match_button_label)
+      end
+    end
+
+    it 'links the author to the chosen entry while keeping the imported name' do
+      visit lexicon_verification_path(entry)
+
+      within("#citation-#{citation.id}") { click_button match_button_label }
+      expect(page).to have_css('#generalDlg', visible: :visible)
+
+      # The modal opens pre-filled with the processed name the match was found by
+      expect(page).to have_field('lex_citation_author_name', with: 'גילי איזיקוביץ')
+
+      fill_in 'lex_citation_author_name', with: 'גילי'
+      expect(page).to have_css('ul.ui-autocomplete li', text: matching_entry.title, wait: 5)
+      find('ul.ui-autocomplete li', text: matching_entry.title).click
+
+      click_button I18n.t('lexicon.citation_authors.match.confirm')
+
+      # The page reloads on success, and the author now renders as a link to the entry --
+      # still labelled with the name exactly as the legacy file had it.
+      within("#citation-#{citation.id}") do
+        expect(page).to have_link('איזיקוביץ, גילי', href: lexicon_entry_path(matching_entry), wait: 8)
+        expect(page).to have_no_button(match_button_label)
+      end
+
+      expect(author.reload.entry).to eq(matching_entry)
+      expect(author.name).to eq('איזיקוביץ, גילי')
+    end
+
+    it 'leaves the author alone when the modal is closed without confirming' do
+      visit lexicon_verification_path(entry)
+
+      within("#citation-#{citation.id}") { click_button match_button_label }
+      expect(page).to have_css('#generalDlg', visible: :visible)
+
+      click_button I18n.t(:cancel)
+
+      expect(page).to have_css('#generalDlg', visible: :hidden)
+      expect(author.reload.entry).to be_nil
+      expect(author.name).to eq('איזיקוביץ, גילי')
+    end
+  end
+
+  context 'when no person entry carries that name' do
+    it 'does not offer the match button' do
+      visit lexicon_verification_path(entry)
+
+      within("#citation-#{citation.id}") do
+        expect(page).to have_content('איזיקוביץ, גילי')
+        expect(page).to have_no_button(match_button_label)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Legacy PHP ingestion writes citation authors as `"lastname, firstname"`. `Lexicon::ParseCitations#update_link` can only auto-link the ones whose legacy `link` already pointed at `/lex/entries/<id>`; the rest stay as plaintext even when the person already has a lexicon entry.

On the verification card, a plaintext author now gets a **"התאמה לערך קיים"** button whenever a person entry is titled exactly like its normalized name. The button opens a modal with a person-filtered autocomplete pre-filled with that name. Confirming links the entry; closing the modal changes nothing.

**The imported name is preserved verbatim.** `#update` permits only `lex_entry_id`, so the citation keeps displaying `"איזיקוביץ, גילי"` exactly as the legacy file had it — now as a link to the entry.

## How

| | |
|---|---|
| `LexCitationAuthor.normalize_name` | splits on the first comma, moves the surname to the end: `"איזיקוביץ, גילי"` → `"גילי איזיקוביץ"`. Names without a comma pass through. |
| `LexCitationAuthor.matchable_names` | one batched query for the whole section, so a citation-heavy page costs one lookup rather than one per author. Already-linked authors are skipped. |
| `LexEntry.person_type` | SQL counterpart of `#entry_type == :person` (`lex_item_type = 'LexPerson'` OR the legacy file's `entrytype = person`), so not-yet-migrated person entries are matchable too. |
| `Lexicon::VerificationHelper#citation_authors_for_verification` | replaces the inline `safe_join` in `_person_sections.html.haml`. |
| `GET /lex/citation_authors/:id/match` | renders the modal. |
| `PATCH /lex/citation_authors/:id` | this route already existed but **had no action**; it is implemented here. |

Two design points worth a reviewer's eye:

- **Matching is exact** on the normalized name. Deliberate: it keeps the query batchable and means the button never lies. The cost is that variants like `"ביאליק, ח.נ."` show no button — the verifier can still link those through the existing citation edit modal.
- **A leftover `link` is dropped on confirm.** `LexCitationAuthor` validates `link` *absence* when `entry` is present, so an author that kept a non-lex legacy link could not otherwise be matched. This mirrors what `ParseCitations#update_link` already does when it links an author at ingest time.

Free-typed text with no autocomplete selection re-renders the modal at 422 rather than silently unlinking (the autocomplete clears its hidden id field as soon as you edit the text).

## Scope

Verification card only, as specified. The citation edit modal's author list and the public entry page are untouched.

## Test plan

New coverage:

- `spec/models/lex_citation_author_spec.rb` — 16 examples over `.normalize_name` (comma forms, multiple given names, trailing comma, stray whitespace, blank) and `.matchable_names` (person entry, publication entry rejected, not-yet-migrated person file accepted, no match, already-linked author skipped).
- `spec/requests/lexicon/citation_authors_spec.rb` — 6 examples: modal pre-fill, the happy path asserting `name` is unchanged, the leftover-link case, blank selection → 422, non-person entry → 422.
- `spec/system/lexicon/verification_citation_author_match_spec.rb` — drives a real browser end to end: button visibility (present with a match, absent without), button → modal → autocomplete → confirm asserting the author renders as a link *still labelled* `"איזיקוביץ, גילי"`, and close-without-confirming leaving the record alone.

Ran locally — **382 examples, 0 failures**:

```
spec/models/lex_citation_author_spec.rb  spec/models/lex_entry_spec.rb
spec/models/lex_citation_spec.rb         spec/requests/lexicon/citation_authors_spec.rb
spec/requests/lexicon/citations_spec.rb  spec/services/lexicon/parse_citations_spec.rb
spec/helpers                             spec/system/lexicon/verification_citation_*
spec/system/lexicon/citation_text_links_spec.rb
spec/system/author_lex_citations_spec.rb
```

RuboCop and haml-lint clean on every file touched.

**The full suite was not run** (40+ min) — leaving that to CI.

## Note for the reviewer

This dev database has only one `LexCitationAuthor` row, so the feature is verified against fixtures rather than real migrated data. Worth a spot-check on the first real batch of migrated citations.

Closes by-wyw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
