### PR TITLE
Implement reading mode for collections

### DIFF
--- a/app/assets/javascripts/collection_readmode.js
+++ b/app/assets/javascripts/collection_readmode.js
@@ -1,0 +1,70 @@
+// Collection reading mode (Collection#readmode): scroll progress indicator, ESC to leave, and
+// navigation between the collection's items via the control panel's selector.
+$(document).ready(function() {
+  var readmode = $('#collection-readmode');
+  if (readmode.length === 0) {
+    return;
+  }
+
+  $(window).on('scroll', function() {
+    var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
+    var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    var scrolled = height > 0 ? (winScroll / height) * 100 : 0;
+    if (scrolled > 100) {
+      scrolled = 100;
+    }
+    $('.progress-bar').css('width', scrolled + '%');
+    $('.progress-number').html(Math.ceil(scrolled) + '%');
+    $('.progress-handle').css('right', Math.floor(scrolled) + '%');
+  });
+
+  $(document).on('keyup', function(evt) {
+    if (evt.keyCode === 27) {
+      window.location.href = readmode.data('collection-url');
+    }
+  });
+
+  var selector = $('#collitem');
+  if (selector.length === 0) {
+    return; // single-item collection: no item navigation
+  }
+
+  function scrollToItem(index) {
+    var anchor = $('a[name=collitem_text_' + index + ']');
+    if (anchor.length === 0) {
+      return;
+    }
+    $('html, body').animate({ scrollTop: anchor.offset().top - 20 }, 0);
+  }
+
+  // the last item whose anchor is at or above the current scroll position
+  function currentOption() {
+    var current = selector.find('option').first();
+    selector.find('option').each(function() {
+      var anchor = $('a[name=collitem_text_' + $(this).val() + ']');
+      if (anchor.length > 0 && anchor.offset().top <= $(window).scrollTop() + 25) {
+        current = $(this);
+      }
+    });
+    return current;
+  }
+
+  function goToSibling(sibling, emptyMessage) {
+    if (sibling.length === 0) {
+      alert(emptyMessage);
+      return;
+    }
+    selector.val(sibling.val());
+    scrollToItem(sibling.val());
+  }
+
+  selector.change(function() {
+    scrollToItem($(this).val());
+  });
+  $('#next_collitem').click(function() {
+    goToSibling(currentOption().next(), readmode.data('no-next-item'));
+  });
+  $('#prev_collitem').click(function() {
+    goToSibling(currentOption().prev(), readmode.data('no-prev-item'));
+  });
+});

--- a/app/assets/javascripts/collection_readmode.js
+++ b/app/assets/javascripts/collection_readmode.js
@@ -1,5 +1,5 @@
-// Collection reading mode (Collection#readmode): scroll progress indicator, ESC to leave, and
-// navigation between the collection's items via the control panel's selector.
+// Collection reading mode (Collection#readmode): scroll progress indicator and ESC to leave.
+// Navigation between the collection's items lives in readmode_nav.js, shared with the work page.
 $(document).ready(function() {
   var readmode = $('#collection-readmode');
   if (readmode.length === 0) {
@@ -22,49 +22,5 @@ $(document).ready(function() {
     if (evt.keyCode === 27) {
       window.location.href = readmode.data('collection-url');
     }
-  });
-
-  var selector = $('#collitem');
-  if (selector.length === 0) {
-    return; // single-item collection: no item navigation
-  }
-
-  function scrollToItem(index) {
-    var anchor = $('a[name=collitem_text_' + index + ']');
-    if (anchor.length === 0) {
-      return;
-    }
-    $('html, body').animate({ scrollTop: anchor.offset().top - 20 }, 0);
-  }
-
-  // the last item whose anchor is at or above the current scroll position
-  function currentOption() {
-    var current = selector.find('option').first();
-    selector.find('option').each(function() {
-      var anchor = $('a[name=collitem_text_' + $(this).val() + ']');
-      if (anchor.length > 0 && anchor.offset().top <= $(window).scrollTop() + 25) {
-        current = $(this);
-      }
-    });
-    return current;
-  }
-
-  function goToSibling(sibling, emptyMessage) {
-    if (sibling.length === 0) {
-      alert(emptyMessage);
-      return;
-    }
-    selector.val(sibling.val());
-    scrollToItem(sibling.val());
-  }
-
-  selector.change(function() {
-    scrollToItem($(this).val());
-  });
-  $('#next_collitem').click(function() {
-    goToSibling(currentOption().next(), readmode.data('no-next-item'));
-  });
-  $('#prev_collitem').click(function() {
-    goToSibling(currentOption().prev(), readmode.data('no-prev-item'));
   });
 });

--- a/app/assets/javascripts/readmode_nav.js
+++ b/app/assets/javascripts/readmode_nav.js
@@ -1,0 +1,69 @@
+// The reading-mode control panel's item navigator (shared/_readmode_nav), used by both
+// Manifestation#readmode and Collection#readmode. It replaces a native <select>, whose options
+// cannot wrap, with a list of divs, so long chapter and item titles wrap instead of being clipped.
+$(document).ready(function() {
+  var nav = $('#rm_nav');
+  if (nav.length === 0) {
+    return;
+  }
+
+  var list = $('#rm_nav_list');
+  var trigger = $('#rm_nav_current');
+  var label = trigger.find('.rm-nav-current-label');
+  var items = nav.find('.rm-nav-item');
+
+  function anchorOf(item) {
+    return $('a[name="' + $(item).data('anchor') + '"]');
+  }
+
+  function goTo(item) {
+    var anchor = anchorOf(item);
+    if (anchor.length === 0) {
+      return;
+    }
+    items.removeClass('current');
+    $(item).addClass('current');
+    label.text($(item).text());
+    $('html, body').animate({ scrollTop: anchor.offset().top - 20 }, 0);
+  }
+
+  // the last item whose anchor is at or above the current scroll position
+  function currentItem() {
+    var current = items.first();
+    items.each(function() {
+      var anchor = anchorOf(this);
+      if (anchor.length > 0 && anchor.offset().top <= $(window).scrollTop() + 25) {
+        current = $(this);
+      }
+    });
+    return current;
+  }
+
+  function step(offset, message) {
+    var index = items.index(currentItem()) + offset;
+    if (index < 0 || index >= items.length) {
+      alert(message);
+      return;
+    }
+    goTo(items.get(index));
+  }
+
+  trigger.click(function(e) {
+    e.stopPropagation();
+    list.toggleClass('open');
+  });
+  items.click(function() {
+    list.removeClass('open');
+    goTo(this);
+  });
+  $(document).click(function() {
+    list.removeClass('open');
+  });
+
+  $('#next_rm_item').click(function() {
+    step(1, nav.data('no-next'));
+  });
+  $('#prev_rm_item').click(function() {
+    step(-1, nav.data('no-prev'));
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,10 +151,6 @@ body.staging::before {
   margin-left: 25px;
 
 }
-#chapters {
-  width: -webkit-fill-available;
-  width: -moz-available;
-}
 .anthology-badge{
   cursor: pointer;
 }
@@ -1349,6 +1345,124 @@ p.by-genre-name-v02.headline-2-v02 {
 .reading-mode-btn-v02 .by-icon-v02,
 .reading-mode-icon-btn-v02 .by-icon-v02 {
   line-height: 26px;
+}
+
+/* The horizontal half of the same problem, on the icon-only (mobile) button:
+   .by-icon-v02's box is 26px wide but the glyph's inline box is only 18px, and
+   the RTL page's inherited text-align:right pinned it to the right edge, so it
+   sat 4px right of centre in its purple square. The desktop button is left out
+   deliberately -- there the glyph is one item in a row beside its label, and
+   centring it inside its box would only open a gap between the two. */
+.reading-mode-icon-btn-v02 .by-icon-v02 {
+  text-align: center;
+}
+
+/* Reading-mode control panel. BY_styles_General.css sizes it at 210px, which is
+   narrower than most chapter and collection-item titles, so the navigator below
+   had nowhere to put them. Pinning it 10px from the viewport edge (it was 7.5%,
+   and 30px below 1280px) buys back most of what the extra width costs the
+   reading column. Between 992px -- where the panel first appears -- and 1280px
+   there is not enough room for the full width, so it stays narrower there. */
+.rm-control-panel {
+  width: 280px;
+  left: 10px;
+}
+
+@media (max-width: 1279px) {
+  .rm-control-panel {
+    width: 240px;
+  }
+}
+
+/* The work page's reading mode clears the fixed control panel only by accident,
+   via the 25%-wide decorative .work-side-color strip down the left of its text
+   card. Collection#readmode renders the plain item cards of Collection#show,
+   which have no such strip, so reserve the panel's own footprint here: its 10px
+   offset plus its width at each breakpoint, plus a gutter. Below 992px the
+   panel is hidden altogether and the text may use the full width. */
+@media (min-width: 992px) and (max-width: 1279px) {
+  #collection-readmode .text-page-content {
+    padding-left: 270px;
+  }
+}
+
+@media (min-width: 1280px) {
+  #collection-readmode .text-page-content {
+    padding-left: 310px;
+  }
+}
+
+/* The navigator itself (shared/_readmode_nav): [prev] [dropdown] [next] on one
+   row, with the dropdown taking whatever width is left. */
+.rm-nav {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.rm-nav .rm-nav-step {
+  width: auto; /* .chapterbutton is width:100%, which would stack the three controls */
+  flex: 0 0 auto;
+  line-height: 26px;
+  color: #660248;
+}
+
+.rm-nav-dropdown {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0; /* let the flex item shrink below its content width, so labels wrap */
+}
+
+.rm-nav-current {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 2px 6px;
+  border: solid 1px #d9cdd5;
+  border-radius: 3px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
+.rm-nav-current-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.rm-nav .dropdown-arrow {
+  flex: 0 0 auto;
+  float: none; /* .dropdown-arrow floats left; in this flex row that would drop it out of line */
+  margin-right: 0;
+}
+
+/* .by-dropdown-content-v02 is white-space:nowrap, which is exactly what we are
+   fixing here: let long titles wrap, and cap the list's height so a long table
+   of contents scrolls rather than running off the screen. */
+.rm-nav-list {
+  right: 0;
+  left: 0;
+  white-space: normal;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.rm-nav-list.open {
+  display: block;
+}
+
+.rm-nav-item {
+  margin: 0;
+  padding: 6px 12px;
+  overflow-wrap: break-word;
+}
+
+.rm-nav-item:hover {
+  background-color: #d9cdd5;
+}
+
+.rm-nav-item.current {
+  font-weight: bold;
 }
 
 .share-name {

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -10,28 +10,11 @@ class CollectionsController < ApplicationController
   include FilteringAndPaginationConcern
 
   before_action :require_editor, except: %i(browse show readmode download print kwic kwic_download pby_volumes)
-  before_action :set_collection, only: %i(show update destroy)
+  before_action :set_collection, only: %i(show readmode update destroy)
+  before_action :redirect_unviewable_collection, only: %i(show readmode)
 
   # GET /collections/1 or /collections/1.json
   def show
-    # Sub-volume/sub-issue collections (type 'series') and uncollected-works collections should
-    # never be the focus of a Collection#show view. Redirect them to a more appropriate target
-    # (to prevent URL-hacking or stale links to sub-collections). If there is no suitable target
-    # (e.g. an orphan series with no volume/issue ancestor), fall through and render normally.
-    if @collection.series?
-      parent = @collection.parent_volume_or_isssue
-      if parent.present?
-        redirect_to collection_path(parent.id, q: params[:q])
-        return
-      end
-    elsif @collection.uncollected?
-      authority = Authority.find_by(uncollected_works_collection_id: @collection.id)
-      if authority.present?
-        redirect_to authority_path(authority)
-        return
-      end
-    end
-
     data = FetchCollection.call(@collection)
 
     if data.all_manifestations.size == 1
@@ -60,23 +43,6 @@ class CollectionsController < ApplicationController
   # GET /collections/1/readmode - distraction-free reading of the collection's texts
   def readmode
     @readmode = true
-    @collection = Collection.find(params[:collection_id])
-
-    # Match Collection#show guards: series/uncollected collections should not be directly viewed.
-    if @collection.series?
-      parent = @collection.parent_volume_or_isssue
-      if parent.present?
-        redirect_to collection_path(parent.id, q: params[:q])
-        return
-      end
-    elsif @collection.uncollected?
-      authority = Authority.find_by(uncollected_works_collection_id: @collection.id)
-      if authority.present?
-        redirect_to authority_path(authority)
-        return
-      end
-    end
-
     @page_title = "#{@collection.title} - #{t(:default_page_title)}"
     prep_for_show
     # [label, anchor index] pairs for the reading-mode item selector, indented by nesting level
@@ -634,8 +600,24 @@ class CollectionsController < ApplicationController
   private
 
   # Use callbacks to share common setup or constraints between actions.
+  # Member routes (show, update, destroy) carry :id; nested ones (readmode) carry :collection_id.
   def set_collection
-    @collection = Collection.find(params[:id])
+    @collection = Collection.find(params[:id] || params[:collection_id])
+  end
+
+  # Sub-volume/sub-issue collections (type 'series') and uncollected-works collections should never
+  # be the focus of a Collection#show or #readmode view, so send them somewhere more appropriate
+  # (guarding against URL-hacking and stale links to sub-collections). If there is no suitable
+  # target -- e.g. an orphan series with no volume/issue ancestor -- fall through and render
+  # normally. Redirecting here halts the before_action chain, so the action never runs.
+  def redirect_unviewable_collection
+    if @collection.series?
+      parent = @collection.parent_volume_or_isssue
+      redirect_to collection_path(parent.id, q: params[:q]) if parent.present?
+    elsif @collection.uncollected?
+      authority = Authority.find_by(uncollected_works_collection_id: @collection.id)
+      redirect_to authority_path(authority) if authority.present?
+    end
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -61,6 +61,22 @@ class CollectionsController < ApplicationController
   def readmode
     @readmode = true
     @collection = Collection.find(params[:collection_id])
+
+    # Match Collection#show guards: series/uncollected collections should not be directly viewed.
+    if @collection.series?
+      parent = @collection.parent_volume_or_isssue
+      if parent.present?
+        redirect_to collection_path(parent.id, q: params[:q])
+        return
+      end
+    elsif @collection.uncollected?
+      authority = Authority.find_by(uncollected_works_collection_id: @collection.id)
+      if authority.present?
+        redirect_to authority_path(authority)
+        return
+      end
+    end
+
     @page_title = "#{@collection.title} - #{t(:default_page_title)}"
     prep_for_show
     # [label, anchor index] pairs for the reading-mode item selector, indented by nesting level

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -9,7 +9,7 @@ class CollectionsController < ApplicationController
   include KwicConcordanceConcern
   include FilteringAndPaginationConcern
 
-  before_action :require_editor, except: %i(browse show download print kwic kwic_download pby_volumes)
+  before_action :require_editor, except: %i(browse show readmode download print kwic kwic_download pby_volumes)
   before_action :set_collection, only: %i(show update destroy)
 
   # GET /collections/1 or /collections/1.json
@@ -55,6 +55,19 @@ class CollectionsController < ApplicationController
     prep_for_show
     track_view(@collection)
     prep_user_content(:collection) # user anthologies, bookmarks
+  end
+
+  # GET /collections/1/readmode - distraction-free reading of the collection's texts
+  def readmode
+    @readmode = true
+    @collection = Collection.find(params[:collection_id])
+    @page_title = "#{@collection.title} - #{t(:default_page_title)}"
+    prep_for_show
+    # [label, anchor index] pairs for the reading-mode item selector, indented by nesting level
+    @rm_items = @htmls.reject { |item| item[0].blank? }.map do |item|
+      title, _ias, _html, _is_curated, _genre, index, _ci, nesting_level = item
+      [('– ' * nesting_level) + title, index]
+    end
   end
 
   # GET /pby_volumes
@@ -715,7 +728,28 @@ class CollectionsController < ApplicationController
     else
       build_htmls_recursively(@collection.collection_items, parent_authorities, 0, counter)
     end
+    set_effective_authorities
     set_collection_metadata
+  end
+
+  # Per-item authors and translators worth naming next to an item's title, i.e. those that differ
+  # from the collection-level ones. Keyed by item title, for the show and readmode views.
+  def set_effective_authorities
+    collection_author_ids = @collection.authors.map(&:id)
+    collection_translator_ids = @collection.translators.map(&:id)
+    @effective_authors = {}
+    @effective_translators = {}
+    @htmls.each do |title, ias, *_rest|
+      authors = authorities_by_role(ias, 'author').reject { |a| collection_author_ids.include?(a.id) }
+      @effective_authors[title] = authors.map(&:name).join(', ') if authors.present?
+
+      translators = authorities_by_role(ias, 'translator').reject { |a| collection_translator_ids.include?(a.id) }
+      @effective_translators[title] = translators.map(&:name).join(', ') if translators.present?
+    end
+  end
+
+  def authorities_by_role(involved_authorities, role)
+    involved_authorities.select { |ia| ia.role == role }.map(&:authority)
   end
 
   def set_collection_metadata

--- a/app/views/collections/_coll_texts.html.haml
+++ b/app/views/collections/_coll_texts.html.haml
@@ -1,0 +1,70 @@
+-# The collection's items, rendered as text cards. Shared by Collection#show and Collection#readmode.
+- @htmls.each do |title, ias, html, _is_curated, genre, i, ci, nesting_level, _parent_authorities, title_footnote|
+  %a{ name: "collitem_text_#{i}" }
+  - card_attrs = { data: { item_id: ci.item_id, item_type: ci.item_type } }
+  - card_attrs[:style] = "margin-right: #{nesting_level * 10}px;" if nesting_level > 0
+  -# a sub-collection whose whole ToC is a single text is collapsed into it: heading only (#1488)
+  - collapsed_text = @collapsed_texts[ci.id]
+  - if collapsed_text.present? || (html.nil? && ci.item_type == 'Collection')
+    -#
+      This is a sub-collection header, rendered with full detail. Its anchor is stable (keyed by
+      sub-collection id) so search results and deep links can jump here.
+    %a{ name: "collection_#{ci.item_id}" }
+    .by-card-v02.proofable{ card_attrs }
+      .by-card-header-v02
+        .by-icon-v02
+        .headline-1-v02
+          -# a collapsed heading takes over the link and genre glyph of the text it stands for
+          - link = collapsed_text.present? ? url_for(collapsed_text) : url_for_collection_item(ci)
+          - glyph_genre = collapsed_text.present? ? collapsed_text.genre : genre
+          %span.by-icon-v02{ title: textify_genre(glyph_genre) }= glyph_for_genre(glyph_genre)
+          - if link.present?
+            = link_to '‏' + title, link # RLM character to help with LTR elements in title. Fixes #664
+          - else
+            = '‏' + title # RLM character to help with LTR elements in title. Fixes #664
+          - if title_footnote.present?
+            != ' ' + title_footnote
+        -# Show all authorities with their roles (already filtered)
+        - authors = ias.select { |ia| ia.role == 'author' }.map(&:authority)
+        - if authors.present?
+          %p
+            = t(:by)
+            != authors.map { |a| authority_link(a) }.join(', ')
+        - editors = ias.select { |ia| ia.role == 'editor' }.map(&:authority)
+        - if editors.present?
+          %p
+            = t(:edited_by)
+            != editors.map { |a| authority_link(a) }.join(', ')
+        - translators = ias.select { |ia| ia.role == 'translator' }.map(&:authority)
+        - if translators.present?
+          %p
+            = t(:translated_by)
+            != translators.map { |a| authority_link(a) }.join(', ')
+  - else
+    -# This is a manifestation or other content item
+    .by-card-v02.proofable{ card_attrs }
+      - if title.present?
+        .by-card-header-v02
+          .by-icon-v02
+          .headline-1-v02
+            - link = url_for_collection_item(ci)
+            - tstr = @effective_authors[title].present? ? "#{title} / #{@effective_authors[title]}" : title
+            - if link.present?
+              %span.by-icon-v02{ title: textify_genre(genre) }= glyph_for_genre(genre)
+              = link_to '‏' + tstr, link # RLM character to help with LTR elements in title. Fixes #664
+            - else
+              = '‏' + tstr # RLM character to help with LTR elements in title. Fixes #664
+            - if title_footnote.present?
+              != ' ' + title_footnote
+            - if @effective_translators[title].present?
+              %p
+                #{t(:translated_by)} #{@effective_translators[title]}
+                - if ci.item_type == 'Manifestation' && ci.item&.expression&.work.present?
+                  = " (#{orig_lang_label(ci.item.expression.work.orig_lang)})"
+        - if ci.item_type == 'Manifestation' && ci.item.present?
+          - item_ip = ci.item.expression.intellectual_property
+          .metadata{ style: 'padding-top: 4px;' }
+            .ip-statement
+              = render partial: 'shared/intellectual_property', locals: { intellectual_property: item_ip }
+      .by-card-content-v02.textcard#actualtext
+        != convert_internal_links_to_relative(request.base_url, html, request.path)

--- a/app/views/collections/readmode.html.haml
+++ b/app/views/collections/readmode.html.haml
@@ -1,0 +1,63 @@
+-# distraction-free reading mode for a collection. Companion of manifestation/readmode.html.haml
+- rm_data = { collection_url: collection_path(@collection), no_next_item: t(:no_next_item),
+              no_prev_item: t(:no_prev_item) }
+.reading-mode#collection-readmode{ data: rm_data }
+  .container-fluid#content
+    .row.text-page-content
+      .col-12.col-lg-8
+        .logo-for-print
+          %img.logoBY-v02{ alt: t(:logo), src: '/assets/logo-byp-mobile.svg' }
+        .by-card-v02.rm-control-panel
+          .rm-control-top
+            .rm-logo
+              %img.logoBY-v02{ alt: t(:logo), src: '/assets/logo-byp.svg' }
+            %a.collapse-expand-icon{ href: collection_path(@collection), title: t(:leave_readmode_tt) }
+              %span.by-icon-v02 .
+          .rm-control-info
+            .headline-2-v02.work-name-top{ style: 'margin-right:0px' }= @collection.title
+            - if @collection.authors.present?
+              .headline-3-v02
+                != @collection.authors.map { |a| authority_link(a) }.join(', ')
+            - collection_editors = @collection.editors(true)
+            - if collection_editors.present?
+              .headline-3-v02
+                = t('involved_authority.abstract_roles.editor') + ': '
+                != collection_editors.map { |a| authority_link(a) }.join(', ')
+            - if @collection.translators.present?
+              .headline-3-v02
+                = t('involved_authority.abstract_roles.translator') + ': '
+                != @collection.translators.map { |a| authority_link(a) }.join(', ')
+            - if @rm_items.many?
+              .rm-field-label= t(:table_of_contents) + ':'
+              %button.plainbutton.chapterbutton#prev_collitem= '('
+              %select#collitem{ name: 'collitem' }
+                - @rm_items.each do |label, index|
+                  %option{ value: index }= label
+              %button.plainbutton.chapterbutton#next_collitem= ')'
+            .rm-field-label= t(:location_in_work)
+            .progress-outside
+              .progress-inside.progress-bar
+            .progress-number= '0%'
+          .rm-control-icons
+            - proof_btn_style = 'background-color:unset; border-color: transparent; box-shadow:unset; padding-top:2px;'
+            .linkcolor.pointer#found_mistake{ title: t(:report_error_tt) }
+              %button.error-found-btn.by-icon-v02.pointer{ style: proof_btn_style } g
+            .linkcolor.pointer{ 'data-toggle' => 'modal', 'data-target' => '#shareDlg', title: t(:share_tt) }
+              %span.by-icon-v02 U
+        .by-card-v02.rm-control-panel-mobile
+          .rm-logo
+            %img.logoBY-v02{ alt: '', src: '/assets/logo-byp.svg' }
+          .progress-area
+            .progress-outside
+              .progress-inside.progress-bar
+              .progress-handle
+            .progress-number= '0%'
+          .rm-control-left
+            %a.collapse-expand-icon{ href: collection_path(@collection), title: t(:leave_readmode_tt) }
+              %span.by-icon-v02 .
+        .row
+          .col.work-side-menu-area
+          .col
+            = render partial: 'coll_texts'
+/ found mistake popup
+= render partial: 'shared/proof'

--- a/app/views/collections/readmode.html.haml
+++ b/app/views/collections/readmode.html.haml
@@ -27,13 +27,10 @@
               .headline-3-v02
                 = t('involved_authority.abstract_roles.translator') + ': '
                 != @collection.translators.map { |a| authority_link(a) }.join(', ')
-            - if @rm_items.many?
-              .rm-field-label= t(:table_of_contents) + ':'
-              %button.plainbutton.chapterbutton#prev_collitem= '('
-              %select#collitem{ name: 'collitem' }
-                - @rm_items.each do |label, index|
-                  %option{ value: index }= label
-              %button.plainbutton.chapterbutton#next_collitem= ')'
+            - nav_items = @rm_items.map { |label, index| [label, "collitem_text_#{index}"] }
+            = render partial: 'shared/readmode_nav',
+                     locals: { items: nav_items, field_label: t(:table_of_contents) + ':',
+                               no_next: t(:no_next_item), no_prev: t(:no_prev_item) }
             .rm-field-label= t(:location_in_work)
             .progress-outside
               .progress-inside.progress-bar

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -5,9 +5,6 @@
 = render partial: 'shared/search_highlight_controls',
          locals: { search_query: params[:q], entity_title: @collection.title }
 #content.container-fluid
-  - cauthors = @collection.authors
-  - ceditors = @collection.editors
-  - ctranslators = @collection.translators
   .row.text-page-content
     .col-12.col-lg-8
       .logo-for-print
@@ -188,17 +185,7 @@
                           %img{ src: image_path('cover_placeholder.svg'), alt: issue.title, style: 'max-width: 150px; height: auto;' }
                         %div= issue.title
 
-          :ruby
-            eauthors = {}
-            etranslators = {}
-            @htmls.each do |title, ias, html, is_curated, genre, i, ci, nesting_level, parent_authorities, title_footnote|
-              effective_authors = ias.select{|ia| ia.role == 'author'}.map(&:authority).reject{|a| cauthors.map(&:id).include?(a.id)}
-              eauthors[title] = effective_authors.map(&:name).join(', ') if effective_authors.present?
-
-              effective_translators = ias.select{|ia| ia.role == 'translator'}.map(&:authority).reject{|a| ctranslators.map(&:id).include?(a.id)}
-              etranslators[title] = effective_translators.map(&:name).join(', ') if effective_translators.present?
-            end
-          - if !@collection.periodical? && (eauthors.present? || @htmls.any?)
+          - if !@collection.periodical? && (@effective_authors.present? || @htmls.any?)
             .by-card-v02.binder-texts-list
               .by-card-content-v02
                 .list-no-bullets
@@ -211,79 +198,11 @@
                         %a.side-menu-item{href: "#collitem_text_#{i}", 'data-target' => "collitem_text_#{i}"}
                           %span.by-icon-v02{title: textify_genre(genre) }= glyph_for_genre(genre)
                           - parts = ['‏' + title] # RLM character to help with LTR elements in title. Fixes #664
-                          - parts << eauthors[title] if eauthors[title].present?
-                          - parts << etranslators[title] if etranslators[title].present?
+                          - parts << @effective_authors[title] if @effective_authors[title].present?
+                          - parts << @effective_translators[title] if @effective_translators[title].present?
                           = parts.join(' / ')
 
-          - @htmls.each do |title, ias, html, is_curated, genre, i, ci, nesting_level, parent_authorities, title_footnote|
-            %a{ name: "collitem_text_#{i}" }
-            - card_attrs = { data: { item_id: ci.item_id, item_type: ci.item_type } }
-            - card_attrs[:style] = "margin-right: #{nesting_level * 10}px;" if nesting_level > 0
-            -# a sub-collection whose whole ToC is a single text is collapsed into it: heading only (#1488)
-            - collapsed_text = @collapsed_texts[ci.id]
-            - if collapsed_text.present? || (html.nil? && ci.item_type == 'Collection')
-              -# This is a sub-collection header - render with full detail
-              -# Stable anchor (keyed by sub-collection id) so search results and deep links can jump here
-              %a{ name: "collection_#{ci.item_id}" }
-              .by-card-v02.proofable{ card_attrs }
-                .by-card-header-v02
-                  .by-icon-v02
-                  .headline-1-v02
-                    -# a collapsed heading takes over the link and genre glyph of the text it stands for
-                    - link = collapsed_text.present? ? url_for(collapsed_text) : url_for_collection_item(ci)
-                    - glyph_genre = collapsed_text.present? ? collapsed_text.genre : genre
-                    %span.by-icon-v02{title: textify_genre(glyph_genre)}= glyph_for_genre(glyph_genre)
-                    - if link.present?
-                      = link_to '‏' + title, link # RLM character to help with LTR elements in title. Fixes #664
-                    - else
-                      = '‏' + title # RLM character to help with LTR elements in title. Fixes #664
-                    - if title_footnote.present?
-                      != ' ' + title_footnote
-                  -# Show all authorities with their roles (already filtered)
-                  - authors = ias.select{|ia| ia.role == 'author'}.map(&:authority)
-                  - if authors.present?
-                    %p
-                      = t(:by)
-                      != authors.map { |a| authority_link(a) }.join(', ')
-                  - editors = ias.select{|ia| ia.role == 'editor'}.map(&:authority)
-                  - if editors.present?
-                    %p
-                      = t(:edited_by)
-                      != editors.map { |a| authority_link(a) }.join(', ')
-                  - translators = ias.select{|ia| ia.role == 'translator'}.map(&:authority)
-                  - if translators.present?
-                    %p
-                      = t(:translated_by)
-                      != translators.map { |a| authority_link(a) }.join(', ')
-            - else
-              -# This is a manifestation or other content item
-              .by-card-v02.proofable{ card_attrs }
-                - if title.present?
-                  .by-card-header-v02
-                    .by-icon-v02
-                    .headline-1-v02
-                      - link = url_for_collection_item(ci)
-                      - tstr = eauthors[title].present? ? "#{title} / #{eauthors[title]}" : title
-                      - if link.present?
-                        %span.by-icon-v02{title: textify_genre(genre)}= glyph_for_genre(genre)
-                        = link_to '‏' + tstr, link # RLM character to help with LTR elements in title. Fixes #664
-                      - else
-                        = '‏' + tstr # RLM character to help with LTR elements in title. Fixes #664
-                      - if title_footnote.present?
-                        != ' ' + title_footnote
-                      - translators = ias.select{|ia| ia.role == 'translator'}.map(&:authority).reject{|a| ctranslators.map(&:id).include?(a.id)}
-                      - if translators.present?
-                        %p
-                          = "#{t(:translated_by)} #{translators.map(&:name).join(', ')}"
-                          - if ci.item_type == 'Manifestation' && ci.item&.expression&.work.present?
-                            = " (#{orig_lang_label(ci.item.expression.work.orig_lang)})"
-                    - if ci.item_type == 'Manifestation' && ci.item.present?
-                      - item_ip = ci.item.expression.intellectual_property
-                      .metadata{ style: 'padding-top: 4px;' }
-                        .ip-statement
-                          = render partial: 'shared/intellectual_property', locals: { intellectual_property: item_ip }
-                .by-card-content-v02.textcard#actualtext
-                  != convert_internal_links_to_relative(request.base_url, html, request.path)
+          = render partial: 'coll_texts'
           - credit_lines = @collection.fetch_credits.lines
           - if credit_lines.present?
             .by-card-v02

--- a/app/views/manifestation/readmode.html.haml
+++ b/app/views/manifestation/readmode.html.haml
@@ -46,12 +46,10 @@
               .headline-3-v02
                 = "#{t('involved_authority.abstract_roles.other')}: "
                 != @others.map { |t| authority_link(t) }.join(', ')
-            .rm-field-label &#x5E4;&#x5E8;&#x5E7;:
-            %button.plainbutton.chapterbutton#prev_chapter= '('
-            %select#chapters{name: 'chapters'}
-              - @chapters.each do |ch|
-                %option{value: ch[1]}= ch[0]
-            %button.plainbutton.chapterbutton#next_chapter= ')'
+            - nav_items = @chapters.map { |ch| [ch[0], "ch#{ch[1]}"] }
+            = render partial: 'shared/readmode_nav',
+                     locals: { items: nav_items, field_label: t(:chapter) + ':',
+                               no_next: t(:no_next_chapter), no_prev: t(:no_prev_chapter) }
             .rm-field-label= t(:location_in_work)
             .progress-outside
               .progress-inside.progress-bar
@@ -135,65 +133,4 @@
         window.location.href = '#{url_for(action: :read, id: @m.id)}';
       }
     });
-    if(#{@chapters.length} > 1) {
-      $('#chapters').change(function(e) {
-        anchor = $('a[name=ch'+$(this).val()+']');
-        $('html, body').animate({
-          scrollTop: $(anchor).offset().top - 20
-        }, 0);
-        $('#actualtext').focus({preventScroll: true});
-      });
-      function get_first_visible_chapter() {
-        chs = $('a[name*=ch');
-        first = null;
-        chs.each(function(){
-          if($(this).offset().top > $(window).scrollTop() && $(this).offset().top < ($(window).scrollTop() +$(window).innerHeight())) { 
-            first = this; 
-            return false;
-          }
-        });
-        if(first == null) {
-          first = chs[0];
-        }
-        return first;
-      };
-      $('#next_chapter').click(function(){
-        first = get_first_visible_chapter();
-        cur = $('#chapters').find('option[value='+$(first).attr('name').replace('ch','')+']');
-        if(cur.length == 0) {
-          alert('no current chapter?!');
-        } else {
-          nextch = cur.next();
-          if(nextch.length == 0) {
-            alert("#{t(:no_next_chapter)}");
-          } else {
-            $('#chapters').val($(nextch[0]).val());
-            anch = $('a[name=ch'+$(nextch[0]).val()+']');
-            $('html, body').animate({
-              scrollTop: $(anch).offset().top - 20
-            }, 0);
-            $('#actualtext').focus({preventScroll: true});
-          }
-        }
-      });
-      $('#prev_chapter').click(function(){
-        first = get_first_visible_chapter();
-        cur = $('#chapters').find('option[value='+$(first).attr('name').replace('ch','')+']');
-        if(cur.length == 0) {
-          alert('no current chapter?!');
-        } else {
-          prevch = cur.prev();
-          if(prevch.length == 0) {
-            alert("#{t(:no_prev_chapter)}");
-          } else {
-            $('#chapters').val($(prevch[0]).val());
-            anch = $('a[name=ch'+$(prevch[0]).val()+']');
-            $('html, body').animate({
-              scrollTop: $(anch).offset().top - 20
-            }, 0);
-            $('#actualtext').focus({preventScroll: true});
-          }
-        }
-      });  
-    }
   });

--- a/app/views/shared/_collection_top.html.haml
+++ b/app/views/shared/_collection_top.html.haml
@@ -4,6 +4,9 @@
   .top-space
   - aus = @collection.authors_string
   - eds = @collection.editors_string(true)
+  - rm_path = collection_readmode_path(@collection.id)
+  - rm_tooltip = { title: t(:readmode_tt), 'data-selector' => 'true', 'data-placement' => 'top',
+                   'data-toggle' => 'tooltip', 'data-delay' => { show: 200, hide: 100 } }
 
   .work-page-top
     .work-page-top-info-card
@@ -41,9 +44,10 @@
             = select_tag 'collitem', options_for_select(@htmls.reject{|x| x[0].blank?}.map{ |title, authors, html, is_curated, genre, i, ci, nesting_level, parent_authorities| [("– " * nesting_level) + strip_coll_prefix.call(title), i] }, 0), class: 'dropdown-v02', id: 'collitem_dropdown', style: 'width: 100%;'
 
           .work-page-top-icons-desktop
-            %button.btn-small-outline-v02.btn-text-v02.reading-mode-btn-v02{href: "#"}
-              %span.by-icon-v02= '/'
-              = t(:reading_mode)
+            %a.white{ href: rm_path }
+              %button.btn-small-outline-v02.btn-text-v02.reading-mode-btn-v02{ rm_tooltip }
+                %span.by-icon-v02= '/'
+                = t(:reading_mode)
             .top-left-icons-group
               .icons-group-v02
                 .by-icon-v02.pointer.linkcolor.bookmark-status.notyet
@@ -52,6 +56,8 @@
                   .by-icon-v02.pointer.linkcolor.download{ data: { 'downloadable-id' => @collection.id, toggle: :modal, target: '#downloadDlg' } }= 3
           .chapters-and-icons-mobile
             .work-page-top-icons-mobile
+              %a.btn-small-outline-v02.btn-text-v02.reading-mode-icon-btn-v02{ href: rm_path, title: t(:readmode_tt) }
+                %span.by-icon-v02 /
               .top-left-icons-group
                 .icons-group-v02
                   .by-icon-v02.pointer.linkcolor.bookmark-status.notyet

--- a/app/views/shared/_readmode_nav.html.haml
+++ b/app/views/shared/_readmode_nav.html.haml
@@ -1,0 +1,20 @@
+-#
+  The reading-mode control panel's item navigator, shared by Manifestation#readmode (chapters) and
+  Collection#readmode (collection items). `items` is an array of [label, anchor name] pairs; the
+  anchor name is the `name` of an %a already present in the text body. `no_next`/`no_prev` are the
+  messages shown when there is nothing to step to.
+
+  This is a list of divs rather than a <select> because a <select>'s options cannot wrap in any
+  browser, and titles are routinely wider than the control panel.
+- if items.many?
+  .rm-field-label= field_label
+  .rm-nav#rm_nav{ data: { no_next: no_next, no_prev: no_prev } }
+    %button.plainbutton.chapterbutton.rm-nav-step#prev_rm_item{ type: 'button', title: t(:to_previous_item) }= '('
+    .rm-nav-dropdown
+      .rm-nav-current#rm_nav_current{ tabindex: 0 }
+        %span.rm-nav-current-label= items.first.first
+        %span.dropdown-arrow )
+      .by-dropdown-content-v02.rm-nav-list#rm_nav_list
+        - items.each do |label, anchor|
+          %p.pointer.linkcolor.rm-nav-item{ data: { anchor: anchor } }= label
+    %button.plainbutton.chapterbutton.rm-nav-step#next_rm_item{ type: 'button', title: t(:to_next_item) }= ')'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2743,8 +2743,10 @@ en:
   no_more_items: No More Items
   no_more_to_review: No More To Review
   no_next_chapter: No Next Chapter
+  no_next_item: No Next Item
   no_permission: No Permission
   no_prev_chapter: No Prev Chapter
+  no_prev_item: No Previous Item
   no_recommendations_yet: No Recommendations Yet
   no_source_edition: No Source Edition
   no_such_item: No Such Item

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1307,6 +1307,7 @@ en:
   catalog_title: Project Ben-Yehuda Catalog
   catalogue: Catalog
   change_or_merge: Change / Merge
+  chapter: Chapter
   chapters_list: 'Chapters List:'
   chinese: Chinese
   choose_font_size: What size do you prefer?

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -650,6 +650,7 @@ he:
   our_own_content: 'תוכן משלנו:'
   bookshelf: מדפים
   found_br_mistake_html: מצאתי<BR /> שגיאה
+  chapter: פרק
   chapters_list: 'רשימת פרקים:'
   additional_translations: תרגומים נוספים ליצירה
   additional_versions: נוסחים אחרים ליצירה זו

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1181,6 +1181,8 @@ he:
   anth_add_curated_tt: "הוספת טקסט מלווה מטעמך כגון שער, הערות, שיעורי בית, וכו'"
   no_next_chapter: אין פרק נוסף
   no_prev_chapter: אין פרק קודם
+  no_next_item: אין פריט נוסף
+  no_prev_item: אין פריט קודם
   facebook_url: https://www.facebook.com/projectbenyehuda/
   latest_youtube: קטעי וידאו אחרונים בערוץ היו-טיוב
   youtube_url: https://www.youtube.com/user/ProjectBenYehuda/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,7 @@ Bybeconv::Application.routes.draw do
 
   resources :collections, only: %i(show create update destroy) do
     get 'manage'
+    get 'readmode'
     post 'download'
     get 'print'
     get 'kwic'

--- a/spec/requests/collection_readmode_spec.rb
+++ b/spec/requests/collection_readmode_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Collection reading mode', type: :request do
+  after { Chewy.massacre }
+
+  let!(:author) { create(:authority, name: 'Author Name') }
+
+  let!(:m1) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'First Text', markdown: 'Body of the first text', status: :published)
+    end
+  end
+
+  let!(:m2) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Second Text', markdown: 'Body of the second text', status: :published)
+    end
+  end
+
+  let!(:collection) do
+    Chewy.strategy(:atomic) do
+      col = create(:collection, title: 'Readable Collection', collection_type: :volume)
+      create(:involved_authority, item: col, authority: author, role: 'author')
+      create(:collection_item, collection: col, item: m1, seqno: 1)
+      create(:collection_item, collection: col, item: m2, seqno: 2)
+      col
+    end
+  end
+
+  describe 'GET /collections/:collection_id/readmode' do
+    it 'renders the collection texts without the site header and footer' do
+      get collection_readmode_path(collection)
+
+      expect(response).to have_http_status(:success)
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.at_css('.reading-mode')).to be_present
+      expect(doc.at_css('header')).to be_nil
+      expect(doc.at_css('footer')).to be_nil
+      expect(response.body).to include('Body of the first text')
+      expect(response.body).to include('Body of the second text')
+    end
+
+    it 'offers a way back to the collection page and marks itself noindex' do
+      get collection_readmode_path(collection)
+
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.css("a.collapse-expand-icon[href='#{collection_path(collection)}']")).to be_present
+      expect(doc.at_css("meta[name='robots'][content='noindex']")).to be_present
+    end
+
+    it 'lists the collection items in the reading-mode item selector' do
+      get collection_readmode_path(collection)
+
+      options = Nokogiri::HTML(response.body).css('select#collitem option')
+      expect(options.map(&:text)).to eq(['First Text', 'Second Text'])
+    end
+
+    it 'is reachable by anonymous visitors' do
+      get collection_readmode_path(collection)
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'the reading-mode buttons on Collection#show' do
+    it 'links the desktop button and the mobile icon button to the reading mode' do
+      get collection_path(collection)
+
+      doc = Nokogiri::HTML(response.body)
+      readmode_href = collection_readmode_path(collection)
+
+      desktop = doc.at_css(".work-page-top-icons-desktop a[href='#{readmode_href}']")
+      expect(desktop).to be_present
+      expect(desktop.at_css('.reading-mode-btn-v02')).to be_present
+
+      mobile = doc.at_css(".work-page-top-icons-mobile a[href='#{readmode_href}']")
+      expect(mobile).to be_present
+      expect(mobile['class']).to include('reading-mode-icon-btn-v02')
+    end
+  end
+end

--- a/spec/requests/collection_readmode_spec.rb
+++ b/spec/requests/collection_readmode_spec.rb
@@ -50,11 +50,12 @@ RSpec.describe 'Collection reading mode', type: :request do
       expect(doc.at_css("meta[name='robots'][content='noindex']")).to be_present
     end
 
-    it 'lists the collection items in the reading-mode item selector' do
+    it 'lists the collection items in the reading-mode navigator, anchored to their texts' do
       get collection_readmode_path(collection)
 
-      options = Nokogiri::HTML(response.body).css('select#collitem option')
-      expect(options.map(&:text)).to eq(['First Text', 'Second Text'])
+      items = Nokogiri::HTML(response.body).css('#rm_nav_list .rm-nav-item')
+      expect(items.map(&:text)).to eq(['First Text', 'Second Text'])
+      expect(items.map { |i| i['data-anchor'] }).to eq(%w(collitem_text_1 collitem_text_2))
     end
 
     it 'is reachable by anonymous visitors' do

--- a/spec/requests/collection_readmode_spec.rb
+++ b/spec/requests/collection_readmode_spec.rb
@@ -55,12 +55,41 @@ RSpec.describe 'Collection reading mode', type: :request do
 
       items = Nokogiri::HTML(response.body).css('#rm_nav_list .rm-nav-item')
       expect(items.map(&:text)).to eq(['First Text', 'Second Text'])
-      expect(items.map { |i| i['data-anchor'] }).to eq(%w(collitem_text_1 collitem_text_2))
+      expect(items.pluck('data-anchor')).to eq(%w(collitem_text_1 collitem_text_2))
     end
 
     it 'is reachable by anonymous visitors' do
       get collection_readmode_path(collection)
       expect(response).to have_http_status(:success)
+    end
+
+    # Same redirect_unviewable_collection guard Collection#show runs: neither view should be the
+    # focus of a sub-collection or an uncollected-works collection.
+    context 'when the collection should not be viewed directly' do
+      it 'sends a series to its volume ancestor' do
+        volume = create(:collection, collection_type: :volume)
+        series = create(:collection, collection_type: :series, manifestations: create_list(:manifestation, 2))
+        volume.append_item(series)
+
+        get collection_readmode_path(series)
+        expect(response).to redirect_to collection_path(volume.id)
+      end
+
+      it 'sends an uncollected-works collection to its authority' do
+        uncollected = create(:collection, :uncollected)
+        authority = create(:authority)
+        authority.update!(uncollected_works_collection: uncollected)
+
+        get collection_readmode_path(uncollected)
+        expect(response).to redirect_to authority_path(authority)
+      end
+
+      it 'renders normally for a series with no volume/issue ancestor' do
+        orphan = create(:collection, collection_type: :series, manifestations: create_list(:manifestation, 2))
+
+        get collection_readmode_path(orphan)
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -9,6 +9,18 @@ module SystemSpecHelpers
     page.driver.browser.manage.window.resize_to(width, height)
   end
 
+  # Wait until the page has scrolled away from the top, and return the resulting offset.
+  # Capybara's matchers cannot express a scroll position, so we drive its own polling loop
+  # rather than sleeping for an animation to finish.
+  def wait_until_scrolled(wait: Capybara.default_max_wait_time)
+    page.document.synchronize(wait, errors: [Capybara::ExpectationNotMet]) do
+      offset = page.evaluate_script('window.pageYOffset || document.documentElement.scrollTop').to_f
+      raise Capybara::ExpectationNotMet, "page is still at the top (offset #{offset})" unless offset > 0
+
+      offset
+    end
+  end
+
   # Check if WebDriver is available and configured for system specs with JavaScript
   def webdriver_available?
     return false unless defined?(Capybara::Selenium)

--- a/spec/system/collection_reading_mode_spec.rb
+++ b/spec/system/collection_reading_mode_spec.rb
@@ -56,12 +56,10 @@ RSpec.describe 'Collection reading mode', :js, type: :system do
       expect(page).to have_no_css('header')
     end
 
-    it 'scrolls to the chosen item and offers a way back to the collection page' do
+    # The item navigator itself is covered in spec/system/readmode_nav_spec.rb
+    it 'offers a way back to the collection page' do
       visit collection_readmode_path(collection)
-      expect(page).to have_css('select#collitem', wait: 10)
-
-      find('select#collitem').select('Second Text')
-      expect(wait_until_scrolled(wait: 10)).to be > 0
+      expect(page).to have_css('.rm-control-panel a.collapse-expand-icon', wait: 10)
 
       find('.rm-control-panel a.collapse-expand-icon').click
       expect(page).to have_current_path(collection_path(collection), wait: 10)

--- a/spec/system/collection_reading_mode_spec.rb
+++ b/spec/system/collection_reading_mode_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Collection#show used to render the reading-mode button as a bare <button href="#">, which is
+# inert, and omitted it altogether from the mobile icon row. These specs guard both entry points
+# and the reading-mode page they lead to.
+RSpec.describe 'Collection reading mode', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  after { Chewy.massacre }
+
+  # long enough that the reading-mode page is actually scrollable
+  def long_body(label)
+    Array.new(40) { |i| "#{label}, paragraph #{i + 1}." }.join("\n\n")
+  end
+
+  let!(:m1) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'First Text', markdown: long_body('Body of the first text'),
+                             status: :published)
+    end
+  end
+
+  let!(:m2) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Second Text', markdown: long_body('Body of the second text'),
+                             status: :published)
+    end
+  end
+
+  let!(:collection) do
+    Chewy.strategy(:atomic) do
+      col = create(:collection, title: 'Readable Collection', collection_type: :volume)
+      create(:collection_item, collection: col, item: m1, seqno: 1)
+      create(:collection_item, collection: col, item: m2, seqno: 2)
+      col
+    end
+  end
+
+  context 'when on a desktop viewport' do
+    before { resize_window(1400, 900) }
+
+    it 'reaches reading mode by clicking the reading-mode button' do
+      visit collection_path(collection)
+      expect(page).to have_css('.work-page-top-icons-desktop .reading-mode-btn-v02', wait: 10)
+
+      find('.work-page-top-icons-desktop .reading-mode-btn-v02').click
+
+      expect(page).to have_current_path(collection_readmode_path(collection), wait: 10)
+      expect(page).to have_css('.reading-mode .rm-control-panel', visible: :visible, wait: 10)
+      expect(page).to have_content('Body of the first text, paragraph 1.')
+      # the site chrome is gone in reading mode
+      expect(page).to have_no_css('header')
+    end
+
+    it 'scrolls to the chosen item and offers a way back to the collection page' do
+      visit collection_readmode_path(collection)
+      expect(page).to have_css('select#collitem', wait: 10)
+
+      find('select#collitem').select('Second Text')
+      expect(wait_until_scrolled(wait: 10)).to be > 0
+
+      find('.rm-control-panel a.collapse-expand-icon').click
+      expect(page).to have_current_path(collection_path(collection), wait: 10)
+    end
+  end
+
+  context 'when on a mobile viewport' do
+    before { resize_window(375, 812) }
+
+    it 'shows a reading-mode icon button that leads to reading mode' do
+      visit collection_path(collection)
+      expect(page).to have_css('.work-page-top-icons-mobile .reading-mode-icon-btn-v02',
+                               visible: :visible, wait: 10)
+
+      find('.work-page-top-icons-mobile .reading-mode-icon-btn-v02').click
+
+      expect(page).to have_current_path(collection_readmode_path(collection), wait: 10)
+      expect(page).to have_css('.reading-mode .rm-control-panel-mobile', visible: :visible, wait: 10)
+    end
+  end
+end

--- a/spec/system/readmode_icon_alignment_spec.rb
+++ b/spec/system/readmode_icon_alignment_spec.rb
@@ -6,22 +6,39 @@ require 'rails_helper'
 # an 18px ben-yehuda glyph inside the 26px box that .by-icon-v02 reserves to
 # avoid layout shift, so the glyph rendered against the top of the button's
 # purple background instead of lining up with the label beside it.
-describe 'Reading mode icon alignment', :js do
+#
+# The icon-only (mobile) button had the same problem on the horizontal axis: the
+# RTL page's inherited text-align:right pinned the 18px glyph to the right edge
+# of its 26px box, 4px off the centre of the purple square. That button now also
+# appears on the collection page, so both pages are covered.
+describe 'Reading mode icon alignment', :js, type: :system do
   let(:manifestation) { create(:manifestation) }
+
+  let(:collection) do
+    Chewy.strategy(:atomic) do
+      col = create(:collection, title: 'Readable Collection', collection_type: :volume)
+      create(:collection_item, collection: col, item: create(:manifestation, status: :published), seqno: 1)
+      create(:collection_item, collection: col, item: create(:manifestation, status: :published), seqno: 2)
+      col
+    end
+  end
 
   before do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
   end
 
-  # Vertical offset, in CSS pixels, between the centre of the glyph's line box
-  # and the centre of the button it sits in. Positive means the glyph is low.
+  after { Chewy.massacre }
+
+  # Offsets, in CSS pixels, between the centre of the glyph's line box and the
+  # centre of the button it sits in. Positive :v means the glyph is low,
+  # positive :h means it is to the right of centre.
   #
-  # The offset must be measured from the glyph's own inline box (via a Range
+  # The offsets must be measured from the glyph's own inline box (via a Range
   # over the span's text), not from the span's border box: the span is a fixed
-  # 26px tall for CLS reasons and is itself centred in the button, so its box
-  # stays centred even while the shorter line box inside it rides up top.
-  def icon_offset_from_button_centre(button_selector)
-    page.evaluate_script(<<~JS)
+  # 26x26 for CLS reasons and is itself centred in the button, so its box stays
+  # centred even while the smaller line box inside it rides up or over.
+  def icon_offsets_from_button_centre(button_selector)
+    page.evaluate_script(<<~JS).symbolize_keys
       (function () {
         var btn = document.querySelector('#{button_selector}');
         var icon = btn.querySelector('.by-icon-v02');
@@ -29,7 +46,10 @@ describe 'Reading mode icon alignment', :js do
         range.selectNodeContents(icon);
         var g = range.getBoundingClientRect();
         var b = btn.getBoundingClientRect();
-        return (g.top + g.height / 2) - (b.top + b.height / 2);
+        return {
+          v: (g.top + g.height / 2) - (b.top + b.height / 2),
+          h: (g.left + g.width / 2) - (b.left + b.width / 2)
+        };
       })()
     JS
   end
@@ -39,18 +59,30 @@ describe 'Reading mode icon alignment', :js do
     visit manifestation_path(manifestation)
 
     expect(page).to have_css('.reading-mode-btn-v02')
-    expect(icon_offset_from_button_centre('.reading-mode-btn-v02').abs).to be < 1.5
+    expect(icon_offsets_from_button_centre('.reading-mode-btn-v02')[:v].abs).to be < 1.5
   end
 
   # The mobile button only exists below the 991px breakpoint -- above it the whole
   # .chapters-and-icons-mobile container is display:none, so this has to narrow the window
   # before visiting. :narrow_viewport buys the Chrome driver, which is the only one that will
   # size below 500px; it does not do the resizing.
-  it 'centres the glyph in the mobile reading-mode icon button', :narrow_viewport do
+  it 'centres the glyph in the work page mobile reading-mode icon button', :narrow_viewport do
     resize_window(390, 844)
     visit manifestation_path(manifestation)
 
     expect(page).to have_css('.reading-mode-icon-btn-v02')
-    expect(icon_offset_from_button_centre('.reading-mode-icon-btn-v02').abs).to be < 1.5
+    offsets = icon_offsets_from_button_centre('.reading-mode-icon-btn-v02')
+    expect(offsets[:v].abs).to be < 1.5
+    expect(offsets[:h].abs).to be < 1.5
+  end
+
+  it 'centres the glyph in the collection page mobile reading-mode icon button', :narrow_viewport do
+    resize_window(390, 844)
+    visit collection_path(collection)
+
+    expect(page).to have_css('.work-page-top-icons-mobile .reading-mode-icon-btn-v02')
+    offsets = icon_offsets_from_button_centre('.work-page-top-icons-mobile .reading-mode-icon-btn-v02')
+    expect(offsets[:v].abs).to be < 1.5
+    expect(offsets[:h].abs).to be < 1.5
   end
 end

--- a/spec/system/readmode_nav_spec.rb
+++ b/spec/system/readmode_nav_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The reading-mode control panel's item navigator (shared/_readmode_nav) used to be a native
+# <select> inside a 210px panel. A <select>'s options cannot wrap in any browser, so long chapter
+# and collection-item titles were clipped. It is now a list of divs in a widened panel.
+describe 'Reading mode navigator', :js, type: :system do
+  let(:long_title) { 'מסע ארוך מאוד אל קצה העולם ובחזרה, פרק ראשון שבו מתגלה סוד' }
+  let(:body) { (['מילה ' * 40] * 30).join("\n\n") }
+
+  let!(:first_text) do
+    Chewy.strategy(:atomic) { create(:manifestation, title: long_title, markdown: body, status: :published) }
+  end
+
+  let!(:second_text) do
+    Chewy.strategy(:atomic) { create(:manifestation, title: 'שיר קצר', markdown: body, status: :published) }
+  end
+
+  let!(:collection) do
+    Chewy.strategy(:atomic) do
+      col = create(:collection, title: 'Readable Collection', collection_type: :volume)
+      create(:collection_item, collection: col, item: first_text, seqno: 1)
+      create(:collection_item, collection: col, item: second_text, seqno: 2)
+      col
+    end
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    resize_window(1400, 900)
+  end
+
+  after { Chewy.massacre }
+
+  def box(selector)
+    page.evaluate_script(<<~JS).symbolize_keys
+      (function () {
+        var r = document.querySelector('#{selector}').getBoundingClientRect();
+        return { left: r.left, right: r.right, top: r.top, width: r.width, height: r.height };
+      })()
+    JS
+  end
+
+  # Left edge of the first paragraph's own text, which is what the fixed control panel would
+  # cover. Measured from a Range so it is the text's extent, not its block's full width.
+  def text_left_edge
+    page.evaluate_script(<<~JS)
+      (function () {
+        var p = document.querySelector('#actualtext p') || document.querySelector('#actualtext');
+        var r = document.createRange();
+        r.selectNodeContents(p);
+        return r.getBoundingClientRect().left;
+      })()
+    JS
+  end
+
+  it 'wraps a long title in the closed control instead of clipping it' do
+    visit collection_readmode_path(collection)
+    expect(page).to have_css('#rm_nav_current')
+
+    expect(page).to have_css('.rm-nav-current-label', text: long_title)
+    # a single line of this font is ~22px; wrapping this title takes several
+    expect(box('#rm_nav_current')[:height]).to be > 40
+  end
+
+  it 'wraps long titles in the open list and keeps the list inside the panel' do
+    visit collection_readmode_path(collection)
+    find('#rm_nav_current').click
+
+    expect(page).to have_css('.rm-nav-list.open')
+    items = page.all('.rm-nav-item')
+    expect(items.map(&:text)).to eq([long_title, 'שיר קצר'])
+
+    long_item = box('.rm-nav-item:first-child')
+    short_item = box('.rm-nav-item:last-child')
+    expect(long_item[:height]).to be > short_item[:height] # i.e. it wrapped rather than clipped
+    expect(long_item[:width]).to be <= box('.rm-control-panel')[:width]
+  end
+
+  it 'scrolls to the item picked from the list and remembers it as current' do
+    visit collection_readmode_path(collection)
+    find('#rm_nav_current').click
+    page.all('.rm-nav-item').last.click
+
+    expect(page).to have_css('.rm-nav-current-label', text: 'שיר קצר')
+    expect(wait_until_scrolled(wait: 10)).to be > 0
+    expect(page).to have_no_css('.rm-nav-list.open') # picking an item closes the list
+  end
+
+  it 'steps between items with the previous/next buttons' do
+    visit collection_readmode_path(collection)
+    expect(page).to have_css('#next_rm_item')
+
+    find('#next_rm_item').click
+    expect(page).to have_css('.rm-nav-current-label', text: 'שיר קצר')
+    expect(wait_until_scrolled(wait: 10)).to be > 0
+
+    find('#prev_rm_item').click
+    expect(page).to have_css('.rm-nav-current-label', text: long_title)
+  end
+
+  it 'keeps the collection text clear of the fixed control panel' do
+    visit collection_readmode_path(collection)
+    expect(page).to have_css('.rm-control-panel', visible: :visible)
+
+    expect(text_left_edge).to be > box('.rm-control-panel')[:right]
+  end
+
+  context 'when reading a work rather than a collection' do
+    let!(:chaptered_work) do
+      Chewy.strategy(:atomic) do
+        create(:manifestation, title: 'יצירה עם פרקים', status: :published,
+                               markdown: "## #{long_title}\n\n#{body}\n\n## פרק שני\n\n#{body}\n")
+      end
+    end
+
+    it 'shows the same navigator over the work chapters, and wraps their titles' do
+      visit manifestation_readmode_path(chaptered_work)
+      expect(page).to have_css('#rm_nav_current')
+
+      expect(page).to have_no_css('select#chapters') # the native select it replaced
+      find('#rm_nav_current').click
+      expect(page).to have_css('.rm-nav-item', count: 2)
+      expect(box('.rm-nav-item:first-child')[:height]).to be > box('.rm-nav-item:last-child')[:height]
+    end
+
+    it 'steps between chapters and keeps the text clear of the control panel' do
+      visit manifestation_readmode_path(chaptered_work)
+      expect(page).to have_css('#next_rm_item')
+
+      expect(text_left_edge).to be > box('.rm-control-panel')[:right]
+
+      find('#next_rm_item').click
+      expect(page).to have_css('.rm-nav-current-label', text: 'פרק שני')
+      expect(wait_until_scrolled(wait: 10)).to be > 0
+    end
+  end
+end


### PR DESCRIPTION
## Problem

On `Collection#show` the full-screen (reading mode) button was a bare
`%button{href: "#"}` — a `<button>` ignores `href`, so it was visible but did
nothing on desktop. On mobile it was missing entirely: the mobile icon row had
no reading-mode control at all. And there was no reading-mode page for a
collection to begin with.

## What changed

**New `Collection#readmode`** (`GET /collections/:collection_id/readmode`),
modelled on `Manifestation#readmode`:

- sets `@readmode`, so the layout drops the site header, footer and left-hand
  cards, and emits `<meta name="robots" content="noindex">`
- fixed desktop control panel: BY logo, exit-to-collection icon, collection
  title and authorities, a table-of-contents selector with prev/next buttons
  that scroll between items, scroll-progress bar, report-a-mistake and share
- mobile control bar with the progress indicator and the exit icon
- ESC returns to the collection page

**Entry points fixed** in `shared/_collection_top`: the desktop button is now
wrapped in a link to the reading mode (with the same tooltip the work page
uses), and the mobile icon row gets the `reading-mode-icon-btn-v02` button that
`Manifestation#read` already has.

**Refactor to avoid duplicating ~70 lines of HAML:** the item cards
`Collection#show` renders are extracted into `collections/_coll_texts`, shared
by `show` and `readmode`. The per-item "effective" authors/translators (those
differing from the collection-level ones) move from an inline `:ruby` block in
the show template into `CollectionsController#set_effective_authorities`, so
both views can use them; this also hoists the collection-authority id lookup
out of the per-item loop. The now-unused `cauthors`/`ceditors`/`ctranslators`
locals at the top of `show.html.haml` are dropped (`ceditors` was already
unused before this change).

The reading-mode JavaScript lives in `app/assets/javascripts/collection_readmode.js`,
guarded by the presence of `#collection-readmode`, with the collection URL and
the two alert strings passed in as data attributes.

New I18n keys: `no_next_item`, `no_prev_item` (he + en).

## Test plan

New specs:

- `spec/requests/collection_readmode_spec.rb` — the page renders the texts with
  no header/footer, is noindex, offers the way back, lists items in the
  selector, is reachable anonymously; and both buttons on `Collection#show`
  point at the reading mode.
- `spec/system/collection_reading_mode_spec.rb` (`js: true`) — clicking the
  desktop button navigates to reading mode; the item selector scrolls and the
  exit icon returns to the collection; at 375×812 the mobile icon button is
  visible and leads to reading mode.

A `wait_until_scrolled` helper was added to the existing
`spec/support/system_spec_helpers.rb` (Capybara `synchronize`-based polling, no
`sleep`) rather than hand-rolling one in the spec file.

Ran green (175 examples, 0 failures, 9 pre-existing scaffold pendings):

```
spec/requests/collection_readmode_spec.rb
spec/system/collection_reading_mode_spec.rb
spec/controllers/collections_controller_spec.rb
spec/requests/{collection_show_ip_status,collection_lex_citations,periodicals,collection_items}_spec.rb
spec/system/{collection_show_authorities,collection_show_orig_lang,collection_volume_series_nav,
             collection_toc_navbar_width,collection_selective_download_print,periodical_toc_display,
             toc_paratext_collapse,periodical_navbar_prefix,collection_image_alignment,download_modal,
             manifestation_breadcrumbs,tag_policy_modal,external_link_proposal,pby_volumes,
             collection_involved_authority_ui_update}_spec.rb
```

**The full suite was not run** (40+ minutes; per `.claude/rules/full-test-suite-runtime.md`
that needs explicit approval). CI will cover it.

Closes bd `by-v1k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: mobile glyph centring and a wrappable navigator

**Mobile reading-mode icon was 4px off centre.** `.by-icon-v02` reserves a 26px-wide
box for CLS while the ben-yehuda font loads; the glyph's own inline box is 18px, and
the RTL page's inherited `text-align: right` pinned it to the box's right edge, so it
sat 4px right of the purple square's centre. Measured at `+4.0` on both the collection
and the work page. `text-align: center` on the icon-only button fixes it — the
horizontal half of what e216e13a0 did on the vertical axis. The desktop button is
deliberately left alone: there the glyph sits in a row beside its label, and centring
it inside its box would only open a gap.

**The readmode chapter/item dropdown could not wrap.** It was a native `<select>` in a
210px panel, and a `<select>`'s options do not wrap in any browser, so long titles were
clipped. It is now `shared/_readmode_nav` — a list of divs in the site's existing
`.by-dropdown-content-v02` idiom, driven by `readmode_nav.js` — shared by
`Manifestation#readmode` and `Collection#readmode`. The panel goes to 280px (240px
below 1280px, where there is less room) and is pinned 10px from the viewport edge
instead of 7.5%. The native `#chapters` select and its ~60 lines of inline JS in
`manifestation/readmode.html.haml` are gone, along with the now-dead `#chapters` rule
in `application.scss`. The hardcoded `פרק:` label became a new `chapter` I18n key.

**A layout bug this surfaced:** `Collection#readmode` renders the plain item cards of
`Collection#show`, which lack the 25%-wide decorative `.work-side-color` strip that
keeps the work page's text clear of the fixed panel — so the collection's text ran
under the panel (measured 198px of overlap at 1400px, and it predates this follow-up).
`#collection-readmode .text-page-content` now reserves the panel's footprint. Measured
clearance between the panel's right edge and the first paragraph's text, after the
change:

| viewport | Collection#readmode | Manifestation#readmode |
| --- | --- | --- |
| 1920 | +256 | +330 |
| 1400 | +227 | +154 |
| 1100 | +98 | +61 |
| 1000 | +72 | +35 |

No horizontal overflow at any of those widths.

### Tests

- `spec/system/readmode_nav_spec.rb` (new) — the long title wraps in the closed control
  and in the open list rather than being clipped; the list stays inside the panel;
  picking an item scrolls to it, marks it current and closes the list; prev/next step
  between items; the text clears the fixed panel. Covered for both readmode pages.
- `spec/system/readmode_icon_alignment_spec.rb` (extended) — now measures the horizontal
  offset as well as the vertical, on both the work page's and the collection page's
  mobile button.
- `spec/system/collection_reading_mode_spec.rb`, `spec/requests/collection_readmode_spec.rb`
  updated for the new markup.

Ran green: the four specs above plus `spec/controllers/manifestations_controller_spec.rb`
and `spec/requests/noindex_meta_tags_spec.rb` — 141 examples, 0 failures. Full suite
still not run (needs your approval).
