### PR TITLE
Double the length of collections.title (and the sort_title derived from it)

### DIFF
--- a/db/migrate/20260831120000_double_collections_title_limit.rb
+++ b/db/migrate/20260831120000_double_collections_title_limit.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# varchar(1024) has proven too short for some collection titles. Double it to 2048.
+class DoubleCollectionsTitleLimit < ActiveRecord::Migration[8.0]
+  def up
+    change_column :collections, :title, :string, limit: 2048
+  end
+
+  def down
+    change_column :collections, :title, :string, limit: 1024
+  end
+end

--- a/db/migrate/20260831120001_double_collections_sort_title_limit.rb
+++ b/db/migrate/20260831120001_double_collections_sort_title_limit.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# sort_title is derived from title by the SortedTitle concern, so leaving it at varchar(255) would
+# keep any title over 255 characters unsaveable even after title itself was widened. Widen it to
+# match title.
+#
+# utf8mb4 varchar(2048) is 8192 bytes, past InnoDB's 3072-byte key limit, so the index has to become
+# a prefix index. 255 characters is exactly what it covered before this change. Nothing in the app
+# does SQL `ORDER BY collections.sort_title` -- alphabetical browsing of collections runs through
+# CollectionsIndex in Elasticsearch -- so losing ORDER BY support on this index costs nothing.
+class DoubleCollectionsSortTitleLimit < ActiveRecord::Migration[8.0]
+  # Rails/BulkChangeTable wants one `change_table ... bulk: true`, but these three statements are
+  # order-dependent: the index has to be gone before the column is widened past the key limit, and
+  # recreated with the prefix afterwards. Folding them into a single ALTER would make correctness
+  # depend on how MySQL orders the clauses.
+  # rubocop:disable Rails/BulkChangeTable
+  def up
+    remove_index :collections, name: 'index_collections_on_sort_title'
+    change_column :collections, :sort_title, :string, limit: 2048
+    add_index :collections, :sort_title, name: 'index_collections_on_sort_title', length: 255
+  end
+
+  def down
+    remove_index :collections, name: 'index_collections_on_sort_title'
+    change_column :collections, :sort_title, :string, limit: 255
+    add_index :collections, :sort_title, name: 'index_collections_on_sort_title'
+  end
+  # rubocop:enable Rails/BulkChangeTable
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_120001) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -309,16 +309,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_090000) do
     t.string "pub_year"
     t.integer "publication_id"
     t.string "publisher_line", limit: 2048
-    t.string "sort_title"
+    t.string "sort_title", limit: 2048
     t.string "subtitle"
     t.boolean "suppress_download_and_print", default: false, null: false
-    t.string "title", limit: 1024
+    t.string "title", limit: 2048
     t.integer "toc_id"
     t.integer "toc_strategy"
     t.datetime "updated_at", null: false
     t.index ["inception_year"], name: "index_collections_on_inception_year"
     t.index ["publication_id"], name: "index_collections_on_publication_id"
-    t.index ["sort_title"], name: "index_collections_on_sort_title"
+    t.index ["sort_title"], name: "index_collections_on_sort_title", length: 255
     t.index ["toc_id"], name: "index_collections_on_toc_id"
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -9,12 +9,13 @@ describe Collection do
     expect { build(:collection, collection_type: 'made_up') }.to raise_error(ArgumentError)
   end
 
-  it 'stores a title longer than 1024 characters, and the sort_title derived from it' do
-    long_title = 'א' * 1500
-    collection = create(:collection, title: long_title)
-    expect(collection.reload.title).to eq(long_title)
-    expect(collection.sort_title).to eq(long_title)
-  end
+it 'stores a title longer than 1024 characters, and the sort_title derived from it' do
+  long_title = 'א' * 1500
+  collection = create(:collection, title: long_title, sort_title: nil)
+  collection.reload
+  expect(collection.title).to eq(long_title)
+  expect(collection.sort_title).to eq(long_title)
+end
 
   it 'strips leading/trailing whitespace from a manually-set sort_title on save' do
     collection = create(:collection, title: 'כותרת', sort_title: '  זבל  ')

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -9,6 +9,13 @@ describe Collection do
     expect { build(:collection, collection_type: 'made_up') }.to raise_error(ArgumentError)
   end
 
+  it 'stores a title longer than 1024 characters, and the sort_title derived from it' do
+    long_title = 'א' * 1500
+    collection = create(:collection, title: long_title)
+    expect(collection.reload.title).to eq(long_title)
+    expect(collection.sort_title).to eq(long_title)
+  end
+
   it 'strips leading/trailing whitespace from a manually-set sort_title on save' do
     collection = create(:collection, title: 'כותרת', sort_title: '  זבל  ')
     expect(collection.reload.sort_title).to eq('זבל')


### PR DESCRIPTION
## What

`collections.title`: `varchar(1024)` → `varchar(2048)`.

## Why the second migration

Widening `title` on its own would not have achieved anything. `SortedTitle` derives `sort_title` from `title` on every save (`app/models/concerns/sorted_title.rb:27`), and `collections.sort_title` was `varchar(255)` — so a collection with a title over 255 characters still failed with `Mysql2::Error: Data too long for column 'sort_title'`, and the old 1024 limit was already unreachable through the normal path. `sort_title` is therefore widened to match.

## The index

utf8mb4 `varchar(2048)` is 8192 bytes, past InnoDB's 3072-byte key limit, so `index_collections_on_sort_title` becomes a prefix index over 255 characters — exactly the width it covered before this change.

MySQL cannot use a prefix index for `ORDER BY`, but nothing in the app does SQL `ORDER BY collections.sort_title`: the two `order(:sort_title)` call sites (`bib_controller.rb:248`, `manifestation_controller.rb:709`) are on Manifestation, and alphabetical browsing of collections goes through `CollectionsIndex` in Elasticsearch (`collections_controller.rb:503` is a Chewy `prefix` filter). So the change costs nothing at the query layer.

Both migrations are reversible; `down` was exercised and re-applied locally.

## Known edge

`update_sort_title!` prepends `תתתת_` (5 chars) to titles that start with a non-Hebrew character, so a title longer than 2043 characters in that shape would overflow `sort_title`. Left alone rather than adding truncation logic to a concern shared by four models — real titles are nowhere near that length.

## Test plan

- New regression spec in `spec/models/collection_spec.rb`: a 1500-character title round-trips, and the auto-derived `sort_title` does too. It fails against the old schema on both columns.
- `bundle exec rspec spec/models/collection_spec.rb spec/models/collection_item_spec.rb` → 124 examples, 0 failures, 1 pending (pre-existing "Not yet implemented").
- RuboCop clean on both migrations.
- Full suite **not** run (40+ min, needs your approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
