### PR TITLE
Match a lexicon work to a publication and its volume together

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -180,6 +180,7 @@ module Lexicon
       end
 
       # Update the work with the confirmed publication and collection
+      publication_id, collection_id = complete_work_match_pair(person.authority, publication_id, collection_id)
       work.update!(
         publication_id: publication_id,
         collection_id: collection_id
@@ -497,7 +498,9 @@ module Lexicon
     # Publications alone are not enough: we only did bibliography work for Hebrew authors, so a
     # translated author usually has no Publication of their own. Their books are still in BYP as
     # volumes they are an involved authority of -- with the Publication, if any, filed under the
-    # Hebrew *translator*. Those volumes are reachable only through Authority#volumes.
+    # Hebrew *translator*. Those volumes are reachable only through Authority#volumes_including_series,
+    # which also picks up the volumes of a multi-volume work that records its authorship once on the
+    # containing volume_series, leaving each member volume without involved_authorities of its own.
     def work_match_candidates(authority)
       from_publications = authority.publications.includes(:volume).map do |pub|
         WorkMatchCandidate.new(title: pub.title, publication: pub, collection: pub.volume)
@@ -505,7 +508,7 @@ module Lexicon
 
       # A volume reachable through a publication of this authority is already offered with it
       already_offered = from_publications.filter_map { |candidate| candidate.collection&.id }.to_set
-      unoffered_volumes = authority.volumes.distinct.includes(:publication)
+      unoffered_volumes = authority.volumes_including_series.includes(:publication)
                                    .reject { |vol| already_offered.include?(vol.id) }
       from_volumes = unoffered_volumes.map do |vol|
         # Only propose the volume's publication when it is this authority's own -- confirming a
@@ -593,15 +596,32 @@ module Lexicon
       return nil if collection_id.blank?
 
       # A volume confirmed on its own only has to be the authority's; one confirmed together with
-      # a publication has to be that publication's volume.
+      # a publication has to be that publication's volume. The authority's volumes are taken the
+      # same way work_match_candidates offers them, so confirm cannot reject its own proposal.
       valid = if publication_id.present?
                 Collection.exists?(id: collection_id, publication_id: publication_id)
               else
-                authority.volumes.exists?(id: collection_id)
+                authority.volumes_including_series.exists?(id: collection_id)
               end
       return I18n.t('lexicon.verification.messages.collection_not_in_publication') unless valid
 
       nil
+    end
+
+    # A publication and a volume that are already linked to each other in BYP describe one book, so
+    # confirming either side confirms both -- the editor approved the book, not one of its records.
+    # Run this only on an already-validated pair: it fills in a missing side, never overrides a
+    # named one, and never fills in a publication that is not this authority's own (a translated
+    # author's volume points at the translator's publication, which confirm would reject).
+    def complete_work_match_pair(authority, publication_id, collection_id)
+      if publication_id.blank? && collection_id.present?
+        linked = Collection.where(id: collection_id).pick(:publication_id)
+        publication_id = linked if linked.present? && authority.publications.exists?(id: linked)
+      elsif publication_id.present? && collection_id.blank?
+        collection_id = Collection.where(publication_id: publication_id, collection_type: 'volume').pick(:id)
+      end
+
+      [publication_id, collection_id]
     end
   end
 end

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -194,6 +194,21 @@ class Authority < ApplicationRecord
     Collection.joins(:involved_authorities).where(collection_type: 'volume', involved_authorities: { authority_id: id })
   end
 
+  # #volumes, plus the volumes contained in any volume_series associated with this authority.
+  # A multi-volume work often records the authorship once, on the series, leaving the individual
+  # volumes with no involved_authorities of their own -- those volumes are this authority's just
+  # as much, and are invisible to #volumes because it inner-joins involved_authorities.
+  # Only direct members of the series are collected; a series nested inside a series is not walked.
+  def volumes_including_series
+    series_ids = Collection.joins(:involved_authorities)
+                           .where(collection_type: 'volume_series', involved_authorities: { authority_id: id })
+                           .select(:id)
+    in_series_ids = CollectionItem.where(collection_id: series_ids, item_type: 'Collection').select(:item_id)
+
+    volumes_scope = Collection.where(collection_type: 'volume')
+    volumes_scope.where(id: volumes.select(:id)).or(volumes_scope.where(id: in_series_ids))
+  end
+
   # return all manifestation IDs that are included in collections (useful for migrating legacy TOCs)
   def collected_manifestation_ids
     ids = published_manifestations.pluck(:id)

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -6,7 +6,9 @@
   # Volumes come from the authority's involved_authorities, not from its publications: we only
   # did bibliography work for Hebrew authors, so a translated author has no Publication of their
   # own and their volumes' publications are filed under the Hebrew translator instead.
-  collection_volumes = authority ? authority.volumes.distinct.order(:title).to_a : []
+  # ...including the volumes of the authority's volume_series, which frequently carry no
+  # involved_authorities of their own -- see Authority#volumes_including_series.
+  collection_volumes = authority ? authority.volumes_including_series.order(:title).to_a : []
   # Whatever the work is already associated with stays selectable, so that re-saving the form
   # cannot silently drop an association made before this list was sourced from involved_authorities.
   current_collection = @work.collection

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -153,12 +153,36 @@
         // The chosen publication has no volume of its own. A collection that is not linked to any
         // publication stays selected -- saving will link the two. Only a collection belonging to
         // some *other* publication is dropped, since that pairing cannot be saved.
-        const belongsToAnotherPublication = Object.keys(collectionsData).some(function(pubId) {
-          return String(collectionsData[pubId].id) === collectionSelect.value;
-        });
+        const belongsToAnotherPublication = publicationOf(collectionSelect.value) !== null;
         if (belongsToAnotherPublication) {
           collectionSelect.value = '';
         }
       });
+
+      // ...and the same in reverse: picking a volume selects the publication it is already linked
+      // to. The two records describe one book, so the editor should only have to name it once.
+      collectionSelect.addEventListener('change', function() {
+        const publicationId = publicationOf(this.value);
+        if (publicationId === null) {
+          return;
+        }
+        // Only publications of this authority are offered; a volume filed under someone else's
+        // publication (a translator's, typically) leaves the publication picker alone.
+        if (publicationSelect.querySelector('option[value="' + publicationId + '"]')) {
+          publicationSelect.value = publicationId;
+        }
+      });
+
+      // The id of the publication the given collection is linked to, or null if it is linked to none.
+      // Assigning .value programmatically fires no 'change' event, so the two handlers cannot loop.
+      function publicationOf(collectionId) {
+        if (!collectionId) {
+          return null;
+        }
+        const found = Object.keys(collectionsData).find(function(pubId) {
+          return String(collectionsData[pubId].id) === String(collectionId);
+        });
+        return found === undefined ? null : found;
+      }
     }
   })();

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -869,6 +869,80 @@ describe Authority do
         expect(authority.reload.sort_name).to eq('חנה לאה')
       end
     end
+
+    describe '#volumes_including_series' do
+      subject(:result) { authority.volumes_including_series }
+
+      let(:authority) { create(:authority) }
+
+      context 'with a volume the authority is directly involved in' do
+        let!(:own_volume) { create(:collection, collection_type: :volume, authors: [authority]) }
+
+        it 'includes it, as #volumes does' do
+          expect(result).to contain_exactly(own_volume)
+        end
+      end
+
+      context 'with a volume that only its containing volume_series credits the authority for' do
+        let(:series_volume) { create(:collection, collection_type: :volume, authors: []) }
+        let!(:series) do
+          create(:collection, collection_type: :volume_series, authors: [authority],
+                              included_collections: [series_volume])
+        end
+
+        it 'includes the volume even though it has no involved_authorities of its own' do
+          expect(series_volume.involved_authorities).to be_empty
+          expect(result).to contain_exactly(series_volume)
+        end
+
+        it 'is exactly what #volumes misses' do
+          expect(authority.volumes).to be_empty
+        end
+
+        it 'does not include the volume_series itself' do
+          expect(result).not_to include(series)
+        end
+      end
+
+      context 'when a volume is both directly credited and inside a credited series' do
+        let(:volume) { create(:collection, collection_type: :volume, authors: [authority]) }
+
+        before do
+          create(:collection, collection_type: :volume_series, authors: [authority],
+                              included_collections: [volume])
+        end
+
+        it 'returns it once' do
+          expect(result.to_a).to contain_exactly(volume)
+        end
+      end
+
+      context 'with a volume_series belonging to a different authority' do
+        let(:other_volume) { create(:collection, collection_type: :volume, authors: []) }
+
+        before do
+          create(:collection, collection_type: :volume_series, authors: [create(:authority)],
+                              included_collections: [other_volume])
+        end
+
+        it 'does not include that series\' volumes' do
+          expect(result).to be_empty
+        end
+      end
+
+      context 'with a non-volume collection inside a credited volume_series' do
+        let(:nested_series) { create(:collection, collection_type: :series, authors: []) }
+
+        before do
+          create(:collection, collection_type: :volume_series, authors: [authority],
+                              included_collections: [nested_series])
+        end
+
+        it 'excludes it, since only volumes are selectable' do
+          expect(result).to be_empty
+        end
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/requests/lexicon/verification_auto_matching_spec.rb
+++ b/spec/requests/lexicon/verification_auto_matching_spec.rb
@@ -262,6 +262,46 @@ RSpec.describe 'Lexicon::Verification Auto-Matching', type: :request do
       end
     end
 
+    # A multi-volume work records its authorship once, on the containing volume_series, leaving the
+    # member volumes with no involved_authorities of their own. Shulamit Hareven's "שונא הנסים"
+    # (collection 4944, inside volume_series "צמאון: שלישיית המדבר") is the case that prompted this.
+    context 'when a volume is credited to the authority only through its volume_series' do
+      let!(:series_volume) do
+        create(:collection, collection_type: :volume, title: 'The Miracle Hater', publication: nil, authors: [])
+      end
+      let!(:work) do
+        create(:lex_person_work, person: person, title: 'The Miracle Hater', publication_id: nil, collection_id: nil)
+      end
+
+      before do
+        create(:collection, collection_type: :volume_series, title: 'The Desert Trilogy',
+                            authors: [authority], included_collections: [series_volume])
+      end
+
+      it 'proposes the volume even though it has no involved_authorities of its own' do
+        expect(series_volume.involved_authorities).to be_empty
+
+        get "/lex/verification/#{entry.id}/edit_section", params: { section: 'works' }
+
+        expect(response).to have_http_status(:success)
+        expect(assigns(:work_matches)[work.id]).to include(
+          publication_id: nil,
+          collection_id: series_volume.id,
+          collection_title: 'The Miracle Hater',
+          similarity: 100
+        )
+      end
+
+      it 'accepts that same volume when the proposal is confirmed' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, collection_id: series_volume.id }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['success']).to be true
+        expect(work.reload.collection_id).to eq(series_volume.id)
+      end
+    end
+
     context 'when a volume belongs to a publication of the same authority' do
       let!(:publication) { create(:publication, authority: authority, title: 'Own Book') }
       let!(:volume) do
@@ -280,6 +320,62 @@ RSpec.describe 'Lexicon::Verification Auto-Matching', type: :request do
           collection_id: volume.id,
           similarity: 100
         )
+      end
+    end
+
+    # A publication and its volume are one book. Confirming either side confirms both, so the work
+    # never comes out of the workbench half-matched.
+    describe 'confirming a match that names only one side of a linked publication/volume pair' do
+      let!(:publication) { create(:publication, authority: authority, title: 'Own Book') }
+      let!(:volume) do
+        create(:collection, collection_type: :volume, title: 'Own Book', publication: publication, authors: [authority])
+      end
+      let!(:work) do
+        create(:lex_person_work, person: person, title: 'Own Book', publication_id: nil, collection_id: nil)
+      end
+
+      it 'fills in the volume when only the publication is confirmed' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, publication_id: publication.id }
+
+        expect(response).to have_http_status(:success)
+        expect(work.reload).to have_attributes(publication_id: publication.id, collection_id: volume.id)
+      end
+
+      it 'fills in the publication when only the volume is confirmed' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, collection_id: volume.id }
+
+        expect(response).to have_http_status(:success)
+        expect(work.reload).to have_attributes(publication_id: publication.id, collection_id: volume.id)
+      end
+
+      context 'when the volume is filed under another authority\'s publication' do
+        let(:translators_publication) { create(:publication, authority: create(:authority), title: 'Translated') }
+        let!(:translated_volume) do
+          create(:collection, collection_type: :volume, title: 'Translated',
+                              publication: translators_publication, authors: [authority])
+        end
+
+        it 'confirms the volume alone, since confirm would reject that publication' do
+          patch "/lex/verification/#{entry.id}/confirm_work_match",
+                params: { work_id: work.id, collection_id: translated_volume.id }
+
+          expect(response).to have_http_status(:success)
+          expect(work.reload).to have_attributes(publication_id: nil, collection_id: translated_volume.id)
+        end
+      end
+
+      context 'when the publication has no volume' do
+        let!(:volumeless_publication) { create(:publication, authority: authority, title: 'No Volume') }
+
+        it 'confirms the publication alone' do
+          patch "/lex/verification/#{entry.id}/confirm_work_match",
+                params: { work_id: work.id, publication_id: volumeless_publication.id }
+
+          expect(response).to have_http_status(:success)
+          expect(work.reload).to have_attributes(publication_id: volumeless_publication.id, collection_id: nil)
+        end
       end
     end
 

--- a/spec/system/lexicon/person_work_publication_collection_spec.rb
+++ b/spec/system/lexicon/person_work_publication_collection_spec.rb
@@ -60,6 +60,38 @@ RSpec.describe 'LexPersonWork publication/collection pickers in edit modal', :js
     end
   end
 
+  context 'when a volume is credited to the authority only through its volume_series' do
+    let!(:series_volume) do
+      create(:collection, collection_type: :volume, title: 'Volume In A Series', publication: nil, authors: [])
+    end
+
+    before do
+      create(:collection, collection_type: :volume_series, title: 'The Trilogy',
+                          authors: [authority], included_collections: [series_volume])
+    end
+
+    it 'offers the volume even though it has no involved_authorities of its own' do
+      expect(series_volume.involved_authorities).to be_empty
+
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        expect(page).to have_select('lex_person_work_collection_id', with_options: ['Volume In A Series'])
+        select 'Volume In A Series', from: 'lex_person_work_collection_id'
+        expect(page).to have_select('lex_person_work_collection_id', selected: 'Volume In A Series')
+      end
+    end
+
+    it 'does not offer the volume_series itself, which is not a volume' do
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        expect(page).to have_select('lex_person_work_collection_id', with_options: ['Volume In A Series'])
+        expect(page).to have_no_select('lex_person_work_collection_id', with_options: ['The Trilogy'])
+      end
+    end
+  end
+
   context 'when the chosen collection belongs to a different publication' do
     let!(:other_volume) do
       create(:collection, collection_type: :volume, title: 'Volume Of Another Publication',

--- a/spec/system/lexicon/person_work_publication_collection_spec.rb
+++ b/spec/system/lexicon/person_work_publication_collection_spec.rb
@@ -42,6 +42,55 @@ RSpec.describe 'LexPersonWork publication/collection pickers in edit modal', :js
     expect(page).to have_css('#generalDlg.show', wait: 5)
   end
 
+  # A publication and its volume are two records describing one book, so naming either one in the
+  # form fills in the other. The editor should only have to pick the book once.
+  context 'when a publication and a volume are linked to each other' do
+    let!(:linked_volume) do
+      create(:collection, collection_type: :volume, title: 'Linked Volume',
+                          publication: publication, authors: [authority])
+    end
+
+    it 'selects the volume when its publication is chosen' do
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        select 'Bibliography Entry', from: 'lex_person_work_publication_id'
+
+        expect(page).to have_select('lex_person_work_collection_id', selected: 'Linked Volume')
+      end
+    end
+
+    it 'selects the publication when its volume is chosen' do
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        select 'Linked Volume', from: 'lex_person_work_collection_id'
+
+        expect(page).to have_select('lex_person_work_publication_id', selected: 'Bibliography Entry')
+      end
+    end
+  end
+
+  context 'when the chosen volume belongs to another authority\'s publication' do
+    let!(:translators_volume) do
+      create(:collection, collection_type: :volume, title: 'Translated Volume',
+                          publication: create(:publication, authority: create(:authority), title: 'Not Offered'),
+                          authors: [authority])
+    end
+
+    it 'leaves the publication picker alone, since that publication is not offered' do
+      open_work_edit_modal
+
+      within '#generalDlg' do
+        select 'Translated Volume', from: 'lex_person_work_collection_id'
+
+        expect(page).to have_select('lex_person_work_collection_id', selected: 'Translated Volume')
+        expect(page).to have_select('lex_person_work_publication_id',
+                                    selected: I18n.t('lexicon.person_works.form.select_publication'))
+      end
+    end
+  end
+
   context 'when the chosen collection is not linked to any publication' do
     let!(:unlinked_volume) do
       create(:collection, collection_type: :volume, title: 'Unlinked Volume', publication: nil,


### PR DESCRIPTION
Makes matching a `LexPersonWork` to what BYP already holds work in both directions and on both
sides of the publication/volume pair. Four changes, all in the same area.

## 1. The collection dropdown missed volumes credited only through their volume_series

While verifying Shulamit Hareven's entry (`/lex/verification/5070`), the volume **"שונא הנסים"**
could not be selected. The dropdown came from `Authority#volumes`:

```ruby
Collection.joins(:involved_authorities)
          .where(collection_type: 'volume', involved_authorities: { authority_id: id })
```

That's an **inner** join, so a volume with no `involved_authorities` row of its own is invisible —
and that is the normal shape for a multi-volume work, where authorship is recorded once on the
containing `volume_series` and the member volumes are left bare. On the dev DB:

```
collection 4944  type=volume  title="שונא הנסים"  publication_id=nil
  involved_authorities: (none)
  parent: 4607 "צמאון: שלישיית המדבר"  type=volume_series
            involved_authorities: 509/שולמית הראבן/author
```

Nothing else reached it: `publication_id` is nil and Hareven's 34 publications have no volumes at
all. New `Authority#volumes_including_series` unions `#volumes` with the direct volume members of
any `volume_series` the authority is involved in. Hareven goes from 9 offered volumes to 12.

Only direct members are collected — a series nested in a series is not walked, which matches the
data here. **`#volumes` itself is unchanged**; the two remaining callers (author JSON, admin mass
updates) are a separate decision.

## 2. The auto-matcher had the same blind spot

`work_match_candidates` also read `Authority#volumes`, so it could never propose such a volume.
Now sourced from `#volumes_including_series`, **and** the confirm-side check in `work_match_error`
is widened in lockstep — otherwise confirm would reject a proposal the matcher itself made.

Verified against the real data: candidate for 4944 is now offered, and `work_match_error(a, nil, 4944)`
returns `nil` (accepted). Hareven's own auto-match *output* is unchanged, because both her lexicon
works titled שונא הנסים already have a publication and so are not in the unmatched set — the
candidate is now merely available, which is what the manual flow needed.

## 3. The pickers only populated one way

Choosing a publication already selected its volume; choosing a volume did nothing. Now symmetric.
A volume filed under someone else's publication (a translator's) leaves the publication picker
alone, since only this authority's publications are offered. The shared lookup is factored into
`publicationOf()`; assigning `.value` fires no `change` event, so the two handlers cannot loop.

This one partial is used by both the LexEntry works tab and the verification workbench, so it
covers both contexts.

## 4. Confirming an auto-match left the work half-matched

The confirm endpoint persisted only the side the proposal named, even when the publication and
volume are already linked to each other in BYP. New `complete_work_match_pair` fills in the missing
side **after** validation — never overriding a named side, and never filling in a publication that
isn't this authority's own (which confirm would then reject).

## Test plan

- `spec/models/authority_spec.rb` — 7 examples for `#volumes_including_series`.
- `spec/requests/lexicon/verification_auto_matching_spec.rb` — 6 examples: the series volume is
  proposed and confirm accepts it; both fill-in directions; and the two cases where nothing should
  be filled in.
- `spec/system/lexicon/person_work_publication_collection_spec.rb` — 5 `js: true` examples driving
  the real pickers.

Each new behaviour was verified to **fail** against the pre-change code (2 for the dropdown, 4 for
the controller, 1 for the reverse-population JS). The two "leaves it alone" examples are guards
against an over-broad implementation and pass either way — noted for honesty.

Ran green:

```
282 examples, 0 failures   # the 8 verification/authority spec files
298 examples, 0 failures   # incl. person_works + the picker system specs
```

**The full suite was not run** (40+ min, needs approval). RuboCop and haml-lint report no new
offenses on the touched files.

While iterating I saw one run of the verification+authority set report 6 failures in
`.featurable` / `.not_pageless` / `.popular_authors` and two workbench citation-card examples;
the identical file set re-ran clean twice, and none of those examples touch this code. Flagging it
as flakiness I observed, not something this PR introduces.

## Note

This does not fix the underlying data gap — 82 of 3706 `volume` collections repo-wide have no
`involved_authorities` at all. This PR only rescues the subset explained by series membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
