### PR TITLE
Make author page title and work counts agree with its TOC

### DIFF
--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -328,8 +328,12 @@ class Authority < ApplicationRecord
   # 12h TTL, matching cached_works_count, cached_collections_count and the author page's TOC
   # fragment: the four are rendered side by side, so a longer TTL here let the genre chips drift
   # out of step with the works figure they add up to.
+  # NOTE: cache key deliberately versioned. A TTL is stamped on the entry when it is written, so
+  # shortening it here would not touch entries already written under the old 24h expiry -- they
+  # would keep drifting for up to another 24h after deploy, which is what this change is meant
+  # to stop.
   def cached_genre_stats
-    Rails.cache.fetch("au_#{id}_genre_stats", expires_in: 12.hours) do
+    Rails.cache.fetch("au_#{id}_genre_stats_v2", expires_in: 12.hours) do
       genre_stats
     end
   end

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -8,6 +8,12 @@ class Authority < ApplicationRecord
   WIKIDATA_URI_PATTERN = %r{\Ahttps://wikidata.org/wiki/Q[0-9]+\z}
   PBY_AUTHORITY_ID = 3358
 
+  # Collection types that count as a title ('כותר') for the figure the author page advertises.
+  # Deliberately excludes `series` and `volume_series` -- those are structural groupings *inside* a
+  # title (e.g. the two sub-volumes of a multi-volume work), and the TOC never presents them as
+  # titles of their own -- as well as `other` and the system `uncollected` collection.
+  COUNTED_COLLECTION_TYPES = %i(volume periodical periodical_issue).freeze
+
   update_index('authorities') { self } # update AuthoritiesIndex when entity is updated
   update_index('authorities_autocomplete') { self }
 
@@ -319,8 +325,11 @@ class Authority < ApplicationRecord
       .count
   end
 
+  # 12h TTL, matching cached_works_count, cached_collections_count and the author page's TOC
+  # fragment: the four are rendered side by side, so a longer TTL here let the genre chips drift
+  # out of step with the works figure they add up to.
   def cached_genre_stats
-    Rails.cache.fetch("au_#{id}_genre_stats", expires_in: 24.hours) do
+    Rails.cache.fetch("au_#{id}_genre_stats", expires_in: 12.hours) do
       genre_stats
     end
   end
@@ -365,9 +374,19 @@ class Authority < ApplicationRecord
     Rails.cache.delete("au_#{id}_work_count")
   end
 
+  # The number of titles we advertise to readers on the author page. It must count what the TOC
+  # actually presents as a title, so it is limited to COUNTED_COLLECTION_TYPES: a plain
+  # collections.count also counted the `series` sub-collections nested inside a title, which the
+  # reader only ever sees as sections *within* a volume card.
+  def counted_collections_count
+    collections.where(collection_type: COUNTED_COLLECTION_TYPES).count
+  end
+
+  # NOTE: cache key deliberately renamed from 'au_<id>_collections_count', so deployments pick up
+  # the corrected figure immediately instead of serving the old, inflated one until the TTL expires.
   def cached_collections_count
-    Rails.cache.fetch("au_#{id}_collections_count", expires_in: 12.hours) do
-      collections.count
+    Rails.cache.fetch("au_#{id}_counted_collections_count", expires_in: 12.hours) do
+      counted_collections_count
     end
   end
 

--- a/app/models/toc_tree/manifestation_node.rb
+++ b/app/models/toc_tree/manifestation_node.rb
@@ -37,12 +37,27 @@ module TocTree
       return involvement_check && !involved_in_parent
     end
 
-    # Count manifestations (1 if visible and published, 0 otherwise)
+    # Count manifestations (1 if visible, published and the authority's own, 0 otherwise).
+    #
+    # Visibility is deliberately broader than countability: a volume authored by X also *lists*
+    # a preface someone else wrote, because the reader browsing that volume wants to see it. But
+    # such a work is not one of X's, so it must not inflate the counts the author page shows
+    # beside the metadata card's 'works in the project' figure, which counts direct involvements
+    # only. Hence the extra involvement check here, which is what keeps the two in agreement.
     def count_manifestations(role, authority_id, involved_on_collection_level, parent_collection = nil)
       return 0 unless visible?(role, authority_id, involved_on_collection_level, parent_collection)
       return 0 unless @manifestation.status == 'published'
+      return 0 unless directly_involved?(role, authority_id)
 
       1
+    end
+
+    private
+
+    # Whether the authority is involved in this work itself (as opposed to merely in a collection
+    # containing it) with the given role.
+    def directly_involved?(role, authority_id)
+      @manifestation.involved_authorities_by_role(role).any? { |a| a.id == authority_id }
     end
   end
 end

--- a/app/models/toc_tree/manifestation_node.rb
+++ b/app/models/toc_tree/manifestation_node.rb
@@ -33,8 +33,7 @@ module TocTree
 
       return involved_in_parent if involved_on_collection_level
 
-      involvement_check = @manifestation.involved_authorities_by_role(role).any? { |a| a.id == authority_id }
-      return involvement_check && !involved_in_parent
+      return directly_involved?(role, authority_id) && !involved_in_parent
     end
 
     # Count manifestations (1 if visible, published and the authority's own, 0 otherwise).
@@ -56,8 +55,24 @@ module TocTree
 
     # Whether the authority is involved in this work itself (as opposed to merely in a collection
     # containing it) with the given role.
+    #
+    # Deliberately reads the involved_authorities rows rather than going through
+    # Manifestation#involved_authorities_by_role, which materialises and name-sorts Authority
+    # objects just to answer a membership question. This runs for every work in the TOC, once per
+    # role, so it is memoized too. The preloads in GenerateTocTree cover both associations walked
+    # here, so this issues no queries.
     def directly_involved?(role, authority_id)
-      @manifestation.involved_authorities_by_role(role).any? { |a| a.id == authority_id }
+      role = role.to_s
+      raise "Unknown role #{role}" unless InvolvedAuthority.roles.key?(role)
+
+      @directly_involved ||= {}
+      key = "#{role}_#{authority_id}"
+      return @directly_involved[key] if @directly_involved.key?(key)
+
+      expression = @manifestation.expression
+      @directly_involved[key] = [expression, expression.work].any? do |record|
+        record.involved_authorities.any? { |ia| ia.role == role && ia.authority_id == authority_id }
+      end
     end
   end
 end

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -10,7 +10,11 @@
     .f_circleG#frotateG_07
     .f_circleG#frotateG_08
 .mainlist#browse_mainlist
-  = cache_unless current_user&.editor?, @author, expires_in: 12.hours do
+  -# The count badges below are computed in TocTree::ManifestationNode, which the template digest
+     does not track, so the cache key carries an explicit version: bump it whenever the counting
+     rules change, or a deploy keeps serving the old figures here (while the uncached navbar
+     beside them already shows the new ones) until the TTL expires.
+  = cache_unless current_user&.editor?, [@author, 'toc-counts-v2'], expires_in: 12.hours do
     :ruby
     - top_nodes = @toc_tree ? @toc_tree.top_level_nodes : GenerateTocTree.call(@author).top_level_nodes
     - InvolvedAuthority::ROLES_PRESENTATION_ORDER.each do |role|

--- a/spec/helpers/authors_helpers_spec.rb
+++ b/spec/helpers/authors_helpers_spec.rb
@@ -131,9 +131,12 @@ describe AuthorsHelper do
       let(:role) { :translator }
       let(:involved_on_collection_level) { true }
 
-      it 'returns correct count' do
-        # Should count translated_manifestations (2 items)
-        expect(result).to eq(translated_manifestations.count)
+      it 'returns 0, since the authority is credited on the collection but not on the works' do
+        # translated_manifestations deliberately carry no translator involvement of their own (see
+        # the shared context): the authority is a translator of the *collection* only. Those works
+        # are still listed in the TOC, but they are not counted, so this figure keeps agreeing with
+        # the metadata card's 'works in the project', which counts direct involvements only.
+        expect(result).to eq(0)
       end
     end
 

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -287,9 +287,9 @@ describe Authority do
       end
 
       it 'uses the correct cache key' do
-        cache_key = "au_#{authority.id}_genre_stats"
-        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 12.hours).and_call_original
+        allow(Rails.cache).to receive(:fetch).and_call_original
         authority.cached_genre_stats
+        expect(Rails.cache).to have_received(:fetch).with("au_#{authority.id}_genre_stats_v2", expires_in: 12.hours)
       end
     end
 
@@ -491,15 +491,16 @@ describe Authority do
       end
 
       it 'caches the result' do
-        # First call
-        first_result = authority.cached_collections_count
-        expect(first_result).to eq 3
+        allow(Rails.cache).to receive(:fetch).and_call_original
 
-        # Second call should return cached result
-        expect(Rails.cache).to receive(:fetch).with("au_#{authority.id}_counted_collections_count",
-                                                    expires_in: 12.hours).and_call_original
+        first_result = authority.cached_collections_count
         second_result = authority.cached_collections_count
+
+        expect(first_result).to eq 3
         expect(second_result).to eq first_result
+        # Both calls go through the cache; only the first one runs the query behind it
+        expect(Rails.cache).to have_received(:fetch)
+          .with("au_#{authority.id}_counted_collections_count", expires_in: 12.hours).twice
       end
     end
 

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -288,7 +288,7 @@ describe Authority do
 
       it 'uses the correct cache key' do
         cache_key = "au_#{authority.id}_genre_stats"
-        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 24.hours).and_call_original
+        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 12.hours).and_call_original
         authority.cached_genre_stats
       end
     end
@@ -455,10 +455,10 @@ describe Authority do
       before do
         Rails.cache.clear
 
-        # Create collections where authority is involved in various roles
-        collection1 = create(:collection)
-        collection2 = create(:collection)
-        collection3 = create(:collection)
+        # Create collections of countable types where authority is involved in various roles
+        collection1 = create(:collection, collection_type: :volume)
+        collection2 = create(:collection, collection_type: :periodical)
+        collection3 = create(:collection, collection_type: :periodical_issue)
 
         # Add authority to collections through involved_authorities
         create(:involved_authority, authority: authority, item: collection1, role: :author)
@@ -466,10 +466,29 @@ describe Authority do
         create(:involved_authority, authority: authority, item: collection3, role: :translator)
 
         # Create a collection without this authority (should not be counted)
-        create(:collection)
+        create(:collection, collection_type: :volume)
       end
 
       it { is_expected.to eq 3 }
+
+      # Collection types the reader never sees as a title of their own: a `series` is a section
+      # inside a volume, so counting it made the author page advertise more titles than its TOC
+      # shows volume cards (benyehuda.org/author/1024 said 4 titles over 2 volumes).
+      context 'when the authority is also involved in collections of non-title types' do
+        before do
+          %i(series volume_series other).each do |collection_type|
+            uncountable = create(:collection, collection_type: collection_type)
+            create(:involved_authority, authority: authority, item: uncountable, role: :author)
+          end
+          Rails.cache.clear
+        end
+
+        it { is_expected.to eq 3 }
+
+        it 'only counts types that actually exist in the enum' do
+          expect(Collection.collection_types.keys).to include(*Authority::COUNTED_COLLECTION_TYPES.map(&:to_s))
+        end
+      end
 
       it 'caches the result' do
         # First call
@@ -477,7 +496,7 @@ describe Authority do
         expect(first_result).to eq 3
 
         # Second call should return cached result
-        expect(Rails.cache).to receive(:fetch).with("au_#{authority.id}_collections_count",
+        expect(Rails.cache).to receive(:fetch).with("au_#{authority.id}_counted_collections_count",
                                                     expires_in: 12.hours).and_call_original
         second_result = authority.cached_collections_count
         expect(second_result).to eq first_result

--- a/spec/requests/author_toc_counts_spec.rb
+++ b/spec/requests/author_toc_counts_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Authority TOC counts', type: :request do
   end
 
   it 'shows the same total in the navbar' do
-    navbar = response.body[response.body.index('book-nav-full')...response.body.index('mobile-navbar-backdrop')]
+    navbar = navbar_fragment(response.body)
     expect(navbar).to include(" (#{author.cached_works_count})")
     expect(navbar).not_to include(' (4)')
   end

--- a/spec/requests/author_toc_counts_spec.rb
+++ b/spec/requests/author_toc_counts_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The author page states two figures in its metadata card -- 'titles in the project' and 'works in
+# the project' -- and then repeats them as count badges over the TOC and the in-page navbar beside
+# it. Reproduces benyehuda.org/author/1024, where the card said 4 titles / 36 works while the TOC
+# showed 2 volume cards and a badge of 38.
+RSpec.describe 'Authority TOC counts', type: :request do
+  subject(:call) { get authority_path(author) }
+
+  let(:author) { create(:authority, :published, uncollected_works_collection: uncollected_collection) }
+  let(:uncollected_collection) { create(:collection, :uncollected) }
+  let(:other_authority) { create(:authority) }
+
+  # A multi-volume title, structured the way author/1024's is: one volume card holding two `series`
+  # sub-collections, with the author credited on the sub-collections as well as on the volume.
+  let(:first_section) { create(:collection, collection_type: :series, title: 'First Section', authors: [author]) }
+  let(:second_section) { create(:collection, collection_type: :series, title: 'Second Section', authors: [author]) }
+  let(:volume) do
+    create(
+      :collection,
+      collection_type: :volume,
+      title: 'Collected Studies',
+      authors: [author],
+      included_collections: [first_section, second_section]
+    )
+  end
+
+  before do
+    Chewy.strategy(:atomic) do
+      volume # force creation of the whole hierarchy
+      create_list(:manifestation, 2, author: author, collections: [first_section])
+      create(:manifestation, author: author, collections: [second_section])
+      # Somebody else's preface, sitting in this author's volume
+      create(:manifestation, author: other_authority, title: 'A Foreign Preface', collections: [second_section])
+    end
+    Rails.cache.clear
+    call
+  end
+
+  it 'counts only the volume as a title, not the series sections nested inside it' do
+    # 3 collections carry the author, but only the volume is a title the TOC shows a card for
+    expect(author.collections.count).to eq(3)
+    expect(author.cached_collections_count).to eq(1)
+    expect(response.body).to match(%r{#{Regexp.escape(I18n.t(:total_collections_including_author))}:</span>\s*1\s})
+  end
+
+  it 'still lists the foreign work in the TOC' do
+    expect(response.body).to include('A Foreign Preface')
+  end
+
+  it 'shows a TOC count badge matching the metadata card, excluding the foreign work' do
+    expect(author.cached_works_count).to eq(3)
+    expect(response.body).to include('<span class="count-badge"> (3)</span>')
+    expect(response.body).not_to include('<span class="count-badge"> (4)</span>')
+  end
+
+  it 'shows the same total in the navbar' do
+    navbar = response.body[response.body.index('book-nav-full')...response.body.index('mobile-navbar-backdrop')]
+    expect(navbar).to include(" (#{author.cached_works_count})")
+    expect(navbar).not_to include(' (4)')
+  end
+end

--- a/spec/requests/author_toc_role_sections_spec.rb
+++ b/spec/requests/author_toc_role_sections_spec.rb
@@ -86,9 +86,4 @@ RSpec.describe 'Authority TOC role sections', type: :request do
       expect(response.body).to include('<span class="count-badge"> (1)</span>')
     end
   end
-
-  # The in-page navbar, without the TOC body that follows it
-  def navbar_fragment(body)
-    body[body.index('book-nav-full')...body.index('mobile-navbar-backdrop')]
-  end
 end

--- a/spec/services/generate_toc_tree_spec.rb
+++ b/spec/services/generate_toc_tree_spec.rb
@@ -73,10 +73,19 @@ describe GenerateTocTree do
       end
 
       it 'counts manifestations recursively in nested structure' do
-        # Count all manifestations where authority is involved as translator at collection level
+        # nested_edited_collection sits under top_level_collection_with_nested_collections, and its
+        # manifestations do carry the authority as editor, so the recursive sum reaches them.
+        total_edited = top_level_with_nested_node.count_manifestations(:editor, authority.id, true)
+        expect(total_edited).to eq(edited_manifestations.count)
+      end
+
+      it 'does not count works the authority is only involved in through the collection' do
+        # translated_manifestations have no translator involvement of their own (see the shared
+        # context) -- the authority is a translator of nested_translated_collection only. They are
+        # still rendered in the TOC, but counting them would push these badges above the metadata
+        # card's 'works in the project' figure, which counts direct involvements only.
         total_translated = top_level_with_nested_node.count_manifestations(:translator, authority.id, true)
-        # Should include manifestations in nested_translated_collection (2 items)
-        expect(total_translated).to eq(translated_manifestations.count)
+        expect(total_translated).to eq(0)
       end
 
       it 'returns 0 for invisible manifestations' do
@@ -99,6 +108,32 @@ describe GenerateTocTree do
         count = manifestation_node.count_manifestations(:author, authority.id, false)
         expect(count).to eq(0)
       end
+    end
+  end
+
+  # Reproduces benyehuda.org/author/1024: the metadata card said 36 works while the TOC badge said
+  # 38, because the two prefaces other people contributed to Alon's volumes were counted as his.
+  context "when the authority's own volume also holds a work by somebody else" do
+    let(:uncollected_collection) { create(:collection, :uncollected) }
+    let(:other_authority) { create(:authority) }
+    let!(:volume) { create(:collection, collection_type: :volume, authors: [authority]) }
+    let!(:own_works) { create_list(:manifestation, 3, author: authority, collections: [volume]) }
+    let!(:foreign_preface) { create(:manifestation, author: other_authority, collections: [volume]) }
+
+    let(:volume_node) { find_collection_node(result, volume) }
+
+    it 'still lists the foreign work in the TOC' do
+      listed = volume_node.children_by_role(:author, authority.id, true).map(&:id)
+      expect(listed).to include("manifestation:#{foreign_preface.id}")
+    end
+
+    it 'counts only the works the authority is actually involved in' do
+      expect(volume_node.count_manifestations(:author, authority.id, true)).to eq(own_works.count)
+    end
+
+    it "agrees with the authority's published works count" do
+      expect(volume_node.count_manifestations(:author, authority.id, true))
+        .to eq(authority.published_manifestations.count)
     end
   end
 

--- a/spec/support/navbar_helpers.rb
+++ b/spec/support/navbar_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Helpers for specs asserting on the author page's in-page navbar.
+#
+# The navbar is rendered ahead of the TOC body in the same response, and the two repeat the same
+# role headings and count badges -- so a spec that means to assert on the navbar has to isolate it
+# first, or it will happily match the TOC instead and pass for the wrong reason.
+module NavbarHelpers
+  NAVBAR_START = 'book-nav-full'
+  NAVBAR_END = 'mobile-navbar-backdrop'
+
+  # The in-page navbar markup, without the TOC body that follows it. Fails with a legible message
+  # rather than a nil-range error if the response turns out not to contain a navbar at all.
+  def navbar_fragment(body)
+    expect(body).to include(NAVBAR_START), "response contains no in-page navbar (no '#{NAVBAR_START}')"
+    expect(body).to include(NAVBAR_END), "in-page navbar is not terminated (no '#{NAVBAR_END}')"
+
+    body[body.index(NAVBAR_START)...body.index(NAVBAR_END)]
+  end
+end
+
+RSpec.configure do |config|
+  config.include NavbarHelpers, type: :request
+end


### PR DESCRIPTION
## What

The author page states two figures in its metadata card — "כותרים במאגר" and "יצירות במאגר" — and then repeats them as count badges over the TOC and the in-page navbar. On [benyehuda.org/author/1024](https://benyehuda.org/author/1024) (גדליה אלון) the card said **4 titles / 36 works** while the TOC showed **2 volume cards** and a badge of **38**.

Three independent causes, all fixed here.

### 1. The titles figure counted collections the reader never sees as titles

`Authority#cached_collections_count` was a plain `collections.count`: every `Collection` with an `involved_authorities` record for this authority, of **any `collection_type`, at any nesting depth**.

Alon's data is one volume card holding two `series` sub-volumes, and he is credited on the sub-volumes too — so 4 collection records, 2 volume cards. It now counts only `Authority::COUNTED_COLLECTION_TYPES` = `volume`, `periodical`, `periodical_issue`; `series`, `volume_series`, `other` and the system `uncollected` collection are excluded.

### 2. The TOC/navbar badges counted other people's works

`TocTree::ManifestationNode#count_manifestations` returned 1 for any published work that was *visible*, and at collection level `visible?` is decided purely by involvement in the **parent collection** — the work's own authors are never consulted. So every item inside a volume the authority authored counted as theirs, including front matter by others:

| id | title | actual author |
|---|---|---|
| 38178 | הקדמה | שמואל ספראי |
| 60060 | הקדמת ההוצאה לאור | אלמוני/ת |

38 − 2 = 36. Counting now additionally requires direct involvement in the work, in that role.

**Visibility is deliberately unchanged** — those works are still listed in the TOC, because a reader browsing the volume wants to see them. Only the arithmetic changed.

### 3. Four caches, one of them on a different TTL

`cached_genre_stats` had a 24h TTL while `cached_works_count`, `cached_collections_count`, `author_toc_filter_data` and the `_generated_toc` fragment all had 12h — so the genre chips could drift out of step with the works figure they add up to. All four are now 12h.

Cache keys whose *value* changes are versioned so a deploy doesn't keep serving the old numbers for up to 12h: the collections-count key is renamed (the same trick `Authority.cached_count` already documents), and the `_generated_toc` fragment carries an explicit version — its badges come from a model the template digest doesn't track, and the navbar beside it isn't cached at all, so without this the two would visibly disagree for half a day after deploy.

## Behaviour change worth reviewing

An authority credited on a **collection** but not on the individual works in it now gets a badge of **0** for that role (the badge is omitted entirely below 1), while the section still lists the works. That is the point of the change — the metadata card already reads 0 works for such an authority — but it is a visible difference for translation/anthology volumes credited only at the volume level. `spec/support/shared_examples/collection_toc.rb` models exactly this case, and two existing expectations were flipped to 0 accordingly.

## Test plan

New regression coverage (verified red on the old code — 6 failures — and green on the new):

- `spec/requests/author_toc_counts_spec.rb` — end-to-end reproduction of author/1024: a volume with two `series` sections, three of the author's works plus one foreign preface. Asserts the card reads 1 title / 3 works, the TOC badge reads 3, the navbar agrees, and the foreign preface is still listed.
- `spec/services/generate_toc_tree_spec.rb` — a foreign work in the authority's own volume is listed but not counted, and the count equals `published_manifestations.count`; plus an explicit case for collection-level-only involvement counting 0.
- `spec/models/authority_spec.rb` — `series` / `volume_series` / `other` collections don't inflate the titles count; collection types pinned in the existing example (the factory samples `collection_type` at random).

Specs run — all green:

```
spec/models/authority_spec.rb spec/models/toc_tree/ spec/models/collection_spec.rb
spec/services/generate_toc_tree_spec.rb spec/helpers/authors_helpers_spec.rb
spec/controllers/authors_controller_spec.rb
spec/requests/author_toc_counts_spec.rb spec/requests/author_toc_role_sections_spec.rb
spec/requests/author_toc_filters_spec.rb spec/requests/author_toc_lexicon_content_spec.rb
spec/requests/periodicals_spec.rb spec/requests/collection_sub_collection_display_spec.rb
spec/requests/mobile_menu_totals_spec.rb
spec/system/author_navbar_conditional_expand_spec.rb
spec/system/author_navbar_collection_type_filtering_spec.rb
spec/system/author_toc_volume_collapse_toggle_spec.rb
spec/system/author_toc_uncollected_collapse_toggle_spec.rb
spec/system/periodical_toc_display_spec.rb
```

**The full suite was not run** (40+ min; needs your go-ahead per `.claude/rules/full-test-suite-runtime.md`).

RuboCop and haml-lint on all changed files introduce no new offenses (diffed against baseline; the remaining ones are pre-existing).

Closes by-0w4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
