### PR TITLE
Keep parsing works past a duplicated Books anchor (00104.php translations)

### DIFF
--- a/app/services/lexicon/extract_person_works.rb
+++ b/app/services/lexicon/extract_person_works.rb
@@ -28,8 +28,19 @@ module Lexicon
 
       index = 0
       work_type = 'original'
-      while next_elem.present? && !header?(next_elem)
-        header_line = next_elem.text.strip
+      while next_elem.present? && !works_section_end?(next_elem)
+        # Legacy files re-open a <span dir="rtl"> before each work type and never close it, so
+        # Nokogiri nests the list that follows inside it. Step in rather than walking past it,
+        # which would drop every work of that type (00104.php's translations).
+        if next_elem.name == 'span'
+          next_elem = next_elem.first_element_child
+          next
+        end
+
+        # squish, not strip: legacy files hard-wrap a header across two source lines
+        # ("ספרים \r\nבתרגומו:" in 01741.php), and the embedded newline hides it from
+        # WORK_TYPE_HEADERS, filing the whole section as original works.
+        header_line = next_elem.text.squish
         if %w(p font).include?(next_elem.name)
           work_type = WORK_TYPE_HEADERS.keys.detect do |wt|
             WORK_TYPE_HEADERS[wt].include?(header_line) ||

--- a/app/services/lexicon/html_utils.rb
+++ b/app/services/lexicon/html_utils.rb
@@ -47,6 +47,18 @@ module Lexicon
       end
     end
 
+    # Whether +elem+ ends the works section, i.e. opens a section other than the works.
+    #
+    # A handful of legacy files built the sub-header of a further work type by copying the works
+    # header's markup wholesale, duplicate a[name="Books"] anchor and all (00104.php's
+    # 'תרגומיה:', 01741.php's 'ספרים בתרגומו:'). A repeated Books anchor therefore opens another
+    # kind of work, not another section, and stopping at it drops every work below it.
+    def works_section_end?(elem)
+      return false unless header?(elem)
+
+      elem.at_css('a[name]')['name'] != WORKS_ANCHOR
+    end
+
     # Some legacy files carry layout-only tables: rows and cells, but nothing to show.
     # Pandoc keeps them as raw HTML, so they survive migration as markup noise.
     def content_free_table?(elem)

--- a/app/services/lexicon/match_citation_subjects.rb
+++ b/app/services/lexicon/match_citation_subjects.rb
@@ -26,6 +26,13 @@ module Lexicon
     # ('אור פרא' vs 'אור פרא : שירים'), so both sides are also compared without it.
     SUBTITLE_SEPARATOR = /\s+:\s/
 
+    # A heading about a translation names the work in quotes and then credits the work's own
+    # author, whom the catalogue title does not put there: 'על "הכומר מטור" לאונורה דה בלזאק'
+    # against 'הכומר מטור / אונורה דה בלזאק'. The credit drags the score below the threshold, so
+    # the quoted span is compared on its own as well. Greedy on purpose: a Hebrew title can carry
+    # a gershayim of its own ('69.99 ש"ח'), and only the outermost pair delimits the title.
+    QUOTED_TITLE = /"(.+)"/
+
     Proposal = Struct.new(:subject, :citations, :work, :similarity, :generic, :ambiguous,
                           keyword_init: true) do
       # Good enough to apply without an editor looking at it: one work, identical once normalized.
@@ -76,9 +83,11 @@ module Lexicon
     end
 
     # Both with and without the "about" prefix: a work of its own may be titled "על ...", and
-    # stripping the prefix there would be stripping part of the title.
+    # stripping the prefix there would be stripping part of the title. The quoted span, when the
+    # heading has one, is tried as a third reading of the same heading.
     def subject_variants(subject)
-      [subject, subject.sub(ABOUT_PREFIX, '')].uniq.flat_map { |variant| title_variants(variant) }.uniq
+      [subject, subject.sub(ABOUT_PREFIX, ''), subject[QUOTED_TITLE, 1]]
+        .compact_blank.uniq.flat_map { |variant| title_variants(variant) }.uniq
     end
 
     def title_variants(title)

--- a/spec/services/lexicon/extract_person_works_spec.rb
+++ b/spec/services/lexicon/extract_person_works_spec.rb
@@ -226,6 +226,61 @@ describe Lexicon::ExtractPersonWorks do
     end
   end
 
+  context 'when a work-type sub-header carries a duplicate of the Books anchor' do
+    # Mirrors 00104.php, where the 'תרגומיה:' sub-header was built by copying the works header's
+    # markup, anchor and all, and an unclosed <span dir="rtl"> was re-opened before its list --
+    # so Nokogiri nests the translations one level deeper than the originals. The walk used to
+    # stop at the duplicate anchor, losing all twelve translations.
+    let(:html) do
+      <<~HTML
+        <font size="4" color="#0000FF">ספריה<a name="Books">:</a></font>
+        <span dir="rtl">
+          <ul>
+            <li>ספר מקורי (תל אביב : דביר, 1990)</li>
+          </ul>
+          <font size="4" color="#0000FF">תרגומיה<a name="Books">:</a></font>
+          <span dir="rtl">
+            <ul>
+              <li>הכומר מטור / אונורה דה בלזאק (ירושלים : כרמל, 1999)</li>
+              <li>נואה נואה : מסע לטהיטי / פול גוגן (רמת השרון : אסיה, 2007)</li>
+            </ul>
+            <font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font>
+      HTML
+    end
+
+    it 'keeps parsing past the duplicate anchor and classifies the works as translated' do
+      expect(lex_person.works.select(&:work_type_original?).map(&:title)).to eq(['ספר מקורי'])
+      expect(lex_person.works.select(&:work_type_translated?).map(&:title))
+        .to eq(['הכומר מטור / אונורה דה בלזאק', 'נואה נואה : מסע לטהיטי / פול גוגן'])
+    end
+
+    it 'still stops at the citations header' do
+      expect(result.at_css('a[name="Bib."]')).to be_present
+    end
+  end
+
+  context 'when a work-type header is hard-wrapped across two source lines' do
+    # Mirrors 01741.php: the newline inside the header text hid it from WORK_TYPE_HEADERS,
+    # so all 43 translations below it were filed as original works.
+    let(:html) do
+      <<~HTML
+        <p><a name="Books">ספריו:</a></p>
+        <ul>
+          <li>ספר מקורי (תל אביב : דביר, 1990)</li>
+        </ul>
+        <p>ספרים \r
+        בתרגומו:</p>
+        <ul>
+          <li>ספר מתורגם (תל אביב : הוצאה, 2010)</li>
+        </ul>
+      HTML
+    end
+
+    it 'recognizes the header despite the embedded newline' do
+      expect(lex_person.works.select(&:work_type_translated?).map(&:title)).to eq(['ספר מתורגם'])
+    end
+  end
+
   context 'when citations header appears inside the works span (malformed)' do
     let(:html) do
       <<~HTML

--- a/spec/services/lexicon/html_utils_spec.rb
+++ b/spec/services/lexicon/html_utils_spec.rb
@@ -106,4 +106,24 @@ describe Lexicon::HtmlUtils do
       end
     end
   end
+
+  describe '#works_section_end?' do
+    subject(:helper) { Class.new { include Lexicon::HtmlUtils }.new }
+
+    def element(html)
+      Nokogiri::HTML::DocumentFragment.parse(html).first_element_child
+    end
+
+    it 'is true for a header opening another section' do
+      expect(helper).to be_works_section_end(element('<font><a name="Bib.">על המחבר:</a></font>'))
+    end
+
+    it 'is false for a work-type sub-header repeating the works anchor' do
+      expect(helper).not_to be_works_section_end(element('<font>תרגומיה<a name="Books">:</a></font>'))
+    end
+
+    it 'is false for an element that is not a header at all' do
+      expect(helper).not_to be_works_section_end(element('<ul><li>ספר</li></ul>'))
+    end
+  end
 end

--- a/spec/services/lexicon/match_citation_subjects_spec.rb
+++ b/spec/services/lexicon/match_citation_subjects_spec.rb
@@ -69,6 +69,36 @@ describe Lexicon::MatchCitationSubjects do
     end
   end
 
+  describe 'a heading crediting the translated work’s own author' do
+    # 00104.php's headings, e.g. 'על "הכומר מטור" לאונורה דה בלזאק'. The credit is not part of
+    # the title, and used to drag the score below the threshold, leaving the heading unresolved.
+    let(:subject_heading) { 'על "הכומר מטור" לאונורה דה בלזאק' }
+
+    before do
+      add_work('הכומר מטור / אונורה דה בלזאק ; אחרית דבר, אלישבע רוזן')
+      add_citation(subject_heading)
+    end
+
+    it 'proposes the work with certainty, matching on the quoted title alone' do
+      expect(proposal_for(subject_heading)).to have_attributes(work: person.works.first, similarity: 100,
+                                                               certain?: true)
+    end
+  end
+
+  describe 'a heading whose quoted title contains a gershayim of its own' do
+    let(:subject_heading) { 'על "69.99 ש"ח" לפרדריק בגבדה' }
+
+    before do
+      add_work('69.99 ש"ח : רומן / פרדריק בגבדה')
+      add_citation(subject_heading)
+    end
+
+    it 'takes the outermost pair of quotes as the title, not the innermost' do
+      expect(proposal_for(subject_heading)).to have_attributes(work: person.works.first, similarity: 100,
+                                                               certain?: true)
+    end
+  end
+
   describe 'a generic bucket heading' do
     before do
       add_work('שונא הנסים')


### PR DESCRIPTION
## The bug

In `00104.php` (ארזה טיר-אפלרויט, a translator) the citation-headings workbench offered only
one work — her dissertation — so none of the six headings naming a translation could be
matched, and auto-matching never saw those works either.

The person's twelve translations were never ingested at all. `ExtractPersonWorks` walks the
elements after the works header and stops at the first `<p>`/`<font>` carrying *any*
`a[name]` anchor, on the assumption that such an anchor opens the next section. But this
file — and seven others — built the sub-header of a further work type by copying the works
header's markup wholesale, duplicate `a[name="Books"]` anchor and all:

```html
<font size="4" color="#0000FF">ספריה<a name="Books">:</a></font>     <-- section header
...
<font size="4" color="#0000FF">תרגומיה<a name="Books">:</a></font>   <-- work-type sub-header
```

The walk stopped at the second one and everything below it was lost.

## The fixes

1. **`HtmlUtils#works_section_end?`** (new) — the works walk now ends only at an anchor naming
   a *different* section (`Bib.`, `links`). A repeated `Books` anchor opens another kind of
   work, not another section.
2. **Step into a re-opened `<span dir="rtl">`** — these files re-open one before each list and
   never close it, so Nokogiri nests the translations a level deeper than the originals. The
   loop used to warn `Unexpected element while parsing person works: span` and walk past the
   list inside.
3. **`squish`, not `strip`, on the header text** — a header hard-wrapped across two source
   lines (`"ספרים \r\nבתרגומו:"` in `01741.php`) was invisible to `WORK_TYPE_HEADERS`, so its
   whole section was filed as original works. Corpus sweep: this recognizes 11 previously
   missed headers across 6 files, and changes no classification in the other direction.
4. **`MatchCitationSubjects` reads the quoted span of a heading** — these entries head their
   citations `על "הכומר מטור" לאונורה דה בלזאק`, crediting the *translated work's* author,
   whom the catalogue title does not put there. That credit dragged every heading under the
   70% threshold (40–68%). The quoted title is now tried as a third reading alongside the
   existing bare and `על`-stripped ones. Greedy on purpose, so a title carrying its own
   gershayim (`69.99 ש"ח`) is delimited by the outermost pair.

## Effect on the affected files

Eight person entries carry a duplicate `Books` anchor; works parsed before → after:

| file | before | after |
| --- | --- | --- |
| 00104 | 1 | 13 (12 translations) |
| 00816 | 3 | 18 |
| 00888 | 31 | 31, retyped (2 now translated) |
| 01024 | 2 | 6 |
| 01131 | 6 | 11 |
| 01741 | 2 | 45 (43 now correctly translated, via fix 3) |
| 01762 | 13 | 26 |
| 01978 | 1 | 13 |

With works and matcher both fixed, all six of `00104.php`'s citation headings now match their
translation — five at 100% (auto-linked at ingest) and `אמיל, או על חינוך` at 94% (offered for
one-click confirmation).

## Test plan

New specs:
- `extract_person_works_spec.rb` — duplicate `Books` anchor on a work-type sub-header with a
  re-opened span (mirrors 00104.php's parsed shape); hard-wrapped work-type header (01741.php).
- `html_utils_spec.rb` — `works_section_end?` for a foreign anchor, a repeated `Books` anchor,
  and a non-header element.
- `match_citation_subjects_spec.rb` — heading crediting the translated work's author; heading
  whose quoted title contains a gershayim.

Ran green: `spec/services/lexicon` (all 352 examples incl. models). RuboCop clean on every
changed file. **The full suite was not run** — it takes 40+ minutes and needs your go-ahead.

## Notes for the reviewer

- **Data repair**: entries already migrated from these eight files keep their truncated works
  until re-ingested. All eight are still `raw` in my dev DB; if any are migrated on
  production/staging they need re-migration to pick this up.
- The pre-loop `if next_elem.name == 'span'` branch in `ExtractPersonWorks#call` is now
  duplicated by the in-loop handling. I left it alone rather than widen the diff — its
  `elsif next_elem.nil?` sibling handles a different case (a span *inside* the header element)
  and is still needed. Happy to collapse the two if you'd prefer.

Closes by-0vp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
