### PR TITLE
Show collection item metadata in the card header

### DIFF
--- a/app/views/collections/_coll_texts.html.haml
+++ b/app/views/collections/_coll_texts.html.haml
@@ -70,10 +70,11 @@
                 #{t(:translated_by)} #{@effective_translators[title]}
                 - if ci.item_type == 'Manifestation' && ci.item&.expression&.work.present?
                   = " (#{orig_lang_label(ci.item.expression.work.orig_lang)})"
-        - if ci.item_type == 'Manifestation' && ci.item.present?
-          - item_ip = ci.item.expression.intellectual_property
-          .metadata{ style: 'padding-top: 4px;' }
-            .ip-statement
-              = render partial: 'shared/intellectual_property', locals: { intellectual_property: item_ip }
+          -# item metadata belongs in the header, above the header's bottom rule
+          - if ci.item_type == 'Manifestation' && ci.item.present?
+            - item_ip = ci.item.expression.intellectual_property
+            .metadata{ style: 'padding-top: 4px;' }
+              .ip-statement
+                = render partial: 'shared/intellectual_property', locals: { intellectual_property: item_ip }
       .by-card-content-v02.textcard#actualtext
         != convert_internal_links_to_relative(request.base_url, html, request.path)

--- a/spec/requests/collection_show_ip_status_spec.rb
+++ b/spec/requests/collection_show_ip_status_spec.rb
@@ -70,5 +70,15 @@ RSpec.describe 'Collection show - intellectual property display', type: :request
       expect(item_cards_text).to include(I18n.t('intellectual_property.public_domain'))
       expect(item_cards_text).to include(I18n.t('intellectual_property.copyrighted'))
     end
+
+    it 'renders the IP statement inside the card header, above the header rule' do
+      get collection_path(collection)
+      doc = Nokogiri::HTML(response.body)
+      headers_text = doc.css('.proofable .by-card-header-v02 .ip-statement').map(&:text).join
+      expect(headers_text).to include(I18n.t('intellectual_property.public_domain'))
+      expect(headers_text).to include(I18n.t('intellectual_property.copyrighted'))
+      # no item metadata may sit between the header and the card body
+      expect(doc.css('.proofable > .metadata')).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Problem

In `Collection#show`, each Manifestation card rendered its intellectual-property statement as a **sibling** of `.by-card-header-v02` rather than a child. Since `.by-card-header-v02` carries `border-bottom: solid 2px #d9cdd5` (the horizontal rule), the copyright status appeared *below* the line, at the top of the card body, instead of with the rest of the item's header metadata.

## Change

`app/views/collections/_coll_texts.html.haml`: nest the `.metadata` / `.ip-statement` block inside `.by-card-header-v02`, alongside the title, translator, and genre glyph. Indentation-only change to the HAML — no logic altered, and the existing `title.present?` and `ci.item_type == 'Manifestation'` guards are unchanged.

## Test plan

- `spec/requests/collection_show_ip_status_spec.rb`: added a regression example asserting the IP statement is found at `.proofable .by-card-header-v02 .ip-statement`, and that no `.metadata` remains a direct child of `.proofable`.
- Verified the new example **fails** on the pre-fix view (stashed the HAML change: 1 failure) and passes with it.
- `bundle exec rspec spec/requests/collection_show_ip_status_spec.rb` — 4 examples, 0 failures
- `bundle exec rspec spec/requests/ --pattern "**/*collection*"` — 56 examples, 0 failures (9 pre-existing pending)
- `bundle exec rspec spec/system/ --pattern "**/*collection*"` — 42 examples, 0 failures
- Full suite not run (40+ min; needs your approval).

Lint: `haml-lint` on the changed view reports only the pre-existing `Metrics/ParameterLists` warning on line 2 (the block params, untouched); `rubocop` on the spec is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)