### PR TITLE
Stop a wide table from blowing the work text column out of its card

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1128,6 +1128,15 @@ small p{
 }
 .work-content{
   scroll-snap-type: y mandatory;
+  /* .work-area is a flex container and .work-content is a `flex: 1` item
+     (BY_styles_General.css). A flex item's automatic minimum size is its
+     min-content width, so a text containing a wide element -- e.g. the
+     `<div style="overflow-x:auto">`-wrapped tables MarkdownToHtml emits --
+     blows the column out past the surrounding .by-card-v02, and the body text
+     lays out at that inflated width, spilling over the card edge into the
+     gutter. min-width: 0 lets the column shrink to the space actually
+     available, so the wrapper scrolls the table instead. */
+  min-width: 0;
 }
 
 .hidden {

--- a/spec/system/manifestation_wide_table_overflow_spec.rb
+++ b/spec/system/manifestation_wide_table_overflow_spec.rb
@@ -46,8 +46,7 @@ describe 'Manifestation#read with a wide table', :js do
         var wc = document.querySelector('.work-content').getBoundingClientRect();
         var card = document.querySelector('.by-card-v02.proofable').getBoundingClientRect();
         return [wc.left, wc.right, card.left, card.right,
-                document.body.scrollWidth, document.documentElement.clientWidth];
-      })()
+                document.documentElement.scrollWidth, document.documentElement.clientWidth];
     JS
   end
 

--- a/spec/system/manifestation_wide_table_overflow_spec.rb
+++ b/spec/system/manifestation_wide_table_overflow_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for a text whose markdown contains a wide table (e.g. work 25626, the
+# "Habima repertoire" table). MarkdownToHtml wraps every <table> in a
+# `<div style="overflow-x:auto">` so wide tables scroll instead of stretching the page, but
+# .work-content is a `flex: 1` item of the flex container .work-area, and a flex item's
+# automatic minimum size is its min-content width. That made the column expand to the table's
+# min-content width, pushing it past the surrounding .by-card-v02 and laying the ordinary body
+# paragraphs out at the inflated width, so they spilled over the card edge into the gutter.
+describe 'Manifestation#read with a wide table', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  # Eight columns. The cells hold single unbreakable words, so each column's min-content width
+  # is the full word and the table's min-content width comfortably exceeds the text column.
+  let(:wide_table_markdown) do
+    header = (1..8).map { |i| "כותרתעמודהארוכהמאד#{i}" }
+    rows = (1..6).map { |r| (1..8).map { |c| "תוכןתאארוךומאודרחב#{r}#{c}" } }
+    [
+      'פסקה רגילה של טקסט לפני הטבלה.',
+      '',
+      "| #{header.join(' | ')} |",
+      "| #{(['---'] * 8).join(' | ')} |",
+      *rows.map { |row| "| #{row.join(' | ')} |" },
+      '',
+      'פסקה רגילה של טקסט אחרי הטבלה, שאמורה להישאר בתוך גבולות הכרטיס.'
+    ].join("\n")
+  end
+
+  let!(:text) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, orig_lang: 'he', status: :published, markdown: wide_table_markdown)
+    end
+  end
+
+  after { Chewy.massacre }
+
+  # Returns [work_content_left, work_content_right, card_left, card_right, body_scroll_width,
+  #          viewport_width] as measured in the browser.
+  def layout_metrics
+    page.evaluate_script(<<~JS)
+      (function () {
+        var wc = document.querySelector('.work-content').getBoundingClientRect();
+        var card = document.querySelector('.by-card-v02.proofable').getBoundingClientRect();
+        return [wc.left, wc.right, card.left, card.right,
+                document.body.scrollWidth, document.documentElement.clientWidth];
+      })()
+    JS
+  end
+
+  # 700px sits in the band where the blowout was worst: wide enough that .work-side-color is
+  # still displayed (BY_styles_Max639.css hides it and gives .work-content width: 100% below
+  # 640px), but too narrow to fit the table's min-content width.
+  [[700, 900], [1400, 900]].each do |width, height|
+    it "keeps the text column inside its card at #{width}px" do
+      page.driver.browser.manage.window.resize_to(width, height)
+      visit manifestation_path(text)
+      expect(page).to have_css('#actualtext table')
+
+      wc_left, wc_right, card_left, card_right, body_scroll_width, viewport_width = layout_metrics
+
+      # The text column must not stick out of the card on either side (it overflowed to the
+      # left, the far side in this RTL layout).
+      expect(wc_left).to be >= card_left - 1
+      expect(wc_right).to be <= card_right + 1
+
+      # ...and the page as a whole must not gain a horizontal scrollbar.
+      expect(body_scroll_width).to be <= viewport_width + 1
+    end
+  end
+
+  it 'still lets the wide table itself scroll horizontally' do
+    page.driver.browser.manage.window.resize_to(700, 900)
+    visit manifestation_path(text)
+    expect(page).to have_css('#actualtext table')
+
+    scrollable = page.evaluate_script(<<~JS)
+      (function () {
+        var wrap = document.querySelector('#actualtext div[style*="overflow-x"]');
+        return wrap ? wrap.scrollWidth > wrap.clientWidth : null;
+      })()
+    JS
+    expect(scrollable).to be true
+  end
+end


### PR DESCRIPTION
## Problem

On `manifestation#read`, a text whose markdown contains a wide table lays its **ordinary body paragraphs** out wider than the card they sit in, so the text spills over the card edge into the surrounding whitespace. Reproduced on [work 25626](http://localhost:3000/read/25626) (the "רפרטואר הבימה" table).

## Cause

`.work-area` is a flex container and `.work-content` is a `flex: 1` item (`BY_styles_General.css:2145`). A flex item's **automatic minimum size is its min-content width**, so the table stretched `.work-content` past the surrounding `.by-card-v02`. Everything inside — including the plain `<p>`s — then laid out at that inflated width.

This also defeated the `<div style="overflow-x:auto">` wrapper that `MarkdownToHtml` puts around every `<table>`: the wrapper was being sized to its content instead of scrolling it.

Measured on `/read/25626` before the fix:

| viewport | `.by-card-v02.proofable` | `.work-content` | page scrollbar |
|---|---|---|---|
| 1200px | w=590 (l=410) | **w=707 (l=293)** | no (spills into gutter) |
| 767px  | w=722 | w=707 | no |
| 700px  | w=655 (l=15) | **w=707 (l=-37)** | **yes** (`bodySW` 722 > `docW` 685) |
| 640px  | w=595 (l=15) | **w=707 (l=-97)** | **yes** |
| ≤576px | w=531 | w=531 | no |

It was invisible at phone widths because `BY_styles_Max639.css` already sets `.work-content { width: 100% }` below 640px, which caps the flex item's content-based minimum.

## Fix

`min-width: 0` on `.work-content` in `application.scss` — the canonical remedy for flexbox blowout. The column shrinks to the space actually available and the wrapper scrolls the table.

After the fix, at every width from 320px to 1400px `.work-content` stays inside the card, no body paragraph overflows `#actualtext`, and `document.body.scrollWidth == documentElement.clientWidth`.

## Test plan

New `spec/system/manifestation_wide_table_overflow_spec.rb` (3 examples) builds a manifestation whose markdown holds an 8-column table of unbreakable words and asserts, at 700px and 1400px, that `.work-content` stays within `.by-card-v02.proofable` on both sides and the page gains no horizontal scrollbar — plus that the table wrapper is still horizontally scrollable.

- **Verified the test catches the bug**: with `min-width: 0` commented out, all 3 examples fail (`expected: >= 499.79, got: -254.48`). With the fix, all 3 pass.
- Adjacent system specs re-run for regressions: `collection_reading_mode`, `manifestation_scrollspy`, `manifestation_search_highlight`, `readmode_icon_alignment`, `readmode_nav`, `manifestation_breadcrumbs`, `footnote_popover` — **33 examples, 0 failures**.
- **The full suite was not run** (40+ min, needs your approval).

## Notes

- RuboCop on the new spec reports only `RSpec/DescribeClass`, which every existing system spec in `spec/system/` also reports (e.g. `manifestation_breadcrumbs_spec.rb:10`). I left it consistent with its neighbours rather than adding a lone per-file disable.
- `min-width: 0` also affects `.work-content` on collection/print/authors-list pages, but it only has any effect when content min-content exceeds the available space — i.e. exactly this blowout case.

Closes bead `by-f4y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
