### PR TITLE
Show sub-collection subtitles and images in Collection#show

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2272,3 +2272,11 @@ p.by-genre-name-v02.headline-2-v02 {
     }
   }
 }
+
+// a sub-collection's own image, shown under its heading in Collection#show
+.subcollection-cover-image {
+  display: block;
+  max-width: 200px;
+  height: auto;
+  margin-top: 10px;
+}

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -726,8 +726,24 @@ class CollectionsController < ApplicationController
     else
       build_htmls_recursively(@collection.collection_items, parent_authorities, 0, counter)
     end
+    preload_sub_collection_images
     set_effective_authorities
     set_collection_metadata
+  end
+
+  # Sub-collection headings show the sub-collection's own image, so load all those attachments in
+  # one go rather than a query per sub-collection.
+  def preload_sub_collection_images
+    sub_collections = @htmls.filter_map do |entry|
+      ci = entry[6] # the CollectionItem of the tuples built above
+      ci.item if ci.item_type == 'Collection' && ci.item.present?
+    end
+    return if sub_collections.empty?
+
+    ActiveRecord::Associations::Preloader.new(
+      records: sub_collections,
+      associations: [{ cover_image_attachment: :blob }, { logo_image_attachment: :blob }]
+    ).call
   end
 
   # Per-item authors and translators worth naming next to an item's title, i.e. those that differ

--- a/app/views/collections/_coll_texts.html.haml
+++ b/app/views/collections/_coll_texts.html.haml
@@ -10,6 +10,7 @@
       This is a sub-collection header, rendered with full detail. Its anchor is stable (keyed by
       sub-collection id) so search results and deep links can jump here.
     %a{ name: "collection_#{ci.item_id}" }
+    - sub_collection = ci.item
     .by-card-v02.proofable{ card_attrs }
       .by-card-header-v02
         .by-icon-v02
@@ -18,10 +19,13 @@
           - link = collapsed_text.present? ? url_for(collapsed_text) : url_for_collection_item(ci)
           - glyph_genre = collapsed_text.present? ? collapsed_text.genre : genre
           %span.by-icon-v02{ title: textify_genre(glyph_genre) }= glyph_for_genre(glyph_genre)
+          -# RLM character to help with LTR elements in title. Fixes #664
+          - heading = '‏' + title
+          - heading += ": #{sub_collection.subtitle}" if sub_collection&.subtitle.present?
           - if link.present?
-            = link_to '‏' + title, link # RLM character to help with LTR elements in title. Fixes #664
+            = link_to heading, link
           - else
-            = '‏' + title # RLM character to help with LTR elements in title. Fixes #664
+            = heading
           - if title_footnote.present?
             != ' ' + title_footnote
         -# Show all authorities with their roles (already filtered)
@@ -40,6 +44,11 @@
           %p
             = t(:translated_by)
             != translators.map { |a| authority_link(a) }.join(', ')
+        -# the sub-collection's own image, under the heading and above the header's bottom rule
+        - cover = sub_collection&.cover_image&.attached? ? sub_collection.cover_image : sub_collection&.logo_image
+        - if cover&.attached?
+          - src = cover.variable? ? cover.variant(resize_to_fit: [200, nil]) : cover
+          %img.subcollection-cover-image{ src: url_for(src), alt: title }
   - else
     -# This is a manifestation or other content item
     .by-card-v02.proofable{ card_attrs }

--- a/spec/requests/collection_sub_collection_display_spec.rb
+++ b/spec/requests/collection_sub_collection_display_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe 'Collection show - sub-collection headings', type: :request do
     expect(header.at_css('img.subcollection-cover-image')).to be_nil
   end
 
+  it 'loads the sub-collection images without a query per sub-collection' do
+    attach_cover(sub_collection)
+    one_sub = count_queries_matching(/active_storage/) { get collection_path(parent_collection) }
+
+    parent_of_many = Chewy.strategy(:atomic) do
+      subs = create_list(:collection, 3, collection_type: :volume,
+                                         manifestations: create_list(:manifestation, 2, status: :published))
+      subs.each { |sub| attach_cover(sub) }
+      create(:collection, collection_type: :other, included_collections: subs)
+    end
+    many_subs = count_queries_matching(/active_storage/) { get collection_path(parent_of_many) }
+
+    expect(many_subs).to eq(one_sub)
+  end
+
   context 'when the sub-collection has no subtitle' do
     let(:sub_collection) do
       Chewy.strategy(:atomic) do

--- a/spec/requests/collection_sub_collection_display_spec.rb
+++ b/spec/requests/collection_sub_collection_display_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Collection show - sub-collection headings', type: :request do
+  after { Chewy.massacre }
+
+  let(:sub_collection) do
+    Chewy.strategy(:atomic) do
+      create(:collection, title: 'Sub Collection', subtitle: 'The Subtitle', collection_type: :volume,
+                          manifestations: create_list(:manifestation, 2, status: :published))
+    end
+  end
+
+  let(:parent_collection) do
+    Chewy.strategy(:atomic) do
+      create(:collection, title: 'Parent Collection', collection_type: :other,
+                          included_collections: [sub_collection])
+    end
+  end
+
+  def attach_cover(collection)
+    collection.cover_image.attach(io: StringIO.new(Rails.root.join('spec/fixtures/files/test_image.jpg').binread),
+                                  filename: 'cover.jpg', content_type: 'image/jpeg')
+  end
+
+  # The header of the sub-collection's own card, i.e. the block ending at the horizontal rule
+  def sub_collection_header(html)
+    Nokogiri::HTML(html).at_css("a[name='collection_#{sub_collection.id}'] + .by-card-v02 .by-card-header-v02")
+  end
+
+  it "shows the sub-collection's subtitle right after its title" do
+    get collection_path(parent_collection)
+    header = sub_collection_header(response.body)
+    expect(header).to be_present
+    expect(header.at_css('.headline-1-v02').text).to include('Sub Collection: The Subtitle')
+  end
+
+  it "shows the sub-collection's image inside the header, above the horizontal rule" do
+    attach_cover(sub_collection)
+    get collection_path(parent_collection)
+    header = sub_collection_header(response.body)
+    expect(header.at_css('img.subcollection-cover-image')).to be_present
+  end
+
+  it 'shows no image when the sub-collection has none attached' do
+    get collection_path(parent_collection)
+    header = sub_collection_header(response.body)
+    expect(header.at_css('img.subcollection-cover-image')).to be_nil
+  end
+
+  context 'when the sub-collection has no subtitle' do
+    let(:sub_collection) do
+      Chewy.strategy(:atomic) do
+        create(:collection, title: 'Bare Collection', subtitle: nil, collection_type: :volume,
+                            manifestations: create_list(:manifestation, 2, status: :published))
+      end
+    end
+
+    it 'shows the title without a trailing colon' do
+      get collection_path(parent_collection)
+      header = sub_collection_header(response.body)
+      expect(header.at_css('.headline-1-v02').text).to include('Bare Collection')
+      expect(header.at_css('.headline-1-v02').text).not_to include('Bare Collection:')
+    end
+  end
+end

--- a/spec/support/query_count_helpers.rb
+++ b/spec/support/query_count_helpers.rb
@@ -5,8 +5,18 @@
 # neither reaches the database on a warm connection.
 module QueryCountHelpers
   def count_queries(&)
+    count_queries_matching(//, &)
+  end
+
+  # As count_queries, but counting only the queries whose SQL matches the given pattern, e.g. to
+  # guard a single table against N+1 without being sensitive to unrelated queries on the page.
+  def count_queries_matching(pattern, &)
     count = 0
-    counter = ->(*, payload) { count += 1 unless payload[:cached] || payload[:name] == 'SCHEMA' }
+    counter = lambda do |*, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      count += 1 if payload[:sql].match?(pattern)
+    end
     ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &)
     count
   end


### PR DESCRIPTION
## What

In `Collection#show`, sub-collection headings now show:

- **Subtitle** appended right after the title, separated by `': '` (part of the heading link, matching how parent-collection links already render `Title: Subtitle` in `show.html.haml`).
- **Image** rendered at the end of the card header — under the heading, above the header's bottom rule (`.by-card-header-v02`'s `border-bottom`). Uses `cover_image` when attached, falling back to `logo_image` (periodicals). A 200px-wide variant is used when the blob is variable.

## Notes

- `_coll_texts.html.haml` is shared with `Collection#readmode`, so reading mode gets the same treatment. That seemed consistent rather than surprising; say the word if reading mode should stay bare.
- New CSS class `.subcollection-cover-image` added to `application.scss` (BY_*.css untouched).
- The image lookup adds one attachment query per sub-collection on show; sub-collection covers are not preloaded in `prep_for_show` (only periodical issues are).

## Test plan

New request spec `spec/requests/collection_sub_collection_display_spec.rb` (4 examples, all passing):
- subtitle appears right after the title in the sub-collection card header
- image renders inside the header when a cover is attached
- no image element when nothing is attached
- no stray colon when the sub-collection has no subtitle

Also re-ran, all green:
`spec/requests/collection_show_ip_status_spec.rb`, `spec/requests/periodicals_spec.rb`, `spec/system/collection_reading_mode_spec.rb`, `spec/system/collection_show_authorities_spec.rb`, `spec/system/collection_show_orig_lang_spec.rb`, `spec/system/collection_selective_download_print_spec.rb`, `spec/controllers/collections_controller_spec.rb`, `spec/system/collection_volume_series_nav_spec.rb`, `spec/system/collection_toc_navbar_width_spec.rb`, `spec/system/collection_image_alignment_spec.rb` — 123 examples, 0 failures.

The full suite (40+ min) was **not** run; it needs your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
