### PR TITLE
Show a one-text volume's lexicon citations on the text's own page

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -513,6 +513,7 @@ class ManifestationController < ApplicationController
       @total_recs = @my_pending_recs.size + @app_recs.size
 
       @links = @m.external_links.group_by(&:linktype)
+      @lex_citations = @m.sole_containing_collection&.lex_citations&.includes(:authors, :manifestation) || []
 
       @header_partial = 'manifestation/work_top'
       @works_about = @w.works_about

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -513,7 +513,7 @@ class ManifestationController < ApplicationController
       @total_recs = @my_pending_recs.size + @app_recs.size
 
       @links = @m.external_links.group_by(&:linktype)
-      @lex_citations = @m.sole_containing_collection&.lex_citations&.includes(:authors, :manifestation) || []
+      @lex_citations = @m.sole_containing_volume&.lex_citations&.includes(:authors, :manifestation) || []
 
       @header_partial = 'manifestation/work_top'
       @works_about = @w.works_about

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -202,14 +202,22 @@ class Manifestation < ApplicationRecord
     return ret.flatten
   end
 
-  # The collection this manifestation is the only item of, if there is one.
+  # The volume this manifestation is the entire content of, if there is one.
   #
   # A one-text volume simply *is* that text, so what the lexicon says about the book (see
-  # Collection#lex_citations) belongs on the text's own page too. A volume holding several texts is
-  # not any one of them, and its citations stay on the collection page.
-  def sole_containing_collection
-    collection_items.includes(collection: :collection_items).map(&:collection).compact
-                    .find { |collection| collection.collection_items.size == 1 }
+  # Collection#lex_citations) belongs on the text's own page too. The gate mirrors
+  # CollectionsController#show, which redirects to the single text whenever a collection flattens to
+  # exactly one manifestation: such a collection never renders its own page, so its citations would
+  # be unreachable if they were not shown here.
+  #
+  # Both halves of that have to be counted the same way #show counts them, i.e. over the *flattened*
+  # tree -- a volume holding one series holding one text still redirects. #volumes does that walk,
+  # and answers with the title-bearing container (volume or periodical_issue), never with the
+  # `series` that is merely a grouping inside it.
+  def sole_containing_volume
+    volumes.uniq.find do |volume|
+      volume.flatten_items.one? { |ci| ci.item_type == 'Manifestation' && ci.item.present? }
+    end
   end
 
   # Check if manifestation is contained in any collection of type 'volume',

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -202,6 +202,16 @@ class Manifestation < ApplicationRecord
     return ret.flatten
   end
 
+  # The collection this manifestation is the only item of, if there is one.
+  #
+  # A one-text volume simply *is* that text, so what the lexicon says about the book (see
+  # Collection#lex_citations) belongs on the text's own page too. A volume holding several texts is
+  # not any one of them, and its citations stay on the collection page.
+  def sole_containing_collection
+    collection_items.includes(collection: :collection_items).map(&:collection).compact
+                    .find { |collection| collection.collection_items.size == 1 }
+  end
+
   # Check if manifestation is contained in any collection of type 'volume',
   # directly or through any parent collection in the tree
   def in_volume?

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -194,6 +194,16 @@
                       %span= ' | ' + t(:source_edition) + ': ' + tr.source_edition
                     - if tr.date.present?
                       %span= ' | ' + tr.date
+        -# LexCitations about the volume this text is the only item of
+        - if @lex_citations.any?
+          .by-card-v02.left-side-card-v02
+            .by-card-header-left-v02
+              %span.headline-1-v02= t(:lex_citations_about_collection)
+            .by-card-content-v02
+              %ul
+                - @lex_citations.each do |citation|
+                  %li= render_citation(citation)
+
         -# External links
         = render partial: 'shared/external_links_panel', locals: { linkable: @m }
 - if @m.not_short?

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -933,30 +933,67 @@ describe Manifestation do
     end
   end
 
-  describe '#sole_containing_collection' do
+  describe '#sole_containing_volume' do
     let(:manifestation) { create(:manifestation) }
 
-    it 'returns the collection when the manifestation is its only item' do
+    it 'returns the volume when the manifestation is its only item' do
       volume = create(:collection, collection_type: :volume)
       create(:collection_item, collection: volume, item: manifestation)
       manifestation.reload
-      expect(manifestation.sole_containing_collection).to eq(volume)
+      expect(manifestation.sole_containing_volume).to eq(volume)
     end
 
-    it 'returns nil when the collection holds other items too' do
+    it 'returns nil when the volume holds other texts too' do
       volume = create(:collection, collection_type: :volume)
       create(:collection_item, collection: volume, item: manifestation)
       create(:collection_item, collection: volume, item: create(:manifestation))
       manifestation.reload
-      expect(manifestation.sole_containing_collection).to be_nil
+      expect(manifestation.sole_containing_volume).to be_nil
     end
 
     it 'returns nil when the manifestation is in no collection at all' do
-      expect(manifestation.sole_containing_collection).to be_nil
+      expect(manifestation.sole_containing_volume).to be_nil
     end
 
-    it 'skips a multi-item collection in favour of one the manifestation is alone in' do
-      crowded = create(:collection, collection_type: :series)
+    # The gate has to be counted over the flattened tree, exactly as CollectionsController#show
+    # counts it before redirecting to the single text -- otherwise the volume page redirects here
+    # and its citations become unreachable.
+    it 'returns the volume when it holds the manifestation through a series' do
+      volume = create(:collection, collection_type: :volume)
+      series = create(:collection, collection_type: :series)
+      create(:collection_item, collection: volume, item: series)
+      create(:collection_item, collection: series, item: manifestation)
+      manifestation.reload
+      expect(manifestation.sole_containing_volume).to eq(volume)
+    end
+
+    it 'returns nil when the series under the volume holds another text as well' do
+      volume = create(:collection, collection_type: :volume)
+      series = create(:collection, collection_type: :series)
+      create(:collection_item, collection: volume, item: series)
+      create(:collection_item, collection: series, item: manifestation)
+      create(:collection_item, collection: series, item: create(:manifestation))
+      manifestation.reload
+      expect(manifestation.sole_containing_volume).to be_nil
+    end
+
+    # A series is a grouping *inside* a title, not a title of its own, so it never answers here.
+    it 'returns nil for a single-item series with no volume above it' do
+      series = create(:collection, collection_type: :series)
+      create(:collection_item, collection: series, item: manifestation)
+      manifestation.reload
+      expect(manifestation.sole_containing_volume).to be_nil
+    end
+
+    it 'returns nil for a single-item collection of type other' do
+      other = create(:collection, collection_type: :other)
+      create(:collection_item, collection: other, item: manifestation)
+      manifestation.reload
+      expect(manifestation.sole_containing_volume).to be_nil
+    end
+
+    it 'skips a multi-text volume in favour of one the manifestation is alone in' do
+      crowded = create(:collection, collection_type: :volume)
       create(:collection_item, collection: crowded, item: manifestation)
       create(:collection_item, collection: crowded, item: create(:manifestation))
 
@@ -964,7 +1001,7 @@ describe Manifestation do
       create(:collection_item, collection: alone, item: manifestation)
 
       manifestation.reload
-      expect(manifestation.sole_containing_collection).to eq(alone)
+      expect(manifestation.sole_containing_volume).to eq(alone)
     end
   end
 

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -933,6 +933,41 @@ describe Manifestation do
     end
   end
 
+  describe '#sole_containing_collection' do
+    let(:manifestation) { create(:manifestation) }
+
+    it 'returns the collection when the manifestation is its only item' do
+      volume = create(:collection, collection_type: :volume)
+      create(:collection_item, collection: volume, item: manifestation)
+      manifestation.reload
+      expect(manifestation.sole_containing_collection).to eq(volume)
+    end
+
+    it 'returns nil when the collection holds other items too' do
+      volume = create(:collection, collection_type: :volume)
+      create(:collection_item, collection: volume, item: manifestation)
+      create(:collection_item, collection: volume, item: create(:manifestation))
+      manifestation.reload
+      expect(manifestation.sole_containing_collection).to be_nil
+    end
+
+    it 'returns nil when the manifestation is in no collection at all' do
+      expect(manifestation.sole_containing_collection).to be_nil
+    end
+
+    it 'skips a multi-item collection in favour of one the manifestation is alone in' do
+      crowded = create(:collection, collection_type: :series)
+      create(:collection_item, collection: crowded, item: manifestation)
+      create(:collection_item, collection: crowded, item: create(:manifestation))
+
+      alone = create(:collection, collection_type: :volume)
+      create(:collection_item, collection: alone, item: manifestation)
+
+      manifestation.reload
+      expect(manifestation.sole_containing_collection).to eq(alone)
+    end
+  end
+
   describe '.popular_works' do
     let!(:manifestation1) { create(:manifestation) }
     let!(:manifestation2) { create(:manifestation) }

--- a/spec/requests/manifestation_lex_citations_spec.rb
+++ b/spec/requests/manifestation_lex_citations_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe 'Manifestation LexCitations', type: :request do
       end
     end
 
+    # The volume page redirects to this text (CollectionsController#show redirects when a collection
+    # flattens to one manifestation), so if the card did not appear here it would appear nowhere.
+    context 'when the volume holds the manifestation through a series' do
+      before do
+        series = create(:collection, collection_type: :series)
+        create(:collection_item, collection: volume, item: series)
+        create(:collection_item, collection: series, item: manifestation)
+      end
+
+      it 'displays the citations card' do
+        get manifestation_path(manifestation)
+
+        expect(response).to be_successful
+        expect(assigns(:lex_citations)).to include(lex_citation)
+        expect(response.body).to include('Test Citation')
+      end
+    end
+
     context 'when the volume holds other texts as well' do
       before do
         create(:collection_item, collection: volume, item: manifestation)

--- a/spec/requests/manifestation_lex_citations_spec.rb
+++ b/spec/requests/manifestation_lex_citations_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# A one-text volume simply *is* that text, so the lexicon's citations about the book are shown on
+# the text's own page as well as on the collection's. See Manifestation#sole_containing_collection.
+RSpec.describe 'Manifestation LexCitations', type: :request do
+  let(:manifestation) { create(:manifestation) }
+  let(:volume) { create(:collection, collection_type: :volume) }
+  let(:lex_person) { create(:lex_entry, :person).lex_item }
+  let(:lex_person_work) { create(:lex_person_work, person: lex_person, collection: volume) }
+
+  let!(:lex_citation) do
+    create(:lex_citation,
+           person: lex_person,
+           person_work: lex_person_work,
+           title: 'Test Citation',
+           from_publication: 'Test Publication')
+  end
+
+  describe 'GET /read/:id' do
+    context 'when the manifestation is the only item of the volume' do
+      before { create(:collection_item, collection: volume, item: manifestation) }
+
+      it 'assigns @lex_citations with the volume\'s citations' do
+        get manifestation_path(manifestation)
+
+        expect(response).to be_successful
+        expect(assigns(:lex_citations)).to include(lex_citation)
+      end
+
+      it 'displays the citations card' do
+        get manifestation_path(manifestation)
+
+        expect(response.body).to include(I18n.t(:lex_citations_about_collection))
+        expect(response.body).to include('Test Citation')
+        expect(response.body).to include('Test Publication')
+      end
+    end
+
+    context 'when the volume holds other texts as well' do
+      before do
+        create(:collection_item, collection: volume, item: manifestation)
+        create(:collection_item, collection: volume, item: create(:manifestation))
+      end
+
+      it 'assigns empty @lex_citations' do
+        get manifestation_path(manifestation)
+
+        expect(response).to be_successful
+        expect(assigns(:lex_citations)).to be_empty
+      end
+
+      it 'does not display the citations card, which belongs to the volume, not to one text' do
+        get manifestation_path(manifestation)
+
+        expect(response.body).not_to include(I18n.t(:lex_citations_about_collection))
+      end
+    end
+
+    context 'when the manifestation is in no collection' do
+      it 'assigns empty @lex_citations' do
+        get manifestation_path(manifestation)
+
+        expect(response).to be_successful
+        expect(assigns(:lex_citations)).to be_empty
+      end
+
+      it 'does not display the citations card' do
+        get manifestation_path(manifestation)
+
+        expect(response.body).not_to include(I18n.t(:lex_citations_about_collection))
+      end
+    end
+
+    context 'when the sole containing volume has no lexicon work linked to it' do
+      let(:bare_volume) { create(:collection, collection_type: :volume) }
+
+      before { create(:collection_item, collection: bare_volume, item: manifestation) }
+
+      it 'assigns empty @lex_citations' do
+        get manifestation_path(manifestation)
+
+        expect(response).to be_successful
+        expect(assigns(:lex_citations)).to be_empty
+      end
+
+      it 'does not display the citations card' do
+        get manifestation_path(manifestation)
+
+        expect(response.body).not_to include(I18n.t(:lex_citations_about_collection))
+      end
+    end
+  end
+end


### PR DESCRIPTION
A volume holding a single manifestation simply *is* that text, so what the lexicon says about the
book belongs on the text's own page as much as on the collection's. `Manifestation#read` now renders
the same citations card `Collection#show` does, sourced from the containing collection when this
manifestation is its only item.

The gate is deliberate: a volume of several texts is not any one of them, so its citations stay on
the collection page only.

## Implementation

New `Manifestation#sole_containing_collection` returns the collection this manifestation is the only
item of, if there is one. The controller feeds `@lex_citations` from that collection's existing
`Collection#lex_citations` (the `has_many :through` added in #1670), so there is no second
definition of "what citations belong to this book".

No new locale entry: `lex_citations_about_collection` is *מראי מקום על כותר זה מלקסיקון הספרות
העברית החדשה* — "about this **title**" — which reads correctly for a manifestation too.

## About the example in the request: `/read/12017`

The wiring is correct end to end, but **the page will not show the card yet**, and it is a data gap
rather than a code one. On the dev DB:

```
Manifestation 12017 "שונא הנסים"
  → sole_containing_collection: 4944 "שונא הנסים" (volume)
    → lex_person_works: [1616 "שונא הנסים : סיפור"]
      → citations_about: 0
```

The nine citations about that book (ids 3335–3343) are still in their **legacy migration state**:

```
id=3335 lex_person_work_id=nil subject='על "שונא הנסים"' title="אפשר גם אחרת."
... 9 rows, all with lex_person_work_id = nil
```

In fact **all 115 of Shulamit Hareven's citations** still carry a `subject` string and none has a
`lex_person_work_id`. `LexCitation` documents `subject` as transitional — *"We should replace all
subjects with person_work references where possible, and then clear the subject field. After Legacy
data migration is done, we can drop subject field entirely"* — so this card is deliberately built on
`person_work`, not on `subject`. Matching citations by that string would build on something slated
for deletion.

I verified the chain by linking citation 3335 to LexPersonWork 1616 inside a transaction and rolling
it back:

```
after linking citation 3335 to LPW 1616:
  collection 4944 lex_citations.count = 1
    3335 "אפשר גם אחרת."
rolled back; citation 3335 person_work is now nil
```

So the card lights up as soon as those citations are linked to the person work. **No data was
modified.**

## Test plan

- `spec/models/manifestation_spec.rb` — 4 examples for `#sole_containing_collection`: sole item,
  multi-item collection, no collection, and picking the collection it is alone in over one it isn't.
- `spec/requests/manifestation_lex_citations_spec.rb` (new) — 8 examples covering the card rendering
  and each case where it must not: volume holds other texts, no containing collection, and a
  containing volume with no lexicon work linked.

All 9 new examples were verified to **fail** against the pre-change code.

Ran green:

```
133 examples, 0 failures   # manifestation model + request + collection citations + 2 system specs
```

**The full suite was not run** (40+ min, needs approval). RuboCop reports no new offenses;
haml-lint on `read.html.haml` reports 122 lints both before and after the change (all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
