### PR TITLE
Expect the surname-first citation author in the verification workbench spec

### DIFF
--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -223,7 +223,9 @@ describe 'Lexicon Verification Workbench' do
 
       within('.verification-migrated') do
         within('#section-citations') do
-          expect(page).to have_content('Citation Author')
+          # An author carrying only an entry reference is listed surname-first, like the
+          # migrated ones that store their name that way (see LexEntry#surname_first_title).
+          expect(page).to have_content('Author, Citation')
         end
       end
     end


### PR DESCRIPTION
## What broke

`spec/system/lexicon/verification_workbench_spec.rb:217` — "displays citation author names in view" — has been failing:

```
expected to find text "Citation Author" in
"מראי מקום … Test Citation יוצרים: דבורה ביטון, Author, Citation ממקור: Test Publication …"
```

## Why

eb93d12af (#1658, "Display manually added citation authors surname-first") changed how a `LexCitationAuthor` that carries only an entry reference is displayed: `display_name` now falls back to `LexEntry#surname_first_title` rather than the raw entry title, so the author added by hand renders in the same bibliographic form as the migrated authors that store `"אדמון, תלמה"` in `name`.

That PR updated `spec/models/lex_entry_spec.rb`, `spec/models/lex_citation_author_spec.rb` and `spec/requests/lexicon/citation_authors_spec.rb`, but the verification workbench system spec — which renders the same partial (`_person_sections.html.haml`) — was missed. With an entry titled `Citation Author`, the card now correctly reads `Author, Citation`.

So this is a stale expectation, not a regression in the code.

## The change

One expectation updated to the surname-first form, with a comment pointing at `LexEntry#surname_first_title`. The inversion rule itself remains covered by that method's own specs; this example only asserts the author is listed on the citation card.

## Test plan

- `bundle exec rspec spec/system/lexicon/verification_workbench_spec.rb` → **40 examples, 0 failures** (was 1 failure)
- Checked the rest of #1658's blast radius, all green: `spec/models/lex_citation_author_spec.rb spec/models/lex_entry_spec.rb spec/requests/lexicon/citation_authors_spec.rb spec/system/lexicon/verification_citation_author_match_spec.rb spec/system/lexicon/verification_citation_create_spec.rb` → 105 examples, 0 failures
- RuboCop on the changed file: only the pre-existing `RSpec/DescribeClass` offense on line 5, untouched by this change.
- Full suite not run (40+ min) — say the word if you want it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
