### PR TITLE
Match legacy citation subject headings to the works they name

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -656,6 +656,58 @@ function reloadScrollingToSection(sectionId) {
     location.reload();
 }
 
+// Opening the citation-headings dialog is what unlocks marking that section verified. The server
+// records it when it serves the dialog; this releases the button without waiting for a reload.
+$(document).on('click', '#citation-subjects-auto-match-btn', function() {
+    $('#section-citation-subjects [data-path="citation_subjects"]')
+        .prop('disabled', false)
+        .removeAttr('title');
+});
+
+// Resolve one legacy citation subject heading, from either list in the citation-headings modal:
+// the proposals (work carried on the button) or the manual rows (work chosen in the row's select,
+// where the blank option means "general heading, not about a work").
+$(document).on('click', '.confirm-citation-subject', function() {
+    var $btn = $(this);
+    var $row = $btn.closest('.match-row');
+    var $select = $row.find('.citation-subject-work-select');
+    var workId = $select.length ? $select.val() : $btn.data('work-id');
+
+    $btn.prop('disabled', true);
+
+    $.ajax({
+        url: $btn.data('confirm-url'),
+        type: 'PATCH',
+        dataType: 'json',
+        headers: {
+            'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+        },
+        data: {
+            subject: $btn.data('subject'),
+            work_id: workId || ''
+        },
+        success: function(data) {
+            // Keep the modal open so the editor can work through the remaining headings.
+            $row.addClass('text-muted');
+            $row.find('.match-actions').html(
+                $('<span>', { 'class': 'text-success font-weight-bold', text: '✓ ' + (data.message || '') })
+            );
+            showToast(data.message);
+            // Refresh the citations sections once, when the editor closes the modal.
+            $('#generalDlg')
+                .off('hidden.bs.modal.citationsubject')
+                .one('hidden.bs.modal.citationsubject', function() {
+                    reloadScrollingToSection('section-citation-subjects');
+                });
+        },
+        error: function(xhr) {
+            $btn.prop('disabled', false);
+            var err = (xhr.responseJSON && xhr.responseJSON.error) || 'Error confirming match';
+            showToast(err);
+        }
+    });
+});
+
 // Confirm an auto-matched work-to-publication proposal
 function confirmWorkMatch(button) {
     var $btn = $(button);

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -115,6 +115,14 @@ module Lexicon
       verified = ['true', true].include?(params[:verified])
       notes = params[:notes] || ''
 
+      # The citation-headings section is only verifiable once its auto-match modal has been seen;
+      # the button is disabled until then, so this is here to stop a hand-made request.
+      if path == 'citation_subjects' && verified && !@entry.citation_subjects_verifiable?
+        render json: { success: false, error: I18n.t('lexicon.verification.messages.citation_subjects_unopened') },
+               status: :unprocessable_content
+        return
+      end
+
       # Special handling: when marking entire works section as verified,
       # also mark all individual works as verified
       if path == 'works' && verified && @entry.lex_item_type == 'LexPerson'
@@ -189,6 +197,32 @@ module Lexicon
       render json: {
         success: true,
         message: I18n.t('lexicon.verification.messages.work_match_confirmed')
+      }
+    rescue ActiveRecord::RecordNotFound
+      render json: { success: false, error: I18n.t('lexicon.verification.messages.work_not_found') }, status: :not_found
+    rescue StandardError => e
+      render json: { success: false, error: e.message }, status: :unprocessable_content
+    end
+
+    # PATCH /lexicon/verification/:id/confirm_citation_subject
+    # Resolves one legacy citation subject heading: points every citation under it at the given
+    # work, or -- with a blank work_id -- clears the heading as a general one about the person.
+    def confirm_citation_subject
+      person = @entry.lex_item
+      subject = params[:subject].to_s
+      unless person.is_a?(LexPerson) && subject.present?
+        render json: { success: false, error: I18n.t('lexicon.verification.messages.subject_not_found') },
+               status: :unprocessable_content
+        return
+      end
+
+      work = person.works.find(params[:work_id]) if params[:work_id].present?
+      count = person.link_citations_with_subject!(subject, work)
+
+      render json: {
+        success: true,
+        count: count,
+        message: I18n.t('lexicon.verification.messages.citation_subject_linked', count: count)
       }
     rescue ActiveRecord::RecordNotFound
       render json: { success: false, error: I18n.t('lexicon.verification.messages.work_not_found') }, status: :not_found
@@ -332,6 +366,12 @@ module Lexicon
       if @section == 'works' && @item.is_a?(LexPerson) && @item.authority.present?
         @work_matches = auto_match_works_to_publications(@item)
         @unmatched_publications = publications_absent_from_entry(@item, @work_matches)
+      end
+
+      if @section == 'citation_subjects' && @item.is_a?(LexPerson)
+        @citation_subject_proposals = Lexicon::MatchCitationSubjects.call(@item)
+        # Opening the modal is what unlocks marking the section verified, so record it here.
+        @entry.mark_citation_subjects_auto_match_opened!
       end
 
       render partial: "lexicon/verification/edit_#{@section}"

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -204,7 +204,7 @@ class LexEntry < ApplicationRecord
     verified = 0
 
     # Count top-level items (excluding collections)
-    %w(title life_years bio description toc az_navbar
+    %w(title life_years bio description toc az_navbar citation_subjects
        external_identifiers attachments date_of_manual_update).each do |key|
       next unless checklist[key]
 
@@ -358,6 +358,30 @@ class LexEntry < ApplicationRecord
     end
   end
 
+  # The citation-headings section may only be marked verified once the editor has actually looked
+  # at the auto-match proposals — the whole point of the section is that a heading left unresolved
+  # hides its citations from the public work page. An entry with no heading left to resolve has
+  # nothing to look at, so it is verifiable straight away.
+  def citation_subjects_verifiable?
+    return true unless lex_item.is_a?(LexPerson) && lex_item.unresolved_citation_subjects?
+
+    verification_progress&.dig('citation_subjects_auto_match_opened') == true
+  end
+
+  # Records that the citation-headings auto-match modal has been opened at least once. Kept beside
+  # the checklist rather than inside it: update_checklist_item replaces a section's hash wholesale,
+  # which would drop the flag the moment the section is verified.
+  def mark_citation_subjects_auto_match_opened!
+    return if verification_progress.blank? || verification_progress['citation_subjects_auto_match_opened']
+
+    with_lock do
+      progress = verification_progress.deep_dup
+      progress['citation_subjects_auto_match_opened'] = true
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
+    end
+  end
+
   private
 
   # Drop one item from a collection section of the checklist. `auto_verify_when_empty` controls what
@@ -441,6 +465,10 @@ class LexEntry < ApplicationRecord
                          {}
                        end
       checklist['citations'] = { 'verified' => false, 'items' => citation_items }
+
+      # Citation subject headings (מראי מקום: כותרות) — matching each legacy heading to the work
+      # it names, so its citations reach that work's public citations card.
+      checklist['citation_subjects'] = { 'verified' => false, 'notes' => '' }
 
     when 'LexPublication'
       checklist['title'] = { 'verified' => false, 'notes' => '' }

--- a/app/models/lex_person.rb
+++ b/app/models/lex_person.rb
@@ -62,4 +62,23 @@ class LexPerson < ApplicationRecord
     cits = cits.reject { |c| c.id == exclude_citation_id } if exclude_citation_id.present?
     cits.map(&:seqno).compact.max || 0
   end
+
+  # Whether any citation still carries a legacy subject heading, i.e. is not reachable from the
+  # work it is about (see Lexicon::MatchCitationSubjects).
+  def unresolved_citation_subjects?
+    citations.where.not(subject: nil).exists?
+  end
+
+  # Resolves one legacy citation subject heading: every citation still carrying it is pointed at
+  # `work` (or left general, when it is nil) and loses the heading string. The two go together --
+  # LexCitation validates the subject away once a person_work is present.
+  #
+  # @param subject [String] the heading as stored on the citations
+  # @param work [LexPersonWork, nil] the work the heading names, or nil for a general heading
+  # @return [Integer] how many citations were resolved
+  def link_citations_with_subject!(subject, work)
+    resolved = citations.where(subject: subject).to_a
+    resolved.each { |citation| citation.update!(person_work: work, subject: nil) }
+    resolved.size
+  end
 end

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -109,21 +109,12 @@ module Lexicon
       copy.to_html
     end
 
+    # Links the citation subject headings whose work is beyond doubt. Everything else -- a heading
+    # naming no work, naming one only approximately, or fitting two works equally well -- is left
+    # for an editor to resolve in the verification workbench's citation-headings section.
     def link_citations_to_works(lex_person)
-      lex_person.citations.each do |citation|
-        subject = citation.subject
-
-        next if subject.blank?
-
-        # For now, we're only checking for an exact title match
-        # We can also consider using more advanced matching techniques if needed to handle typos, etc.
-        work = lex_person.works.detect { |w| w.title == subject }
-
-        next if work.nil?
-
-        citation.person_work = work
-        citation.subject = nil # clear the subject since it's now linked to PersonWork
-        citation.save!
+      MatchCitationSubjects.call(lex_person).select(&:certain?).each do |proposal|
+        lex_person.link_citations_with_subject!(proposal.subject, proposal.work)
       end
     end
 

--- a/app/services/lexicon/match_citation_subjects.rb
+++ b/app/services/lexicon/match_citation_subjects.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Lexicon
+  # Proposes, for each of a person's legacy citation subject headings, the LexPersonWork that
+  # heading names.
+  #
+  # The legacy PHP bibliographies group the citations about a person under headings, and the
+  # migration stored each heading verbatim on every citation below it (LexCitation#subject).
+  # A citation still carrying a subject is invisible to the public citations cards, which are
+  # driven by LexPersonWork#citations_about — so every heading has to end up either linked to a
+  # work or cleared as a general heading about the person.
+  #
+  # Nothing here writes: it returns proposals, which the ingest auto-links when they are certain
+  # and an editor confirms in the verification workbench when they are not. Use
+  # LexPerson#link_citations_with_subject! to apply one.
+  class MatchCitationSubjects < ApplicationService
+    # Headings that bucket citations about the person rather than about one particular work.
+    # These are cleared without a work, leaving their citations as general citations.
+    GENERIC_SUBJECTS = ['מאמרים', 'ספרים', 'על הספר'].freeze
+
+    # Headings read "about X" where the work itself is titled "X" — ParseCitations is supposed to
+    # strip this, but the LLM leaves it in often enough that the matcher has to cope with it.
+    ABOUT_PREFIX = /\A\s*על\s+/
+
+    # A catalogue title carries a subtitle after " : " that the citation heading does not name
+    # ('אור פרא' vs 'אור פרא : שירים'), so both sides are also compared without it.
+    SUBTITLE_SEPARATOR = /\s+:\s/
+
+    Proposal = Struct.new(:subject, :citations, :work, :similarity, :generic, :ambiguous,
+                          keyword_init: true) do
+      # Good enough to apply without an editor looking at it: one work, identical once normalized.
+      def certain?
+        work.present? && similarity == 100
+      end
+
+      # Whether there is anything for an editor to confirm, as opposed to pick by hand.
+      def proposed?
+        generic || work.present?
+      end
+    end
+
+    # @param person [LexPerson]
+    # @return [Array<Proposal>] one per distinct heading still carried by the person's citations,
+    #   ordered by heading so the workbench lists them predictably.
+    def call(person)
+      works = person.works.to_a
+      person.citations.where.not(subject: nil).order(:seqno, :id).group_by(&:subject)
+            .sort_by { |subject, _| subject }
+            .map { |subject, citations| build_proposal(subject, citations, works) }
+    end
+
+    private
+
+    def build_proposal(subject, citations, works)
+      if GENERIC_SUBJECTS.include?(subject.strip)
+        return Proposal.new(subject: subject, citations: citations, generic: true)
+      end
+
+      scored = works.map { |work| [work, similarity(subject, work)] }
+      best_work, best_score = scored.max_by { |_work, score| score }
+      return Proposal.new(subject: subject, citations: citations) if best_score.nil? ||
+                                                                     best_score < TitleSimilarity::MATCH_THRESHOLD
+
+      # Two works the heading fits equally well are never guessed between: the editor picks.
+      ambiguous = scored.many? { |_work, score| score == best_score }
+      Proposal.new(subject: subject, citations: citations, work: ambiguous ? nil : best_work,
+                   similarity: best_score, ambiguous: ambiguous)
+    end
+
+    # The best score over every combination of heading and title, with and without the "about"
+    # prefix and the subtitle: the two databases include either at their own discretion.
+    def similarity(subject, work)
+      subject_variants(subject).product(title_variants(work.title))
+                               .map { |a, b| TitleSimilarity.call(a, b) }
+                               .max || 0
+    end
+
+    # Both with and without the "about" prefix: a work of its own may be titled "על ...", and
+    # stripping the prefix there would be stripping part of the title.
+    def subject_variants(subject)
+      [subject, subject.sub(ABOUT_PREFIX, '')].uniq.flat_map { |variant| title_variants(variant) }.uniq
+    end
+
+    def title_variants(title)
+      [title, title.split(SUBTITLE_SEPARATOR).first].compact_blank.uniq
+    end
+  end
+end

--- a/app/views/lexicon/verification/_checklist.html.haml
+++ b/app/views/lexicon/verification/_checklist.html.haml
@@ -49,6 +49,14 @@
                   %input{type: 'checkbox', checked: citation_check['verified'], disabled: true, data: {path: "citations.items.#{citation_id}", 'section-id': "citation-#{citation_id}"}}
                   = truncate(citation.title, length: 40)
 
+      -# Citation subject headings
+      %li.checklist-item
+        %label
+          -# haml-lint:disable LineLength
+          %input{ type: 'checkbox', checked: checklist['citation_subjects']&.dig('verified'), disabled: true, data: { path: 'citation_subjects', 'section-id': 'section-citation-subjects' } }
+          -# haml-lint:enable LineLength
+          = t('lexicon.verification.checklist.person.citation_subjects')
+
     - elsif item.is_a?(LexPublication)
       -# Title
       %li.checklist-item

--- a/app/views/lexicon/verification/_edit_citation_subjects.html.haml
+++ b/app/views/lexicon/verification/_edit_citation_subjects.html.haml
@@ -1,0 +1,53 @@
+-# haml-lint:disable LineLength
+- confirm_url = lexicon_confirm_citation_subject_verification_path(@entry)
+- works = @item.works.sort_by(&:title)
+-# Headings are Hebrew, so they cannot serve as DOM ids; number them instead.
+- row_ids = @citation_subject_proposals.each_with_index.to_h { |proposal, index| [proposal.subject, "subject-row-#{index}"] }
+- proposed, unmatched = @citation_subject_proposals.partition(&:proposed?)
+.auto-match-citation-subjects-modal
+  %h4= t('lexicon.verification.sections.auto_match_citation_subjects_heading')
+
+  - if @citation_subject_proposals.blank?
+    %p.text-muted= t('lexicon.verification.sections.no_citation_subjects')
+  - else
+    - if proposed.present?
+      %p= t('lexicon.verification.sections.auto_match_citation_subjects_intro')
+      - proposed.each do |proposal|
+        .match-row.citation-subject-match.border-bottom.py-2.d-flex.justify-content-between.align-items-start{ id: row_ids[proposal.subject] }
+          .match-info{ dir: text_dir(proposal.subject) }
+            %strong= proposal.subject
+            %span.badge.bg-light.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_count', count: proposal.citations.size)
+            %span.mx-2 →
+            - if proposal.generic
+              %em= t('lexicon.verification.sections.citation_subject_general')
+            - else
+              = proposal.work.title
+              %span.badge.bg-secondary.ms-2
+                #{proposal.similarity}%
+          .match-actions.ms-3
+            %button.btn.btn-sm.btn-success.confirm-citation-subject{ type: 'button', data: { subject: proposal.subject, 'work-id': proposal.work&.id, 'confirm-url': confirm_url } }
+              = t('lexicon.verification.edit.confirm_match')
+
+    -# Headings no work fits well enough, or that two works fit equally well: the editor picks.
+    - if unmatched.present?
+      %hr
+      %h5= t('lexicon.verification.sections.unmatched_citation_subjects_heading')
+      %p.text-muted= t('lexicon.verification.sections.unmatched_citation_subjects_intro')
+      - unmatched.each do |proposal|
+        .match-row.citation-subject-unmatched.border-bottom.py-2.d-flex.justify-content-between.align-items-start{ id: row_ids[proposal.subject] }
+          .match-info{ dir: text_dir(proposal.subject) }
+            %strong= proposal.subject
+            %span.badge.bg-light.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_count', count: proposal.citations.size)
+            - if proposal.ambiguous
+              %span.badge.bg-warning.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_ambiguous')
+          .match-actions.ms-3.d-flex.align-items-center
+            = select_tag 'work_id',
+                         options_from_collection_for_select(works, :id, :title),
+                         include_blank: t('lexicon.verification.sections.citation_subject_general'),
+                         class: 'form-control form-control-sm citation-subject-work-select me-2'
+            %button.btn.btn-sm.btn-primary.confirm-citation-subject{ type: 'button', data: { subject: proposal.subject, 'confirm-url': confirm_url } }
+              = t('lexicon.verification.sections.citation_subject_assign')
+
+  .text-end.mt-3
+    %button.btn.btn-secondary{ type: 'button', onclick: "$('#generalDlg').modal('hide')" }
+      = t('lexicon.verification.sections.close')

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -272,7 +272,36 @@
   .section-actions
     = link_to t('lexicon.verification.migrated.add_citation'), new_lexicon_person_citation_path(item), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href);"
 
--# Section 5: External Identifiers
+-#
+  Section 5: Citation subject headings (כותרות מראי מקום)
+  Each legacy heading has to end up either linked to the work it names or cleared as a general
+  heading; until then its citations show up on no work page at all.
+.section.verification-section{ id: 'section-citation-subjects', class: checklist['citation_subjects']&.dig('verified') ? 'verified' : 'not-verified' }
+  .section-header
+    .section-title-group
+      %h5= t('lexicon.verification.sections.citation_subjects_section')
+      .verification-badge{ class: checklist['citation_subjects']&.dig('verified') ? 'verified' : 'not-verified' }
+        = checklist['citation_subjects']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
+    %button.btn.btn-sm.btn-outline-secondary#citation-subjects-auto-match-btn{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'citation_subjects')}', function() { reloadScrollingToSection('section-citation-subjects'); })" }
+      = t('lexicon.verification.sections.auto_match_citation_subjects_btn')
+  .section-content
+    - unresolved_subjects = item.citations.where.not(subject: nil).group(:subject).count
+    - if unresolved_subjects.any?
+      %p= t('lexicon.verification.sections.citation_subjects_intro')
+      %ul.unresolved-citation-subjects
+        - unresolved_subjects.sort.each do |subject, count|
+          %li{ dir: text_dir(subject) }
+            = subject
+            %span.badge.bg-light.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_count', count: count)
+    - else
+      %p.text-muted= t('lexicon.verification.sections.no_citation_subjects')
+  .section-actions
+    - subjects_verifiable = entry.citation_subjects_verifiable?
+    %button.btn.btn-sm{ class: checklist['citation_subjects']&.dig('verified') ? 'btn-success' : 'btn-outline-success', disabled: !subjects_verifiable, title: subjects_verifiable ? nil : t('lexicon.verification.messages.citation_subjects_unopened'), data: { action: 'click->verification#quickVerify', path: 'citation_subjects' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')
+
+-# Section 6: External Identifiers
 .section.verification-section{ id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified' }
   .section-header
     %h5= t('lexicon.verification.sections.external_identifiers_section')
@@ -296,7 +325,7 @@
       ✓
       = t('lexicon.verification.migrated.mark_verified')
 
--# Section 6: Links
+-# Section 7: Links
 .section.verification-section{id: 'section-links', class: checklist['links']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.links_section')
@@ -340,7 +369,7 @@
       ✓
       = t('lexicon.verification.migrated.mark_verified')
 
--# Section 7: Attachments
+-# Section 8: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.attachments_section')
@@ -378,7 +407,7 @@
       ✓
       = t('lexicon.verification.migrated.mark_verified')
 
--# Section 8: Date of Manual Update
+-# Section 9: Date of Manual Update
 .section.verification-section{ id: 'section-date-of-manual-update', class: checklist['date_of_manual_update']&.dig('verified') ? 'verified' : 'not-verified' }
   .section-header
     %h5= t('lexicon.verification.sections.date_of_manual_update_section')

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -242,6 +242,7 @@ en:
           bio: Biography
           works: Works
           citations: Citations
+          citation_subjects: Citation headings
           links: Links
           attachments: Attachments
           external_identifiers: Authority Control Identifiers
@@ -317,6 +318,20 @@ en:
         work_from_collection: "From title:"
         unmatched_publications_heading: "Publications missing from the lexicon entry"
         unmatched_publications_intro: "The following publications are associated with the authority record but are not matched to any work in the lexicon entry:"
+        citation_subjects_section: Citation headings
+        citation_subjects_intro: "The following headings are not linked to a work yet. The citations under them appear on no work page. Use the auto-match button to link them."
+        no_citation_subjects: "(no citation headings awaiting resolution)"
+        auto_match_citation_subjects_btn: "Auto-match citation headings"
+        auto_match_citation_subjects_heading: "Auto-match citation headings to works"
+        auto_match_citation_subjects_intro: "The following headings were auto-matched to works by title similarity. Confirming a heading links every citation under it to that work."
+        unmatched_citation_subjects_heading: "Headings without a match"
+        unmatched_citation_subjects_intro: "No work was matched to these headings. Pick a work, or leave the selection blank to mark the heading as a general one, not about a particular work."
+        citation_subject_general: "General (not about a particular work)"
+        citation_subject_assign: "Assign"
+        citation_subject_ambiguous: "More than one work fits"
+        citation_subject_count:
+          one: "1 citation"
+          other: "%{count} citations"
       bio_comparison:
         title: "Biography comparison"
         note: "Both texts are shown with HTML tags and punctuation stripped, so they are not editable here. Differing words are highlighted. To fix a discrepancy, close this dialog and click Edit in the biography pane."
@@ -357,6 +372,11 @@ en:
         collection_not_in_publication: Collection does not belong to publication
         no_match_selected: No publication or volume was selected
         work_not_found: Work not found
+        subject_not_found: Citation heading not found
+        citation_subjects_unopened: Open the citation-headings auto-match dialog first
+        citation_subject_linked:
+          one: 1 citation linked
+          other: "%{count} citations linked"
         attachment_not_found: Attachment not found
         unknown_error: Unknown error
         error_updating_work_verification: Error updating work verification

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -243,6 +243,7 @@ he:
           bio: ביוגרפיה
           works: יצירות
           citations: מראי מקום
+          citation_subjects: כותרות מראי מקום
           links: קישוריוֹת
           attachments: קבצים מצורפים
           external_identifiers: מזהים חיצוניים
@@ -318,6 +319,20 @@ he:
         work_from_collection: "משויך לכותר:"
         unmatched_publications_heading: "פרסומים שאינם בערך הלקסיקון"
         unmatched_publications_intro: "הפרסומים הבאים משויכים לרשומת הסמכות אך אינם מותאמים לאף יצירה בערך הלקסיקון:"
+        citation_subjects_section: כותרות מראי מקום
+        citation_subjects_intro: "הכותרות הבאות עדיין אינן מקושרות ליצירה. מראי המקום שתחתיהן אינם מוצגים בשום עמוד יצירה. לחצו על ״התאמה אוטומטית״ כדי לקשר אותן."
+        no_citation_subjects: "(אין כותרות מראי מקום שממתינות לטיפול)"
+        auto_match_citation_subjects_btn: "התאמה אוטומטית של כותרות מראי מקום"
+        auto_match_citation_subjects_heading: "התאמה אוטומטית של כותרות מראי מקום ליצירות"
+        auto_match_citation_subjects_intro: "הכותרות הבאות הותאמו אוטומטית ליצירות על בסיס דמיון בכותרת. אישור כותרת מקשר את כל מראי המקום שתחתיה ליצירה."
+        unmatched_citation_subjects_heading: "כותרות ללא התאמה"
+        unmatched_citation_subjects_intro: "לכותרות הבאות לא נמצאה יצירה מתאימה. בחרו יצירה, או השאירו ריק כדי לסמן שהכותרת כללית ואינה עוסקת ביצירה מסוימת."
+        citation_subject_general: "כללי (לא על יצירה מסוימת)"
+        citation_subject_assign: "שיוך"
+        citation_subject_ambiguous: "יותר מיצירה אחת מתאימה"
+        citation_subject_count:
+          one: "מראה מקום אחד"
+          other: "%{count} מראי מקום"
       bio_comparison:
         title: "השוואת ביוגרפיה"
         note: "שני הטקסטים מוצגים ללא תגי HTML וללא סימני פיסוק, ולכן אינם ניתנים לעריכה כאן. מילים שונות מודגשות בצבע. לתיקון אי-התאמה, סגרו חלון זה ולחצו על ״עריכה״ בלוח הביוגרפיה."
@@ -358,6 +373,11 @@ he:
         collection_not_in_publication: האוסף אינו שייך לפרסום
         no_match_selected: לא נבחרו פרסום או כרך
         work_not_found: יצירה לא נמצאה
+        subject_not_found: כותרת מראי המקום לא נמצאה
+        citation_subjects_unopened: יש לפתוח תחילה את חלון ההתאמה האוטומטית של כותרות מראי המקום
+        citation_subject_linked:
+          one: מראה מקום אחד קושר
+          other: "%{count} מראי מקום קושרו"
         attachment_not_found: קובץ מצורף לא נמצא
         unknown_error: שגיאה לא ידועה
         error_updating_work_verification: שגיאה בעדכון אימות יצירה

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,8 @@ Bybeconv::Application.routes.draw do
       patch ':id/set_profile_image', to: 'verification#set_profile_image', as: :set_profile_image_verification
       delete ':id/remove_attachment', to: 'verification#remove_attachment', as: :remove_attachment_verification
       patch ':id/confirm_work_match', to: 'verification#confirm_work_match', as: :confirm_work_match_verification
+      patch ':id/confirm_citation_subject', to: 'verification#confirm_citation_subject',
+                                            as: :confirm_citation_subject_verification
       post ':id/mark_verified', to: 'verification#mark_verified', as: :mark_verified_verification
       get ':id/bio_comparison', to: 'verification#bio_comparison', as: :bio_comparison_verification
       get ':id/escalate_form', to: 'verification#escalate_form', as: :escalate_form_verification

--- a/db/migrate/20260831090000_backfill_citation_subject_person_works.rb
+++ b/db/migrate/20260831090000_backfill_citation_subject_person_works.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# The legacy PHP bibliographies group the citations about a person under headings naming one of
+# that person's works, and the migration stored each heading verbatim on every citation below it
+# (LexCitation#subject). Ingest only ever linked a heading that matched a work title character for
+# character, so most headings survived unresolved -- and a citation still carrying a heading is
+# invisible to the public citations cards, which are driven by LexPersonWork#citations_about.
+#
+# This migration resolves what can be resolved without a human: headings that name exactly one work
+# beyond doubt (identical once the "about" prefix, the subtitle and the punctuation are normalized
+# away -- see Lexicon::MatchCitationSubjects). Everything else -- an approximate match, a heading
+# fitting two works equally well, and the general "מאמרים"/"ספרים" buckets -- is left for an editor
+# to confirm in the new citation-headings section of the verification workbench.
+#
+# Published entries that still hold an unresolved heading afterwards are therefore sent back to
+# verification, with the new checklist section added so it counts towards their progress. Entries
+# already under verification get the section too, so it counts for them as well.
+class BackfillCitationSubjectPersonWorks < ActiveRecord::Migration[8.0]
+  CHECKLIST_SECTION = 'citation_subjects'
+
+  def up
+    say 'Linking citation headings that name exactly one work...'
+    linked_headings = 0
+    linked_citations = 0
+
+    LexPerson.where(id: LexCitation.where.not(subject: nil).select(:lex_person_id)).find_each do |person|
+      Lexicon::MatchCitationSubjects.call(person).select(&:certain?).each do |proposal|
+        linked_citations += person.link_citations_with_subject!(proposal.subject, proposal.work)
+        linked_headings += 1
+      end
+    end
+
+    say "linked #{linked_citations} citations under #{linked_headings} headings", true
+
+    add_checklist_section
+    reset_entries_with_unresolved_headings
+  end
+
+  def down
+    # Not reversible: the headings the linked citations carried were cleared, and which citation
+    # carried which heading is not recorded anywhere else.
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  # verification_progress['checklist'] is built once, when verification starts, so entries that
+  # began verification before this section existed would never count it towards their progress.
+  def add_checklist_section
+    added = 0
+    LexEntry.where(lex_item_type: 'LexPerson').find_each do |entry|
+      checklist = entry.verification_progress&.dig('checklist')
+      next if checklist.blank? || checklist.key?(CHECKLIST_SECTION)
+
+      progress = entry.verification_progress.deep_dup
+      progress['checklist'][CHECKLIST_SECTION] = { 'verified' => false, 'notes' => '' }
+      entry.update_columns(verification_progress: progress)
+      added += 1
+    end
+    say "added the #{CHECKLIST_SECTION} checklist section to #{added} entries", true
+  end
+
+  # Only entries whose headings could not all be resolved mechanically need an editor to look at
+  # them again; the rest are already correct and stay published.
+  def reset_entries_with_unresolved_headings
+    person_ids = LexCitation.where.not(subject: nil).select(:lex_person_id)
+    reset = LexEntry.where(lex_item_type: 'LexPerson', lex_item_id: person_ids, status: :published)
+                    .update_all(status: LexEntry.statuses[:verifying])
+    say "sent #{reset} published entries back to verification", true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_29_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_090000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -456,6 +456,61 @@ RSpec.describe LexEntry, type: :model do
     end
   end
 
+  describe 'citation subject headings verification' do
+    let(:person) { create(:lex_person) }
+    let(:entry) { create(:lex_entry, lex_item: person) }
+
+    describe '#build_checklist' do
+      it 'includes citation_subjects in the checklist for LexPerson entries' do
+        entry.start_verification!('test@example.com')
+
+        expect(entry.verification_progress.dig('checklist', 'citation_subjects'))
+          .to eq({ 'verified' => false, 'notes' => '' })
+      end
+
+      it 'omits citation_subjects for LexPublication entries' do
+        pub_entry = create(:lex_entry, :publication)
+        pub_entry.start_verification!('test@example.com')
+
+        expect(pub_entry.verification_progress['checklist']).not_to have_key('citation_subjects')
+      end
+    end
+
+    describe '#verification_percentage' do
+      before { entry.start_verification!('test@example.com') }
+
+      it 'counts the citation_subjects section towards the total' do
+        expect { entry.update_checklist_item('citation_subjects', true, '') }
+          .to change(entry, :verification_percentage).by_at_least(1)
+      end
+    end
+
+    describe '#citation_subjects_verifiable?' do
+      before { entry.start_verification!('test@example.com') }
+
+      context 'with an unresolved heading' do
+        before { create(:lex_citation, person: person, subject: 'על "אור פרא"') }
+
+        it 'is false until the auto-match dialog has been opened' do
+          expect(entry).not_to be_citation_subjects_verifiable
+          entry.mark_citation_subjects_auto_match_opened!
+          expect(entry).to be_citation_subjects_verifiable
+        end
+
+        it 'keeps the flag when the section is later marked verified' do
+          entry.mark_citation_subjects_auto_match_opened!
+          entry.update_checklist_item('citation_subjects', true, '')
+
+          expect(entry.reload).to be_citation_subjects_verifiable
+        end
+      end
+
+      it 'is true when no heading is left to resolve' do
+        expect(entry).to be_citation_subjects_verifiable
+      end
+    end
+  end
+
   describe 'external_identifiers verification' do
     let(:person) { create(:lex_person) }
     let(:entry) { create(:lex_entry, lex_item: person) }

--- a/spec/requests/lexicon/verification_citation_subjects_spec.rb
+++ b/spec/requests/lexicon/verification_citation_subjects_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lexicon::Verification citation subject headings', type: :request do
+  before do
+    login_as_lexicon_editor
+  end
+
+  let(:person) { create(:lex_person) }
+  let(:entry) { create(:lex_entry, lex_item: person, status: :verifying) }
+  let!(:work) { create(:lex_person_work, person: person, title: 'אור פרא : שירים') }
+
+  describe 'GET /lex/verification/:id/edit_section?section=citation_subjects' do
+    let!(:citation) { create(:lex_citation, person: person, subject: 'על "אור פרא"') }
+
+    before { entry.start_verification!('editor@example.com') }
+
+    it 'proposes the work the heading names, without persisting anything' do
+      get "/lex/verification/#{entry.id}/edit_section", params: { section: 'citation_subjects' }
+
+      expect(response).to have_http_status(:success)
+      expect(assigns(:citation_subject_proposals).map(&:work)).to eq [work]
+      expect(citation.reload.person_work).to be_nil
+      expect(citation.subject).to eq 'על "אור פרא"'
+    end
+
+    it 'records that the auto-match dialog has been opened' do
+      expect { get "/lex/verification/#{entry.id}/edit_section", params: { section: 'citation_subjects' } }
+        .to change { entry.reload.citation_subjects_verifiable? }.from(false).to(true)
+    end
+  end
+
+  describe 'PATCH /lex/verification/:id/confirm_citation_subject' do
+    let!(:citations) { create_list(:lex_citation, 2, person: person, subject: 'על "אור פרא"') }
+
+    it 'links every citation under the heading to the work and clears the heading' do
+      patch "/lex/verification/#{entry.id}/confirm_citation_subject",
+            params: { subject: 'על "אור פרא"', work_id: work.id }
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['count']).to eq 2
+      expect(citations.map { |c| c.reload.person_work }).to all(eq work)
+      expect(citations.map { |c| c.reload.subject }).to all(be_nil)
+    end
+
+    it 'clears a heading confirmed as general without setting a work' do
+      patch "/lex/verification/#{entry.id}/confirm_citation_subject",
+            params: { subject: 'על "אור פרא"', work_id: '' }
+
+      expect(response).to have_http_status(:success)
+      expect(citations.map { |c| c.reload.person_work }).to all(be_nil)
+      expect(citations.map { |c| c.reload.subject }).to all(be_nil)
+    end
+
+    it 'leaves the citations alone when the work belongs to someone else' do
+      other_work = create(:lex_person_work)
+
+      patch "/lex/verification/#{entry.id}/confirm_citation_subject",
+            params: { subject: 'על "אור פרא"', work_id: other_work.id }
+
+      expect(response).to have_http_status(:not_found)
+      expect(citations.map { |c| c.reload.subject }).to all(eq 'על "אור פרא"')
+    end
+  end
+
+  describe 'PATCH /lex/verification/:id/update_checklist' do
+    let!(:citation) { create(:lex_citation, person: person, subject: 'על "אור פרא"') }
+
+    before { entry.start_verification!('editor@example.com') }
+
+    it 'refuses to verify the section before the auto-match dialog has been opened' do
+      patch "/lex/verification/#{entry.id}/update_checklist",
+            params: { path: 'citation_subjects', verified: 'true' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(entry.reload.verification_progress.dig('checklist', 'citation_subjects', 'verified')).to be false
+    end
+
+    it 'verifies the section once the dialog has been opened' do
+      get "/lex/verification/#{entry.id}/edit_section", params: { section: 'citation_subjects' }
+
+      patch "/lex/verification/#{entry.id}/update_checklist",
+            params: { path: 'citation_subjects', verified: 'true' }
+
+      expect(response).to have_http_status(:success)
+      expect(entry.reload.verification_progress.dig('checklist', 'citation_subjects', 'verified')).to be true
+    end
+
+    it 'verifies the section straight away when no heading is left to resolve' do
+      citation.update!(subject: nil)
+
+      patch "/lex/verification/#{entry.id}/update_checklist",
+            params: { path: 'citation_subjects', verified: 'true' }
+
+      expect(response).to have_http_status(:success)
+      expect(entry.reload.verification_progress.dig('checklist', 'citation_subjects', 'verified')).to be true
+    end
+  end
+end

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe 'Lexicon::Verification', type: :request do
         # Simulate user clicking quickVerify on every section (title path covers life_years)
         patch url, params: { path: 'title', verified: 'true' }, as: :json
         patch url, params: { path: 'bio', verified: 'true' }, as: :json
+        patch url, params: { path: 'citation_subjects', verified: 'true' }, as: :json
         patch url, params: { path: 'external_identifiers', verified: 'true' }, as: :json
         patch url, params: { path: 'attachments', verified: 'true' }, as: :json
         patch url, params: { path: 'date_of_manual_update', verified: 'true' }, as: :json

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -29,9 +29,8 @@ describe Lexicon::IngestPerson do
       expect(person).to have_attributes(birthdate: '1946', deathdate: nil)
       expect(person.gender).to eq('female')
       expect(person.citations.count).to eq(53)
-      expect(person.citations.select { |c| c.person_work.present? }.size).to eq(45)
-      # There is a discrepancy between the book name in file and the citation subject for 3 citations
-      expect(person.citations.select { |c| c.subject.present? }.size).to eq(3)
+      expect(person.citations.select { |c| c.person_work.present? }.size).to eq(48)
+      expect(person.citations.select { |c| c.subject.present? }.size).to eq(0)
 
       expect(person.works.count).to eq(19)
       expect(person.works.select(&:work_type_original?).size).to eq(15)
@@ -444,9 +443,9 @@ describe Lexicon::IngestPerson do
       expect(person).to have_attributes(birthdate: '1899', deathdate: '1949')
       expect(person.gender).to eq('male')
       expect(person.citations.count).to eq(4)
-      expect(person.citations.select { |c| c.person_work.present? }.size).to eq(1)
-      # There is a discrepancy between the book name in file and the citation subject for 3 citations
-      expect(person.citations.select { |c| c.subject.present? }.size).to eq(3)
+      expect(person.citations.select { |c| c.person_work.present? }.size).to eq(3)
+      # 'בלדות מעבר לנוער' is spelled 'בלדות מעבר לנער' in the works list, so it is left for an editor
+      expect(person.citations.select { |c| c.subject.present? }.size).to eq(1)
       expect(person.works.count).to eq(22)
       expect(person.works.select(&:work_type_original?).size).to eq(18)
       expect(person.works.select(&:work_type_edited?).size).to eq(2)
@@ -483,8 +482,8 @@ describe Lexicon::IngestPerson do
       expect(person).to have_attributes(birthdate: '1942', deathdate: nil)
       expect(person.gender).to eq('female')
       expect(person.citations.count).to eq(35)
-      expect(person.citations.select { |c| c.subject.present? }.size).to eq(5)
-      expect(person.citations.select { |c| c.person_work.present? }.size).to eq(24)
+      expect(person.citations.select { |c| c.subject.present? }.size).to eq(1)
+      expect(person.citations.select { |c| c.person_work.present? }.size).to eq(28)
 
       expect(person.works.count).to eq(28)
       expect(person.works.select(&:work_type_original?).size).to eq(12)

--- a/spec/services/lexicon/match_citation_subjects_spec.rb
+++ b/spec/services/lexicon/match_citation_subjects_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lexicon::MatchCitationSubjects do
+  subject(:proposals) { described_class.call(person) }
+
+  let(:person) { create(:lex_entry, :person).lex_item }
+
+  def add_work(title)
+    create(:lex_person_work, person: person, title: title)
+  end
+
+  def add_citation(subject)
+    create(:lex_citation, person: person, subject: subject)
+  end
+
+  def proposal_for(subject)
+    proposals.find { |proposal| proposal.subject == subject }
+  end
+
+  describe 'exact heading' do
+    before do
+      add_work('שונא הנסים')
+      add_citation('שונא הנסים')
+    end
+
+    it 'proposes the work with certainty' do
+      expect(proposal_for('שונא הנסים')).to have_attributes(work: person.works.first, similarity: 100,
+                                                            certain?: true, generic: nil)
+    end
+  end
+
+  describe 'the "על" prefix and a catalogue subtitle' do
+    before do
+      add_work('אור פרא : שירים')
+      add_citation('על "אור פרא"')
+    end
+
+    it 'proposes the work with certainty, ignoring the prefix, the quotes and the subtitle' do
+      expect(proposal_for('על "אור פרא"')).to have_attributes(work: person.works.first, similarity: 100,
+                                                              certain?: true)
+    end
+  end
+
+  describe 'a work whose own title starts with "על"' do
+    before do
+      add_work('על משכבם בלילות')
+      add_citation('על משכבם בלילות')
+    end
+
+    it 'proposes it with certainty, rather than stripping part of its title as a prefix' do
+      expect(proposal_for('על משכבם בלילות')).to have_attributes(work: person.works.first, similarity: 100,
+                                                                 certain?: true)
+    end
+  end
+
+  describe 'a heading only approximately naming a work' do
+    before do
+      add_work('אישה בגן')
+      add_citation('על "אשה בגן"')
+    end
+
+    it 'proposes the work, but not with certainty' do
+      proposal = proposal_for('על "אשה בגן"')
+      expect(proposal.work).to eq person.works.first
+      expect(proposal.similarity).to be_between(Lexicon::TitleSimilarity::MATCH_THRESHOLD, 99)
+      expect(proposal).not_to be_certain
+    end
+  end
+
+  describe 'a generic bucket heading' do
+    before do
+      add_work('שונא הנסים')
+      add_citation('מאמרים')
+    end
+
+    it 'proposes clearing it without a work' do
+      expect(proposal_for('מאמרים')).to have_attributes(generic: true, work: nil, certain?: false,
+                                                        proposed?: true)
+    end
+  end
+
+  describe 'a heading naming no work of this person' do
+    before do
+      add_work('שונא הנסים')
+      add_citation('רשימות מבית המרזח')
+    end
+
+    it 'is left unresolved' do
+      expect(proposal_for('רשימות מבית המרזח')).to have_attributes(work: nil, similarity: nil,
+                                                                   generic: nil, proposed?: false)
+    end
+  end
+
+  describe 'a heading fitting two works equally well' do
+    before do
+      add_work('צורות : שירים')
+      add_work('צורות : סיפורים')
+      add_citation('על "צורות"')
+    end
+
+    it 'is reported as ambiguous rather than guessed at' do
+      expect(proposal_for('על "צורות"')).to have_attributes(work: nil, ambiguous: true, certain?: false)
+    end
+  end
+
+  it 'groups every citation under a heading into one proposal' do
+    add_work('שונא הנסים')
+    citations = Array.new(3) { add_citation('שונא הנסים') }
+
+    expect(proposal_for('שונא הנסים').citations).to match_array(citations)
+  end
+
+  it 'ignores citations already linked to a work' do
+    work = add_work('שונא הנסים')
+    create(:lex_citation, person: person, person_work: work, subject: nil)
+
+    expect(proposals).to be_empty
+  end
+end

--- a/spec/system/lexicon/verification_citation_subjects_spec.rb
+++ b/spec/system/lexicon/verification_citation_subjects_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Verification citation subject headings section', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:person) { create(:lex_person, birthdate: '1900', deathdate: '1980', gender: :male) }
+  let!(:entry) { create(:lex_entry, title: 'Test Author', lex_item: person, status: :draft) }
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_author_citation_subjects.php')
+    File.write(file_path, '<html><body><h1>Test Author</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_author_citation_subjects.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  let!(:work) { create(:lex_person_work, person: person, title: 'אור פרא : שירים', work_type: :original) }
+  let!(:matched_citation) { create(:lex_citation, person: person, subject: 'על "אור פרא"') }
+  let!(:generic_citation) { create(:lex_citation, person: person, subject: 'מאמרים') }
+  let!(:unmatched_citation) { create(:lex_citation, person: person, subject: 'רשימות מבית המרזח') }
+
+  after { FileUtils.rm_f(lex_file.full_path) }
+
+  def open_auto_match_modal
+    find('#citation-subjects-auto-match-btn').click
+    expect(page).to have_css('#generalDlg.show .auto-match-citation-subjects-modal', wait: 5)
+  end
+
+  it 'lists the unresolved headings on the section card' do
+    visit "/lex/verification/#{entry.id}"
+
+    within '#section-citation-subjects' do
+      expect(page).to have_content('על "אור פרא"')
+      expect(page).to have_content('מאמרים')
+      expect(page).to have_content('רשימות מבית המרזח')
+    end
+  end
+
+  it 'refuses to mark the section verified before the modal has been opened' do
+    visit "/lex/verification/#{entry.id}"
+
+    within '#section-citation-subjects .section-actions' do
+      expect(page).to have_button(I18n.t('lexicon.verification.migrated.mark_verified'), disabled: true)
+    end
+  end
+
+  it 'links every citation under a proposed heading to the matched work' do
+    visit "/lex/verification/#{entry.id}"
+    open_auto_match_modal
+
+    within '#generalDlg' do
+      row = find('.citation-subject-match', text: 'על "אור פרא"')
+      expect(row).to have_content('אור פרא : שירים')
+      row.click_button I18n.t('lexicon.verification.edit.confirm_match')
+      expect(row).to have_css('.text-success', wait: 5)
+    end
+
+    expect(matched_citation.reload.person_work).to eq work
+    expect(matched_citation.subject).to be_nil
+  end
+
+  it 'clears a generic heading without linking it to a work' do
+    visit "/lex/verification/#{entry.id}"
+    open_auto_match_modal
+
+    within '#generalDlg' do
+      row = find('.citation-subject-match', text: 'מאמרים')
+      expect(row).to have_content(I18n.t('lexicon.verification.sections.citation_subject_general'))
+      row.click_button I18n.t('lexicon.verification.edit.confirm_match')
+      expect(row).to have_css('.text-success', wait: 5)
+    end
+
+    expect(generic_citation.reload.subject).to be_nil
+    expect(generic_citation.person_work).to be_nil
+  end
+
+  it 'lets the editor assign a work to a heading nothing matched' do
+    visit "/lex/verification/#{entry.id}"
+    open_auto_match_modal
+
+    within '#generalDlg' do
+      row = find('.citation-subject-unmatched', text: 'רשימות מבית המרזח')
+      row.find('.citation-subject-work-select').select work.title
+      row.click_button I18n.t('lexicon.verification.sections.citation_subject_assign')
+      expect(row).to have_css('.text-success', wait: 5)
+    end
+
+    expect(unmatched_citation.reload.person_work).to eq work
+    expect(unmatched_citation.subject).to be_nil
+  end
+
+  it 'enables marking the section verified once the modal has been opened' do
+    visit "/lex/verification/#{entry.id}"
+    open_auto_match_modal
+    within('#generalDlg') { click_button I18n.t('lexicon.verification.sections.close') }
+
+    expect(page).to have_css('#section-citation-subjects', wait: 5)
+    within '#section-citation-subjects .section-actions' do
+      expect(page).to have_button(I18n.t('lexicon.verification.migrated.mark_verified'), disabled: false, wait: 5)
+    end
+  end
+end


### PR DESCRIPTION
Closes by-5gl.

## The problem

A `LexCitation` that still carries a `subject` string appears on no page at all: the public citations cards on `Collection#show` (#1670) and `Manifestation#read` (#1672) are both driven by `LexPersonWork#citations_about`. `IngestPerson#link_citations_to_works` only ever linked a heading matching a work title character for character, so **1051 of 1489 citations** (184 distinct headings, 29 people) were left unreachable — including the bead's example, `/read/12017` "שונא הנסים", whose nine citations rendered nothing.

## What this does

**`Lexicon::MatchCitationSubjects`** proposes, per distinct heading, the `LexPersonWork` that heading names. It scores with the existing `Lexicon::TitleSimilarity` at its usual `MATCH_THRESHOLD`, comparing each side both with and without the "about" (`על`) prefix and the catalogue `" : subtitle"` suffix — that is what recovers `על "אור פרא"` → `אור פרא : שירים` at 100%. Quote marks are already separators to `TitleSimilarity`. Two works fitting a heading equally well are reported ambiguous rather than guessed between, and the generic `מאמרים` / `ספרים` / `על הספר` buckets are proposed as *general* headings, to be cleared without a work.

The prefix is stripped as a *variant*, not unconditionally: a work of its own may be titled `על משכבם בלילות`, and stripping there would strip part of the title.

**Ingest** now auto-links only what is beyond doubt (one work, identical once normalized) and leaves the rest to an editor. On the ingest fixtures this raises 00002 from 45 to 48 linked, 00020 from 24 to 28, 00024 from 1 to 3; the leftovers in those fixtures are a genuine spelling variant (`בלדות מעבר לנוער` vs. `בלדות מעבר לנער`, 94%) and a citation about someone else's book — exactly the cases a human should see.

**A new verification section**, "כותרות מראי מקום", lists the entry's unresolved headings and opens an auto-match modal in the style of the works one: proposals with a confirm button on one side, and headings nothing matched with a work picker (blank = general) on the other. Confirming a heading links *every* citation under it and clears the heading in the same update — `LexCitation` validates the subject away once a `person_work` is present, so the two have to go together. The section counts towards the entry's percentage and cannot be marked verified until the modal has been opened at least once (enforced in the view and again in `update_checklist`); an entry with nothing left to resolve is verifiable straight away.

**The migration** applies the certain-only rule to existing data, adds the new checklist section to entries already under verification (their checklist was built before it existed), and sends back to verification only those *published* `LexPerson` entries that still hold an unresolved heading. On the dev DB: **521 citations under 150 headings linked**, 38 checklists updated, 1 published entry reset. What remains for editors is 407 generic-bucket citations plus ~123 under 37 headings needing judgement.

## Notes on scope

- Per your answers on the bead: a **migration**, not a rake task; **LexPerson entries only**; generic buckets **auto-proposed as general** with a confirm click, from a three-item list grounded in the actual data (those are the only bucket phrases present).
- The acceptance criterion about re-linking "when a `LexPersonWork` is created or its title changed" is met by the modal recomputing proposals live on every open, rather than by an `after_save` hook. The original complaint was that the linking never re-ran; adding a silent write-on-save would also re-introduce unconfirmed guessing, which the interactive card exists to avoid.
- The migration is `IrreversibleMigration`: the headings it cleared are not recorded anywhere else.

## Testing

- `spec/services/lexicon/match_citation_subjects_spec.rb` (new, 9): exact match, `על "X"` + `X : subtitle`, a work titled `על ...`, approximate-but-not-certain, generic bucket, no match, ambiguous, grouping, already-linked citations ignored.
- `spec/requests/lexicon/verification_citation_subjects_spec.rb` (new, 8): proposals rendered without persisting, the opened flag, linking a heading, clearing one as general, rejecting another person's work, and the three `update_checklist` gate cases.
- `spec/system/lexicon/verification_citation_subjects_spec.rb` (new, 6, `js: true`): the card listing, the disabled button, confirming a proposal, confirming a generic heading, assigning by hand, and the button unlocking.
- `spec/models/lex_entry_spec.rb`: checklist section built for persons and not publications, counted in the percentage, and the opened flag surviving verification.
- Updated `ingest_person_spec` counts (behaviour change, verified case by case) and added `citation_subjects` to the all-sections-verified case in `verification_spec`.
- Ran: `spec/services/lexicon`, `spec/models/lex_{entry,person,citation,person_work}_spec.rb`, `spec/requests/lexicon` — **817 examples, 0 failures**; `spec/system/lexicon` — **207 examples, 0 failures**. RuboCop and haml-lint clean on every changed file. **The full suite was not run** (40+ min) and needs your approval.
- Verified afterwards on the dev server that `/read/12017` renders its citations card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
