### PR TITLE
Name the containing collection on work search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -29,6 +29,7 @@ class SearchController < ApplicationController
       page = (params[:page] || 1).to_i
       @offset = (page - 1) * Kaminari.config.default_per_page
       @total = @results.count
+      @containing_volumes = containing_volumes_for(@results)
 
       track_event('search', { term: @searchterm, page: page })
     rescue # Faraday::Error::ConnectionFailed => e
@@ -41,6 +42,18 @@ class SearchController < ApplicationController
   end
 
   protected
+
+  # Manifestation hits are shown with the volume/periodical issue they sit in, but ManifestationsIndex
+  # doesn't carry the containing collection's title or pub_year, so look them up in the DB for the
+  # single page of results being rendered. Returns { manifestation_id => [Collection, ...] }.
+  def containing_volumes_for(results)
+    ids = results.to_a.select { |r| r.instance_of?(ManifestationsIndex) }.map { |r| r.attributes['id'].to_i }
+    return {} if ids.empty?
+
+    Manifestation.where(id: ids)
+                 .includes(collection_items: :collection)
+                 .to_h { |m| [m.id, m.volumes.uniq] }
+  end
 
   def sanitize_term(term)
     term = term.gsub(/(\S)"(\S)/, '\1\2').gsub('׳', "'").gsub('״', '"')

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,2 +1,18 @@
+# frozen_string_literal: true
+
+# View helpers for the site-wide search results page.
 module SearchHelper
+  # "בתוך: <title> (<year>)" for the collection(s) a search-result text is contained in.
+  # Returns nil when the text isn't in any volume or periodical issue.
+  def containing_collections_label(collections)
+    return nil if collections.blank?
+
+    titles = collections.map do |collection|
+      year = collection.pub_year
+      # a pub_year of 0 is the sentinel used to sort a collection to the head of a page, not a real year
+      year.present? && year.to_s.strip != '0' ? "#{collection.title} (#{year})" : collection.title
+    end
+
+    t(:contained_in, titles: titles.join('; '))
+  end
 end

--- a/app/views/search/results.html.haml
+++ b/app/views/search/results.html.haml
@@ -60,6 +60,9 @@
             %b= link_to attrs['title'], manifestation_path(attrs['id'], q: @search.query)
             = " / #{attrs['author_string']}"
             = " (#{textify_genre(attrs['genre'])})"
+            - containment = containing_collections_label(@containing_volumes[attrs['id'].to_i])
+            - if containment.present?
+              = " #{containment}"
             - unless result.tags.empty?
               %br
               %div{style: 'line-height: 2.2;'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,7 @@ en:
   dictionary: Dictionary
   collections: Collections
   contained_within: within
+  contained_in: 'In: %{titles}'
   email: Email
   title: Title
   status: Status

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1043,6 +1043,7 @@ he:
   manifestations: מימושים
   collections: כותרים
   contained_within: בתוך
+  contained_in: 'בתוך: %{titles}'
   dictionary_entries: ערכים מילוניים
   volumes: כותרים
   x_volumes: "%{x} כותרים"

--- a/spec/requests/search_results_containment_spec.rb
+++ b/spec/requests/search_results_containment_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Search results containment', type: :request do
+  let(:volume) do
+    create(:collection, collection_type: :volume, title: 'Containing Volume', pub_year: '1923',
+                        manifestations: [manifestation])
+  end
+
+  before do
+    clean_tables
+    Chewy.strategy(:atomic) do
+      manifestation
+      volume
+    end
+  end
+
+  describe 'GET /search/results' do
+    subject(:results) do
+      get search_results_internal_path, params: { q: 'Test', index_types: ['manifestations'] }
+      response.body
+    end
+
+    context 'when the work is contained in a volume' do
+      let(:manifestation) { create(:manifestation, title: 'Test Contained Work') }
+
+      it 'names the containing collection and its pub_year after the linked title' do
+        expect(results).to include('בתוך: Containing Volume (1923)')
+      end
+    end
+
+    context 'when the volume has no pub_year' do
+      let(:manifestation) { create(:manifestation, title: 'Test Contained Work') }
+      let(:volume) do
+        create(:collection, collection_type: :volume, title: 'Yearless Volume', pub_year: nil,
+                            manifestations: [manifestation])
+      end
+
+      it 'names the collection without an empty parenthesis' do
+        expect(results).to include('בתוך: Yearless Volume')
+        expect(results).not_to include('Yearless Volume (')
+      end
+    end
+
+    context 'when the work is contained in a series inside a volume' do
+      let(:manifestation) { create(:manifestation, title: 'Test Nested Work') }
+      let(:series) { create(:collection, collection_type: :series, manifestations: [manifestation]) }
+      let(:volume) do
+        create(:collection, collection_type: :volume, title: 'Outer Volume', pub_year: '1948',
+                            included_collections: [series])
+      end
+
+      it 'names the volume the series sits in' do
+        expect(results).to include('בתוך: Outer Volume (1948)')
+      end
+    end
+
+    context 'when the work is in no collection' do
+      let(:manifestation) { create(:manifestation, title: 'Test Uncontained Work') }
+      let(:volume) { nil }
+
+      it 'does not render a containment label' do
+        expect(results).to include('Test Uncontained Work')
+        expect(results).not_to include('בתוך:')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

On the search results screen, a `Manifestation` hit that is contained in a collection now shows, on
the same line right after the genre, `בתוך: <collection title> (<pub_year>)`.

Example line: **כותרת היצירה** / שם המחבר (שירה) בתוך: כל כתבי X (1923)

## How

`ManifestationsIndex` indexes only the `in_volume?` / `in_periodical?` booleans — it carries neither
the container's title nor its `pub_year`. Rather than adding fields to the index (which would need a
full reindex and would go stale whenever a collection is retitled), `SearchController#results` looks
the containers up in the DB for the single page of manifestation hits being rendered, via
`Manifestation#volumes` — the same walk that already drives the "בתוך" line on a text's own page, so
a text nested in a `series` correctly reports the enclosing volume.

- `SearchController#containing_volumes_for` → `{ manifestation_id => [Collection, ...] }`, one
  batched query with `includes(collection_items: :collection)`.
- `SearchHelper#containing_collections_label` formats the label; `pub_year` is omitted when blank,
  and when it is the `0` sentinel this codebase uses to sort a collection to the head of a page.
- New I18n key `contained_in` in both `he.yml` and `en.yml`.

## Test plan

New `spec/requests/search_results_containment_spec.rb` (4 examples, all passing) covers:
- work directly in a volume → title and pub_year shown
- volume with no pub_year → no empty parentheses
- work in a series inside a volume → the enclosing volume is named
- work in no collection → no label rendered

Also ran `spec/controllers/search_controller_spec.rb` (all pass) and
`spec/services/search_manifestations_spec.rb`. The latter passes on its own but has one failure when
run in the same process as `search_controller_spec` (ES doc leakage between files) — **verified
identical on a clean tree with these changes stashed**, so it is pre-existing and unrelated.

RuboCop and haml-lint are clean on the lines added; remaining offences in
`search_controller.rb` / `results.html.haml` are pre-existing.

The full suite (40+ min) was **not** run — needs approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
