### PR TITLE
Reorder the citation-headings section and badge each citations group

### DIFF
--- a/app/views/lexicon/verification/_checklist.html.haml
+++ b/app/views/lexicon/verification/_checklist.html.haml
@@ -31,6 +31,14 @@
           %input{type: 'checkbox', checked: checklist['works']&.dig('verified'), disabled: true, data: {path: 'works', 'section-id': 'section-works'}}
           = t('lexicon.verification.checklist.person.works')
 
+      -# Citation subject headings
+      %li.checklist-item
+        %label
+          -# haml-lint:disable LineLength
+          %input{ type: 'checkbox', checked: checklist['citation_subjects']&.dig('verified'), disabled: true, data: { path: 'citation_subjects', 'section-id': 'section-citation-subjects' } }
+          -# haml-lint:enable LineLength
+          = t('lexicon.verification.checklist.person.citation_subjects')
+
       -# Citations (מראי מקום)
       %li.checklist-item
         %label
@@ -48,14 +56,6 @@
                 %label
                   %input{type: 'checkbox', checked: citation_check['verified'], disabled: true, data: {path: "citations.items.#{citation_id}", 'section-id': "citation-#{citation_id}"}}
                   = truncate(citation.title, length: 40)
-
-      -# Citation subject headings
-      %li.checklist-item
-        %label
-          -# haml-lint:disable LineLength
-          %input{ type: 'checkbox', checked: checklist['citation_subjects']&.dig('verified'), disabled: true, data: { path: 'citation_subjects', 'section-id': 'section-citation-subjects' } }
-          -# haml-lint:enable LineLength
-          = t('lexicon.verification.checklist.person.citation_subjects')
 
     - elsif item.is_a?(LexPublication)
       -# Title

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -236,7 +236,7 @@
       - total_count = checklist['citations']&.dig('items')&.size || 0
       = "#{verified_count}/#{total_count} " + t('lexicon.verification.migrated.verified')
   .section-content
-    - all_citations = item.citations.includes(authors: { entry: :lex_file })
+    - all_citations = item.citations.includes(:person_work, authors: { entry: :lex_file })
     - cit_size = all_citations.size
     -# Resolved once for the whole section: which plaintext authors have an existing person entry
       to offer a match against (see LexCitationAuthor.matchable_names).
@@ -248,7 +248,15 @@
     - if all_citations.any?
       - all_citations.group_by(&:subject_title).each do |subject, citations|
         .citation-group.mb-3
-          %h6.subject-header= subject.presence || t('lexicon.citations.header.general')
+          -#
+            A group's heading is the work's title once it is linked, and the legacy string until then --
+            two states that look alike, so say which is which (see the citation-headings section above).
+          %h6.subject-header
+            = subject.presence || t('lexicon.citations.header.general')
+            - if citations.first.person_work.present?
+              %span.badge.bg-success.ms-1= t('lexicon.verification.sections.citation_group_linked')
+            - elsif subject.present?
+              %span.badge.bg-warning.text-dark.ms-1= t('lexicon.verification.sections.citation_group_unlinked')
           - citations.each do |citation|
             .citation-card{ id: "citation-#{citation.id}", class: citation_card_css(citation, checklist) }
               .citation-content{dir: text_dir(citation.title.to_s)}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -198,7 +198,36 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_works')
 
--# Section 4: Citations (מראי מקום)
+-#
+  Section 4: Citation subject headings (כותרות מראי מקום)
+  Each legacy heading has to end up either linked to the work it names or cleared as a general
+  heading; until then its citations show up on no work page at all.
+.section.verification-section{ id: 'section-citation-subjects', class: checklist['citation_subjects']&.dig('verified') ? 'verified' : 'not-verified' }
+  .section-header
+    .section-title-group
+      %h5= t('lexicon.verification.sections.citation_subjects_section')
+      .verification-badge{ class: checklist['citation_subjects']&.dig('verified') ? 'verified' : 'not-verified' }
+        = checklist['citation_subjects']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
+    %button.btn.btn-sm.btn-outline-secondary#citation-subjects-auto-match-btn{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'citation_subjects')}', function() { reloadScrollingToSection('section-citation-subjects'); })" }
+      = t('lexicon.verification.sections.auto_match_citation_subjects_btn')
+  .section-content
+    - unresolved_subjects = item.citations.where.not(subject: nil).group(:subject).count
+    - if unresolved_subjects.any?
+      %p= t('lexicon.verification.sections.citation_subjects_intro')
+      %ul.unresolved-citation-subjects
+        - unresolved_subjects.sort.each do |subject, count|
+          %li{ dir: text_dir(subject) }
+            = subject
+            %span.badge.bg-light.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_count', count: count)
+    - else
+      %p.text-muted= t('lexicon.verification.sections.no_citation_subjects')
+  .section-actions
+    - subjects_verifiable = entry.citation_subjects_verifiable?
+    %button.btn.btn-sm{ class: checklist['citation_subjects']&.dig('verified') ? 'btn-success' : 'btn-outline-success', disabled: !subjects_verifiable, title: subjects_verifiable ? nil : t('lexicon.verification.messages.citation_subjects_unopened'), data: { action: 'click->verification#quickVerify', path: 'citation_subjects' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')
+
+-# Section 5: Citations (מראי מקום)
 .section.verification-section{id: 'section-citations', class: checklist['citations']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.citations_section')
@@ -271,35 +300,6 @@
       %p.text-muted= t('lexicon.verification.sections.no_citations')
   .section-actions
     = link_to t('lexicon.verification.migrated.add_citation'), new_lexicon_person_citation_path(item), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href);"
-
--#
-  Section 5: Citation subject headings (כותרות מראי מקום)
-  Each legacy heading has to end up either linked to the work it names or cleared as a general
-  heading; until then its citations show up on no work page at all.
-.section.verification-section{ id: 'section-citation-subjects', class: checklist['citation_subjects']&.dig('verified') ? 'verified' : 'not-verified' }
-  .section-header
-    .section-title-group
-      %h5= t('lexicon.verification.sections.citation_subjects_section')
-      .verification-badge{ class: checklist['citation_subjects']&.dig('verified') ? 'verified' : 'not-verified' }
-        = checklist['citation_subjects']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
-    %button.btn.btn-sm.btn-outline-secondary#citation-subjects-auto-match-btn{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'citation_subjects')}', function() { reloadScrollingToSection('section-citation-subjects'); })" }
-      = t('lexicon.verification.sections.auto_match_citation_subjects_btn')
-  .section-content
-    - unresolved_subjects = item.citations.where.not(subject: nil).group(:subject).count
-    - if unresolved_subjects.any?
-      %p= t('lexicon.verification.sections.citation_subjects_intro')
-      %ul.unresolved-citation-subjects
-        - unresolved_subjects.sort.each do |subject, count|
-          %li{ dir: text_dir(subject) }
-            = subject
-            %span.badge.bg-light.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_count', count: count)
-    - else
-      %p.text-muted= t('lexicon.verification.sections.no_citation_subjects')
-  .section-actions
-    - subjects_verifiable = entry.citation_subjects_verifiable?
-    %button.btn.btn-sm{ class: checklist['citation_subjects']&.dig('verified') ? 'btn-success' : 'btn-outline-success', disabled: !subjects_verifiable, title: subjects_verifiable ? nil : t('lexicon.verification.messages.citation_subjects_unopened'), data: { action: 'click->verification#quickVerify', path: 'citation_subjects' } }
-      ✓
-      = t('lexicon.verification.migrated.mark_verified')
 
 -# Section 6: External Identifiers
 .section.verification-section{ id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified' }

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -327,6 +327,8 @@ en:
         unmatched_citation_subjects_heading: "Headings without a match"
         unmatched_citation_subjects_intro: "No work was matched to these headings. Pick a work, or leave the selection blank to mark the heading as a general one, not about a particular work."
         citation_subject_general: "General (not about a particular work)"
+        citation_group_linked: "Linked to a work"
+        citation_group_unlinked: "Heading not linked"
         citation_subject_assign: "Assign"
         citation_subject_ambiguous: "More than one work fits"
         citation_subject_count:

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -328,6 +328,8 @@ he:
         unmatched_citation_subjects_heading: "כותרות ללא התאמה"
         unmatched_citation_subjects_intro: "לכותרות הבאות לא נמצאה יצירה מתאימה. בחרו יצירה, או השאירו ריק כדי לסמן שהכותרת כללית ואינה עוסקת ביצירה מסוימת."
         citation_subject_general: "כללי (לא על יצירה מסוימת)"
+        citation_group_linked: "מקושר ליצירה"
+        citation_group_unlinked: "כותרת לא מקושרת"
         citation_subject_assign: "שיוך"
         citation_subject_ambiguous: "יותר מיצירה אחת מתאימה"
         citation_subject_count:

--- a/spec/system/lexicon/verification_citation_subjects_spec.rb
+++ b/spec/system/lexicon/verification_citation_subjects_spec.rb
@@ -44,6 +44,19 @@ describe 'Verification citation subject headings section', :js do
     end
   end
 
+  it 'badges each citations group by whether its heading is linked to a work yet' do
+    create(:lex_citation, person: person, person_work: work, subject: nil)
+    visit "/lex/verification/#{entry.id}"
+
+    within '#section-citations' do
+      linked = find('.subject-header', text: work.title)
+      expect(linked).to have_content(I18n.t('lexicon.verification.sections.citation_group_linked'))
+
+      unlinked = find('.subject-header', text: 'רשימות מבית המרזח')
+      expect(unlinked).to have_content(I18n.t('lexicon.verification.sections.citation_group_unlinked'))
+    end
+  end
+
   it 'refuses to mark the section verified before the modal has been opened' do
     visit "/lex/verification/#{entry.id}"
 


### PR DESCRIPTION
Follow-up to #1673.

## 1. Section order

Moves the citation-headings verification section to sit **between** the works section and the citations section, instead of after the citations section. Resolving a heading is work on the works, and it changes how the citations section below groups itself, so it reads better before that section than after it. The checklist modal is reordered to match.

## 2. A badge on each citations group

A group's heading in the citations section is the **work's title** once the heading is linked, and the **legacy subject string** until then — and the two render identically. On an entry like `/lex/verification/5070` (שולמית הראבן), 18 of 21 groups are already resolved, so the section shows "over a dozen headings" while the auto-match modal correctly offers only the 2 that are actually still open, which reads as though the modal were skipping most of them.

Each group heading now carries a small badge: green "מקושר ליצירה" when the group is linked to a work, amber "כותרת לא מקושרת" when it still carries a legacy heading. The general group (no heading at all) is unbadged, as it already labels itself "כללי". `person_work` is added to the section's `includes` so the badge costs no extra queries.

No behaviour change beyond these two — the section, its modal, the checklist key and the progress calculation are untouched.

## Testing

- `spec/system/lexicon/verification_citation_subjects_spec.rb` gains a case asserting both badges appear on the right groups.
- Ran `verification_citation_subjects`, `verification_citation_create`, `verification_citation_delete`, `verification_citation_author_match`, `citation_text_links` — **17 examples, 0 failures**; and earlier for the reorder, `verification_citation_subjects` + `verification_section_shortcuts` + `verification_workbench` — **54 examples, 0 failures**.
- haml-lint on `_person_sections.html.haml` is at its pre-existing baseline (90 lints), unchanged by this diff; RuboCop clean on the changed spec.
- The full suite was not run (40+ min) and needs your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
