### PR TITLE
Index LexEntry bios as plain text rather than HTML

### DIFF
--- a/app/services/lexicon/lex_person_content.rb
+++ b/app/services/lexicon/lex_person_content.rb
@@ -4,15 +4,30 @@ module Lexicon
   # This service generates single Markdown content from given LexPerson object.
   # This content to be indexed by ElasticSearch.
   class LexPersonContent < ApplicationService
+    include BybeUtils
+
+    # Block-level tags whose boundaries are word boundaries. strip_tags drops tags without
+    # leaving any whitespace behind, so without this the words on either side of a </td> or
+    # a <br> would be fused into a single unsearchable token.
+    BLOCK_BOUNDARY_RE = %r{<br\s*/?>|</?\s*(?:p|div|li|ul|ol|tr|td|th|table|h[1-6]|blockquote)\b[^>]*>}i
+
     def call(lex_person)
       "# #{lex_person.entry.title} - #{lex_person.life_years}\n" \
         "## #{lex_person.aliases}\n\n" \
-        "#{lex_person.bio}\n\n" \
+        "#{bio_text(lex_person)}\n\n" \
         "#{person_works_text(lex_person)}\n\n" \
         "#{citations_text(lex_person)}"
     end
 
     private
+
+    # The bio is stored as HTML. We index its plain text, so that search-result snippets
+    # carry no markup (images in particular) into the results view.
+    def bio_text(lex_person)
+      return '' if lex_person.bio.blank?
+
+      html2txt(lex_person.bio.gsub(BLOCK_BOUNDARY_RE, "\n"))
+    end
 
     def person_works_text(lex_person)
       lex_person.works.map do |work|

--- a/db/migrate/20260829090000_re_index_lex_entries.rb
+++ b/db/migrate/20260829090000_re_index_lex_entries.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# LexEntry bios were indexed as raw HTML; they are now indexed as plain text,
+# so the existing documents have to be rebuilt.
+class ReIndexLexEntries < ActiveRecord::Migration[8.0]
+  def change
+    say 'Reindexing Lexicon Entries...'
+    LexEntriesIndex.reset!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_29_090000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"

--- a/spec/chewy/lex_entries_index_spec.rb
+++ b/spec/chewy/lex_entries_index_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LexEntriesIndex do
+  let(:lex_entry) { create(:lex_entry, :person, status: :published, title: 'Test Lexicon Entry') }
+
+  before do
+    clean_tables
+    lex_entry.lex_item.update!(
+      bio: '<img src="/files/lex/1/photo.jpg" width="200" /><span>נולד בוורשה</span><br />ועלה לארץ'
+    )
+    import_and_await(described_class, LexEntry.status_published)
+  end
+
+  after { Chewy.massacre }
+
+  it 'indexes the bio as plain text rather than HTML' do
+    fulltext = described_class.filter(term: { id: lex_entry.id }).first.fulltext
+
+    expect(fulltext).to include('נולד בוורשה')
+    expect(fulltext).to include('ועלה לארץ')
+    expect(fulltext).not_to include('<img')
+    expect(fulltext).not_to include('photo.jpg')
+    expect(fulltext).not_to include('<span>')
+  end
+end

--- a/spec/services/lexicon/lex_person_content_spec.rb
+++ b/spec/services/lexicon/lex_person_content_spec.rb
@@ -19,6 +19,52 @@ describe Lexicon::LexPersonContent do
     expect(result).to be_present
   end
 
+  context 'when the bio contains HTML' do
+    let(:lex_person) do
+      create(:lex_entry, :person).lex_item.tap do |person|
+        person.birthdate = '1890'
+        person.deathdate = '1955'
+        person.bio = '<img src="/files/lex/1/photo.jpg" width="200" />' \
+                     '<span>נולד בוורשה</span><br />ועלה לארץ &amp; התיישב בה' \
+                     '<table><tbody><tr><td>ראשון</td><td>שני</td></tr></tbody></table>'
+        person.save!
+      end
+    end
+
+    it 'indexes the plain text of the bio, without markup' do
+      expect(result).to include('נולד בוורשה')
+      expect(result).not_to include('<img')
+      expect(result).not_to include('photo.jpg')
+      expect(result).not_to include('<span>')
+    end
+
+    it 'decodes HTML entities' do
+      expect(result).to include('ועלה לארץ & התיישב בה')
+    end
+
+    it 'does not fuse words across block-level tag boundaries' do
+      expect(result).to include('ראשון')
+      expect(result).to include('שני')
+      expect(result).not_to include('ראשוןשני')
+      expect(result).not_to include('בוורשהועלה')
+    end
+  end
+
+  context 'when the bio is blank' do
+    let(:lex_person) do
+      create(:lex_entry, :person).lex_item.tap do |person|
+        person.birthdate = '1890'
+        person.deathdate = '1955'
+        person.bio = nil
+        person.save!
+      end
+    end
+
+    it 'completes successfully' do
+      expect(result).to be_present
+    end
+  end
+
   context 'when a work is linked to a lex_publication' do
     let(:publication_entry) { create(:lex_entry, title: 'פרסום ייחודי', lex_item: create(:lex_publication)) }
 


### PR DESCRIPTION
## Problem

`LexEntriesIndex` indexes a lexicon entry's `fulltext` via `Lexicon::LexPersonContent`, which
interpolated `lex_person.bio` — stored as HTML — verbatim. The search results view renders the
ES highlight with `!=` (unescaped), so lexicon results emitted raw markup, `<img>` tags included.

## Change

- `Lexicon::LexPersonContent` now runs the bio through `html2txt` (the same helper `DictIndex`
  uses for `deftext`).
- `html2txt` is `strip_tags` + entity decoding, and `strip_tags` removes tags **without** leaving
  whitespace behind: `"aaa<p>bbb</p>"` → `"aaabbb"`. Live bios contain `<td>`, `<tr>` and `<br>`
  (verified against the dev DB), so block-level boundaries are normalized to newlines first —
  otherwise the words on either side fuse into a single unsearchable token.
- Adds `ReIndexLexEntries`, which calls `LexEntriesIndex.reset!` so existing production documents
  are rebuilt with the new field value. Follows the precedent of `ReIndexAuthorities`.

## Test plan

New coverage:

- `spec/services/lexicon/lex_person_content_spec.rb` — bio markup is stripped (no `<img>`, no
  `<span>`, no image filename), entities are decoded, words are not fused across block boundaries,
  and a blank bio still produces content.
- `spec/chewy/lex_entries_index_spec.rb` — end-to-end: imports into ES and asserts the stored
  `fulltext` carries the bio's text but none of its markup.

Ran:

```
bundle exec rspec spec/services/lexicon/lex_person_content_spec.rb spec/chewy/lex_entries_index_spec.rb
# 7 examples, 0 failures
bundle exec rspec spec/controllers/search_controller_spec.rb spec/lib/bybe_utils_spec.rb
# 86 examples, 0 failures
```

RuboCop clean on all four touched files. **The full suite was not run** (40+ min, needs approval).

Closes by-6nb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
