### PR TITLE
Credit the lexicon editor on the citations card

### DIFF
--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -243,7 +243,10 @@
           - if @lex_citations.any?
             .by-card-v02.left-side-card-v02
               .by-card-header-left-v02
-                %span.headline-1-v02= t(:lex_citations_about_collection)
+                -# wrapper so the credit line stacks under the title instead of becoming a flex sibling
+                %div
+                  %span.headline-1-v02= t(:lex_citations_about_collection)
+                  .lexicon-editor-credit= t('lexicon.header.editor_credit')
               .by-card-content-v02
                 %ul
                   - @lex_citations.each do |citation|

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -198,7 +198,10 @@
         - if @lex_citations.any?
           .by-card-v02.left-side-card-v02
             .by-card-header-left-v02
-              %span.headline-1-v02= t(:lex_citations_about_collection)
+              -# wrapper so the credit line stacks under the title instead of becoming a flex sibling
+              %div
+                %span.headline-1-v02= t(:lex_citations_about_collection)
+                .lexicon-editor-credit= t('lexicon.header.editor_credit')
             .by-card-content-v02
               %ul
                 - @lex_citations.each do |citation|

--- a/spec/requests/author_toc_filters_spec.rb
+++ b/spec/requests/author_toc_filters_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe 'Author TOC filters (server-rendered)', type: :request do
     create(:recommendation, manifestation: poem, status: :approved)
   end
 
-  def rendered
-    Capybara.string(response.body)
-  end
-
   it 'renders the hidden filters pane with dynamic genre and language options' do
     get authority_path(author)
     expect(response).to have_http_status(:ok)

--- a/spec/requests/collection_lex_citations_spec.rb
+++ b/spec/requests/collection_lex_citations_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe 'Collection LexCitations', type: :request do
         expect(response.body).to include('Test Citation')
         expect(response.body).to include('Test Publication')
       end
+
+      it 'credits the lexicon editor in the card header' do
+        get collection_path(collection)
+
+        expect(response.body).to include(I18n.t('lexicon.header.editor_credit'))
+      end
     end
 
     context 'when the collection is linked to a LexPersonWork with no citations' do
@@ -62,6 +68,13 @@ RSpec.describe 'Collection LexCitations', type: :request do
         get collection_path(collection)
 
         expect(response.body).not_to include(I18n.t(:lex_citations_about_collection))
+      end
+
+      # the credit belongs to the card, so with no card there is nothing to credit
+      it 'does not credit the lexicon editor' do
+        get collection_path(collection)
+
+        expect(response.body).not_to include(I18n.t('lexicon.header.editor_credit'))
       end
     end
 

--- a/spec/requests/collection_lex_citations_spec.rb
+++ b/spec/requests/collection_lex_citations_spec.rb
@@ -35,7 +35,12 @@ RSpec.describe 'Collection LexCitations', type: :request do
       it 'credits the lexicon editor in the card header' do
         get collection_path(collection)
 
-        expect(response.body).to include(I18n.t('lexicon.header.editor_credit'))
+        # scoped to the header carrying the citations headline, so this cannot be satisfied by a
+        # credit rendered by some other card, or anywhere else on the page
+        header = rendered.find('.by-card-header-left-v02',
+                               text: I18n.t(:lex_citations_about_collection), visible: :all)
+        expect(header).to have_css('.lexicon-editor-credit',
+                                   text: I18n.t('lexicon.header.editor_credit'), visible: :all)
       end
     end
 
@@ -74,7 +79,7 @@ RSpec.describe 'Collection LexCitations', type: :request do
       it 'does not credit the lexicon editor' do
         get collection_path(collection)
 
-        expect(response.body).not_to include(I18n.t('lexicon.header.editor_credit'))
+        expect(rendered).to have_no_css('.lexicon-editor-credit', visible: :all)
       end
     end
 

--- a/spec/requests/manifestation_lex_citations_spec.rb
+++ b/spec/requests/manifestation_lex_citations_spec.rb
@@ -40,7 +40,12 @@ RSpec.describe 'Manifestation LexCitations', type: :request do
       it 'credits the lexicon editor in the card header' do
         get manifestation_path(manifestation)
 
-        expect(response.body).to include(I18n.t('lexicon.header.editor_credit'))
+        # scoped to the header carrying the citations headline, so this cannot be satisfied by a
+        # credit rendered by some other card, or anywhere else on the page
+        header = rendered.find('.by-card-header-left-v02',
+                               text: I18n.t(:lex_citations_about_collection), visible: :all)
+        expect(header).to have_css('.lexicon-editor-credit',
+                                   text: I18n.t('lexicon.header.editor_credit'), visible: :all)
       end
     end
 
@@ -100,7 +105,7 @@ RSpec.describe 'Manifestation LexCitations', type: :request do
       it 'does not credit the lexicon editor' do
         get manifestation_path(manifestation)
 
-        expect(response.body).not_to include(I18n.t('lexicon.header.editor_credit'))
+        expect(rendered).to have_no_css('.lexicon-editor-credit', visible: :all)
       end
     end
 

--- a/spec/requests/manifestation_lex_citations_spec.rb
+++ b/spec/requests/manifestation_lex_citations_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe 'Manifestation LexCitations', type: :request do
         expect(response.body).to include('Test Citation')
         expect(response.body).to include('Test Publication')
       end
+
+      it 'credits the lexicon editor in the card header' do
+        get manifestation_path(manifestation)
+
+        expect(response.body).to include(I18n.t('lexicon.header.editor_credit'))
+      end
     end
 
     # The volume page redirects to this text (CollectionsController#show redirects when a collection
@@ -88,6 +94,13 @@ RSpec.describe 'Manifestation LexCitations', type: :request do
         get manifestation_path(manifestation)
 
         expect(response.body).not_to include(I18n.t(:lex_citations_about_collection))
+      end
+
+      # the credit belongs to the card, so with no card there is nothing to credit
+      it 'does not credit the lexicon editor' do
+        get manifestation_path(manifestation)
+
+        expect(response.body).not_to include(I18n.t('lexicon.header.editor_credit'))
       end
     end
 

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -10,6 +10,16 @@ module TestHelpers
   end
   # rubocop:enable RSpec/AnyInstance
 
+  # The last response's body as a Capybara node, so that a request spec can assert on selectors
+  # (`expect(rendered).to have_css(...)`) instead of grepping the raw HTML string. Asserting on a
+  # selector proves the markup was rendered where it belongs; a bare `body.include?('text')` also
+  # passes when the text happens to appear somewhere else entirely.
+  # Note this is Capybara::Node::Simple, not a session: it is a snapshot with no waiting behaviour,
+  # which is exactly right for a request spec (there is no JavaScript and nothing to wait for).
+  def rendered
+    Capybara.string(response.body)
+  end
+
   BROWSER_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120'
 
   # Ahoy.track_bots is false and the default controller-spec user agent ('Rails Testing') is


### PR DESCRIPTION
## What

Adds the lexicon editor credit line to the lexicon citations card on `Manifestation#read` and `Collection#show`.

## Why

Every other surface that shows lexicon content — the entry page (`lexicon/_header`), the entry list (`lexicon/entries/_list_top`), and the author TOC (`authors/_generated_toc`) — carries the `.lexicon-editor-credit` line under its title. The citations card was the one place showing lexicon material without naming its editor.

## How

Reuses the existing `lexicon.header.editor_credit` string and `.lexicon-editor-credit` class, so **no new I18n keys and no CSS changes** were needed.

The credit is wrapped in a plain `%div` together with the headline because `.by-card-header-left-v02` is `display: flex; flex-direction: row` — without the wrapper the credit would land beside the headline instead of under it. This is the same wrapper (and the same reason) as in `authors/_generated_toc.html.haml:35`.

## Tests

Extended the two existing request specs rather than adding new files:

- `spec/requests/manifestation_lex_citations_spec.rb` — credit shown when the card is shown; **not** shown when the manifestation is in no collection.
- `spec/requests/collection_lex_citations_spec.rb` — credit shown when the card is shown; **not** shown when the collection has no linked `LexPersonWork`.

The negative cases matter: the credit belongs to the card, so it must not leak onto pages that have no citations card.

```
bundle exec rspec spec/requests/collection_lex_citations_spec.rb spec/requests/manifestation_lex_citations_spec.rb
20 examples, 0 failures
```

Lint: `rubocop` clean on both specs. `haml-lint` on the two views introduces no new warning types — diffing the output against master, the only delta is the line count in the pre-existing `ViewLength` warning (both files were already 3x over that limit before this change).

**The full suite was not run** (40+ min, needs your approval).

## Bead

Closes `by-ozq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
