### PR TITLE
Hide the TOC action bar once the reader is into the lexicon block

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1523,6 +1523,9 @@ p.by-genre-name-v02.headline-2-v02 {
 .sticky-fold {
 	flex-wrap: wrap;
 
+	/* for the fade in/out of .sticky-fold-away, below */
+	transition: opacity 0.2s ease, visibility 0.2s ease;
+
 	/* The sort label + <select> share a <p>; both need to be shrinkable, or the
 	 * select's widest option sets an un-shrinkable min-content width. */
 	p {
@@ -1547,6 +1550,16 @@ p.by-genre-name-v02.headline-2-v02 {
 		.toc-flat-action {
 			display: flex;
 		}
+	}
+
+	/* Out of the way once the reader has scrolled into the lexicon block, whose
+	 * content none of the bar's actions apply to. Set by the scroll handler in
+	 * authors/toc. visibility, not display: the bar's box sits in the flow above
+	 * the works list, so removing it would shift the whole page under the reader
+	 * while the bar itself is stuck far below its own place in the flow. */
+	&.sticky-fold-away {
+		visibility: hidden;
+		opacity: 0;
 	}
 }
 

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -377,6 +377,33 @@
         $('.sticky-fold').toggleClass('flat-mode', flat);
       };
 
+      // The action bar acts on the works list, and (for authors with a lexicon
+      // entry) the lexicon block sits below that list. Once the reader is into
+      // the lexicon -- its first card past the middle of the viewport -- the bar
+      // has nothing on screen left to act on, so it gets out of the way, and
+      // comes back when the reader scrolls up to the works again.
+      // The card is looked up on each check rather than held on to: a re-sort
+      // rebuilds #browse_mainlist, replacing the lexicon block or (in the flat
+      // sorts) dropping it entirely, in which case the bar simply stays put.
+      function syncStickyFoldForLexicon() {
+        var card = document.querySelector('.peach2-lexicon .by-card-v02');
+        var in_lexicon = card !== null &&
+                         card.getBoundingClientRect().top < window.innerHeight / 2;
+        $('.sticky-fold').toggleClass('sticky-fold-away', in_lexicon);
+      }
+      // Coalesced into a frame: the check reads layout, and the author page of a
+      // prolific author is a very long scroll.
+      var stickyFoldPending = false;
+      $(window).on('scroll resize', function() {
+        if (stickyFoldPending) { return; }
+        stickyFoldPending = true;
+        window.requestAnimationFrame(function() {
+          stickyFoldPending = false;
+          syncStickyFoldForLexicon();
+        });
+      });
+      syncStickyFoldForLexicon();
+
       // The Collapse all / Expand all buttons reflect the list's current state:
       // whichever action would still change something is the primary (filled)
       // button, and the one that would be a no-op is greyed out and disabled.

--- a/spec/requests/author_toc_lexicon_content_spec.rb
+++ b/spec/requests/author_toc_lexicon_content_spec.rb
@@ -154,7 +154,10 @@ RSpec.describe 'Authority TOC lexicon content', type: :request do
       # not part of the lexicon block and stays
       it 'drops the lexicon heading and the whole navbar group' do
         call
-        expect(response.body).not_to include('peach2-lexicon')
+        # parsed rather than substring-matched: the page's inline script names .peach2-lexicon in
+        # a selector (the sticky TOC bar steps aside once the reader is into the lexicon block),
+        # so only the rendered DOM can say whether the block itself is on the page
+        expect(Nokogiri::HTML(response.body).css('.peach2-lexicon')).to be_empty
         expect(response.body).not_to include('lexicon-background-color')
         expect(response.body).not_to include('id="lexicon-bio"')
       end

--- a/spec/system/author_toc_lexicon_sticky_bar_spec.rb
+++ b/spec/system/author_toc_lexicon_sticky_bar_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Authority TOC's sticky action bar (collapse/expand, sort) acts on the works
+# list. For an authority with a published lexicon entry the lexicon block sits
+# below that list, and once the reader has scrolled into it the bar is left
+# hovering over content none of its actions apply to -- so it gets out of the way,
+# and comes back on the way up.
+describe 'Authority TOC sticky bar over the lexicon block', :js do
+  # Lazy `let` (not `let!`) so the WebDriver skip in the before hook can
+  # short-circuit without running the DB + Chewy setup when Chrome is unavailable.
+  let(:author) { create(:authority, name: 'Lexicon Author') }
+  let(:volume) { create(:collection, title: 'A Volume', collection_type: :volume) }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    poem = Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Alpha Poem', status: :published, author: author, orig_lang: 'he',
+                             markdown: 'The opening line of the Alpha poem.')
+    end
+    create(:collection_item, collection: volume, item: poem)
+    create(:involved_authority, authority: author, item: volume, role: 'editor')
+  end
+
+  after { Chewy.massacre }
+
+  def add_lexicon_entry
+    person = create(:lex_person, authority: author, bio: 'A lexicon biography of the author.')
+    create(:lex_entry, title: author.name, lex_item: person, status: :published)
+  end
+
+  # Puts the top of the lexicon block's first card at the top of the viewport,
+  # i.e. well past the middle, which is what the bar reacts to.
+  def scroll_to_lexicon
+    page.execute_script("document.querySelector('.peach2-lexicon .by-card-v02').scrollIntoView(true)")
+  end
+
+  it 'hides the bar once the first lexicon card is past mid-viewport, and shows it again above that' do
+    add_lexicon_entry
+    visit authority_path(author)
+
+    expect(page).to have_css('.peach2-lexicon .by-card-v02')
+    expect(page).to have_css('.sticky-fold', visible: :visible)
+
+    scroll_to_lexicon
+
+    expect(page).to have_css('.sticky-fold', visible: :hidden)
+
+    page.execute_script('window.scrollTo(0, 0)')
+
+    expect(page).to have_css('.sticky-fold', visible: :visible)
+  end
+
+  it 'keeps the bar up all the way down an authority page with no lexicon content' do
+    visit authority_path(author)
+
+    expect(page).to have_no_css('.peach2-lexicon')
+    expect(page).to have_css('.sticky-fold', visible: :visible)
+
+    page.execute_script('window.scrollTo(0, document.body.scrollHeight)')
+
+    expect(page).to have_css('.sticky-fold', visible: :visible)
+  end
+end


### PR DESCRIPTION
## What

On the Authority TOC page, the sticky action bar (Collapse all / Expand all, sort) acts on the
works list. For an authority with a published lexicon entry, the lexicon block sits *below* that
list, so a reader who scrolls down into it was left with the bar hovering over content none of its
actions apply to.

The bar now gets out of the way once the **first lexicon card is past mid-viewport vertically**,
and comes back when the reader scrolls back up to the works.

## How

- `app/views/authors/toc.html.haml` — a `scroll`/`resize` handler (coalesced into an animation
  frame) toggles `.sticky-fold-away` when `.peach2-lexicon .by-card-v02`'s top is above
  `innerHeight / 2`. The card is looked up on each check rather than held on to, because a re-sort
  rebuilds `#browse_mainlist`, replacing the lexicon block — or, in the flat sorts, dropping it
  entirely, in which case the bar just stays up.
- `app/assets/stylesheets/application.scss` — `.sticky-fold-away` hides via `visibility`/`opacity`
  (with a short fade), **not** `display`: the bar's box sits in the flow above the works list, so
  removing it would shift the whole page under the reader while the bar itself is stuck far below
  its own place in the flow.

Authorities without lexicon content are unaffected (no `.peach2-lexicon`, so the check is a no-op).

## Test plan

New system spec `spec/system/author_toc_lexicon_sticky_bar_spec.rb`:
- hides the bar after scrolling the first lexicon card to the top of the viewport, and shows it
  again after scrolling back to the top of the page;
- keeps the bar up all the way down an authority page that has no lexicon content.

Verified the first example fails without the toggle (temporarily disabled the class toggle → red).

Specs run:
```
bundle exec rspec spec/system/author_toc_lexicon_sticky_bar_spec.rb            # 2 examples, 0 failures
bundle exec rspec spec/system/author_toc_action_bar_spec.rb \
                  spec/system/author_toc_collapse_buttons_state_spec.rb \
                  spec/system/author_toc_mobile_layout_spec.rb \
                  spec/system/author_toc_colls_abc_spec.rb                     # 17 examples, 0 failures
bundle exec rspec spec/system/author_toc_filters_spec.rb \
                  spec/system/author_toc_mobile_filter_spec.rb                 # 21 examples, 0 failures
```
The full suite (40+ min) was **not** run; per `.claude/rules/full-test-suite-runtime.md` that needs
your approval.

Closes bead by-3bn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
