### PR TITLE
Preserve the general sub-headings of a lexicon bibliography

### DIFF
--- a/app/controllers/lexicon/citation_groups_controller.rb
+++ b/app/controllers/lexicon/citation_groups_controller.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Lexicon
+  # Manages the sub-headings of a person's general citations (ספרים, מאמרים, ...).
+  # See LexCitationGroup. Editors work with these from the citations tab of the entry editor;
+  # citations are moved between headings by dragging, or from the citation's own edit form.
+  class CitationGroupsController < ApplicationController
+    include LockLexEntryConcern
+
+    before_action do
+      require_editor('edit_lexicon')
+    end
+
+    before_action :set_person, only: %i(create)
+    before_action :set_group, only: %i(update destroy reorder)
+    before_action :try_to_lock_record
+
+    layout false
+
+    # Every action answers a bare status and lets the caller reload the citations pane, rather than
+    # rendering a fragment: adding, renaming or removing a heading reshuffles the whole list.
+    def create
+      @group = @person.citation_groups.build(citation_group_params)
+      return head :created if @group.save
+
+      render_errors(@group)
+    end
+
+    def update
+      return head :ok if @group.update(citation_group_params)
+
+      render_errors(@group)
+    end
+
+    # The heading goes; its citations stay, returning to the ungrouped general list
+    # (has_many :citations, dependent: :nullify).
+    def destroy
+      @group.destroy!
+      head :ok
+    end
+
+    # Repositions the heading among the person's other headings.
+    def reorder
+      new_index = params.fetch(:new_index).to_i # zero-based
+      groups = @person.citation_groups.to_a
+      old_index = groups.index(@group)
+
+      if old_index.nil? || !new_index.between?(0, groups.size - 1)
+        render plain: "cannot move heading to position #{new_index}", status: :bad_request
+        return
+      end
+
+      groups.delete_at(old_index)
+      groups.insert(new_index, @group)
+      groups.each_with_index do |group, index|
+        group.update_column(:seqno, index + 1) if group.seqno != index + 1
+      end
+
+      head :ok
+    end
+
+    private
+
+    def render_errors(group)
+      render plain: group.errors.full_messages.to_sentence, status: :unprocessable_content
+    end
+
+    def set_person
+      @person = LexPerson.find(params[:person_id])
+    end
+
+    def set_group
+      @group = LexCitationGroup.find(params[:id])
+      @person = @group.person
+    end
+
+    def record_to_lock
+      @person.lex_entry
+    end
+
+    def citation_group_params
+      params.expect(lex_citation_group: %i(title))
+    end
+  end
+end

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -134,9 +134,10 @@ module Lexicon
 
     # Whether a token names one of the general buckets a citation may be dragged in or out of:
     # the ungrouped general citations, or a general sub-heading. A work's list, and a heading still
-    # carrying an unresolved legacy subject, are not. Renders the refusal itself.
+    # carrying an unresolved legacy subject, are not -- and a work titled 'heading:something' must
+    # not pass for one either, hence the exact 'heading:<id>' match. Renders the refusal itself.
     def general_bucket?(token)
-      return true if token.nil? || token.start_with?(LexCitation::HEADING_TOKEN_PREFIX)
+      return true if token.nil? || LexCitation.heading_token_group_id(token).present?
 
       render plain: "'#{token}' is not a general citation heading", status: :bad_request
       false
@@ -147,8 +148,7 @@ module Lexicon
     def resolve_general_group(token)
       return nil if token.nil?
 
-      group_id = token.delete_prefix(LexCitation::HEADING_TOKEN_PREFIX).to_i
-      group = @person.citation_groups.find_by(id: group_id)
+      group = @person.citation_groups.find_by(id: LexCitation.heading_token_group_id(token))
       render plain: "unknown citation group '#{token}'", status: :bad_request if group.nil?
       group
     end

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -26,8 +26,8 @@ module Lexicon
     def create
       @citation = @person.citations.build(lex_citation_params)
 
-      # Assign seqno as the last position in the subject_title group
-      @citation.seqno = @person.max_citation_seqno_by_subject_title(@citation.subject_title) + 1
+      # Assign seqno as the last position in the heading's group
+      @citation.seqno = @person.max_citation_seqno_by_group_token(@citation.group_token) + 1
 
       return if @citation.save
 
@@ -37,16 +37,16 @@ module Lexicon
     def edit; end
 
     def update
-      old_subject_title = @citation.subject_title
+      old_group_token = @citation.group_token
       # Captured before assign_attributes: link_broken? must be evaluated against the stored link
       link_was_broken = @citation.link_broken?
       old_link = @citation.link
       @citation.assign_attributes(lex_citation_params)
-      new_subject_title = @citation.subject_title
+      new_group_token = @citation.group_token
 
-      # If subject_title changed, move item to the bottom of new subject_title group
-      if new_subject_title != old_subject_title
-        max_seqno = @person.max_citation_seqno_by_subject_title(new_subject_title, exclude_citation_id: @citation.id)
+      # If the heading changed, move item to the bottom of the new group
+      if new_group_token != old_group_token
+        max_seqno = @person.max_citation_seqno_by_group_token(new_group_token, exclude_citation_id: @citation.id)
         @citation.seqno = max_seqno + 1
       end
 
@@ -79,41 +79,89 @@ module Lexicon
       remove_text_link_from(@citation, :text_links)
     end
 
+    # Repositions a citation within its heading's group, or -- when to_group_token names a
+    # different one -- moves it to a position in that group. Only the general buckets (the
+    # ungrouped citations and the general sub-headings) can be dragged between: moving a citation
+    # under a work changes what it is about, which is the edit form's business, not a drag's.
     def reorder
       new_index = params.fetch(:new_index).to_i # zero-based
       old_index = params.fetch(:old_index).to_i # zero-based
-      subject_title = params[:subject_title]
+      from_token = params[:group_token].presence
+      to_token = params.key?(:to_group_token) ? params[:to_group_token].presence : from_token
 
-      if @citation.subject_title != subject_title
-        render plain: "subject_title mismatch, actual: '#{@citation.subject_title}', got: '#{subject_title}'",
+      if @citation.group_token != from_token
+        render plain: "group_token mismatch, actual: '#{@citation.group_token}', got: '#{from_token}'",
                status: :bad_request
         return
       end
 
-      # Get all citations for the same person and subject_title
-      citations = @person.citations_by_subject_title(subject_title).sort_by(&:seqno)
-
-      real_old_index = citations.index(@citation)
+      source = @person.citations_by_group_token(from_token).sort_by(&:seqno)
+      real_old_index = source.index(@citation)
       if old_index != real_old_index
         render plain: "old_index mismatch, actual: #{real_old_index}, got: #{old_index}", status: :bad_request
         return
       end
 
-      return head :ok if old_index == new_index
+      return head :ok if from_token == to_token && old_index == new_index
 
-      citations.delete_at(old_index)
-      citations.insert(new_index, @citation)
+      source.delete_at(old_index)
 
-      # Reassign seqno values
-      citations.each_with_index do |c, index|
-        c.seqno = index + 1
-        c.save(validate: false) if c.attribute_changed?(:seqno)
+      if from_token == to_token
+        target = source
+      else
+        # Both ends have to be general buckets. Dragging a citation out of a work's list would
+        # leave it both about a work and under a general sub-heading, which LexCitation forbids --
+        # and renumber saves without validating, so nothing downstream would catch it.
+        return unless general_bucket?(from_token) && general_bucket?(to_token)
+
+        target_group = resolve_general_group(to_token)
+        return if performed?
+
+        # Read the target list before reassigning: @citation is a separate instance from the copy
+        # @person.citations holds, so the list would otherwise contain it twice.
+        target = @person.citations_by_group_token(to_token).sort_by(&:seqno)
+        @citation.citation_group = target_group
+        renumber(source)
       end
+
+      target.insert(new_index.clamp(0, target.size), @citation)
+      renumber(target)
 
       head :ok
     end
 
     private
+
+    # Whether a token names one of the general buckets a citation may be dragged in or out of:
+    # the ungrouped general citations, or a general sub-heading. A work's list, and a heading still
+    # carrying an unresolved legacy subject, are not. Renders the refusal itself.
+    def general_bucket?(token)
+      return true if token.nil? || token.start_with?(LexCitation::HEADING_TOKEN_PREFIX)
+
+      render plain: "'#{token}' is not a general citation heading", status: :bad_request
+      false
+    end
+
+    # The LexCitationGroup a drag target token names, or nil for the ungrouped general citations.
+    # Renders an error (leaving #performed? true) when it names no heading of this person.
+    def resolve_general_group(token)
+      return nil if token.nil?
+
+      group_id = token.delete_prefix(LexCitation::HEADING_TOKEN_PREFIX).to_i
+      group = @person.citation_groups.find_by(id: group_id)
+      render plain: "unknown citation group '#{token}'", status: :bad_request if group.nil?
+      group
+    end
+
+    # Writes 1..n into the seqno of a group's citations. Saves any citation with a pending change,
+    # not only a changed seqno: a citation dragged into another group keeps its position number as
+    # often as not, and its new lex_citation_group_id still has to be written.
+    def renumber(citations)
+      citations.each_with_index do |citation, index|
+        citation.seqno = index + 1
+        citation.save(validate: false) if citation.changed?
+      end
+    end
 
     def set_person
       @person = LexPerson.find(params[:person_id])
@@ -132,7 +180,7 @@ module Lexicon
     # Only allow a list of trusted parameters through.
     def lex_citation_params
       params.expect(lex_citation: %i(title from_publication pages link backup_url manifestation_id subject
-                                     lex_person_work_id notes))
+                                     lex_person_work_id lex_citation_group_id notes))
     end
   end
 end

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -204,9 +204,14 @@ module Lexicon
       render json: { success: false, error: e.message }, status: :unprocessable_content
     end
 
+    # The work_id standing for "this heading is a sub-heading of the general citations", rather
+    # than the title of one of the person's works. See LexCitationGroup.
+    GENERAL_HEADING_WORK_ID = 'heading'
+
     # PATCH /lexicon/verification/:id/confirm_citation_subject
     # Resolves one legacy citation subject heading: points every citation under it at the given
-    # work, or -- with a blank work_id -- clears the heading as a general one about the person.
+    # work, keeps it as a general sub-heading, or -- with a blank work_id -- drops it, leaving its
+    # citations as plain general ones about the person.
     def confirm_citation_subject
       person = @entry.lex_item
       subject = params[:subject].to_s
@@ -216,8 +221,12 @@ module Lexicon
         return
       end
 
-      work = person.works.find(params[:work_id]) if params[:work_id].present?
-      count = person.link_citations_with_subject!(subject, work)
+      count = if params[:work_id] == GENERAL_HEADING_WORK_ID
+                person.group_citations_with_subject!(subject, Lexicon::MatchCitationSubjects.normalize_subject(subject))
+              else
+                work = person.works.find(params[:work_id]) if params[:work_id].present?
+                person.link_citations_with_subject!(subject, work)
+              end
 
       render json: {
         success: true,

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -162,9 +162,10 @@ module LexiconHelper
   #
   # +kind+ tells apart the three things a heading can be, which are worded differently: :general
   # (the citations about the person carrying no sub-heading), :heading (a general sub-heading such
-  # as ספרים -- a category, shown verbatim), and :subject (a work the citations are about, shown
-  # as 'על ״...״'). +token+ is LexCitation#group_token, the key the citations were grouped by.
-  CitationHeading = Struct.new(:kind, :token, :title) do
+  # as ספרים -- a category, shown verbatim), and :work/:subject (a work the citations are about,
+  # shown as 'על ״...״'). +token+ is LexCitation#group_token, the key the citations were grouped
+  # by, and +position+ the heading's order within its kind (a group's or a work's seqno).
+  CitationHeading = Struct.new(:kind, :token, :title, :position) do
     def general?
       kind == :general
     end
@@ -174,6 +175,9 @@ module LexiconHelper
       kind == :heading
     end
   end
+
+  # The order the kinds of heading appear in; see #heading_order.
+  HEADING_KIND_ORDER = { general: 0, heading: 1, work: 2, subject: 3 }.freeze
 
   # The wording of a heading. A general sub-heading names a category of writing about the person,
   # not a work, so it is shown as it stands rather than run through the 'על ״...״' template.
@@ -330,8 +334,8 @@ module LexiconHelper
     # an author with no name of its own derives its display name from the entry (see
     # LexEntry#surname_first_title), which consults the file of a not-yet-ingested entry
     grouped_citations = lex_person.citations.preload(authors: { entry: :lex_file })
-                                  .group_by { |c| citation_heading(c.group_token, person_works, groups) }
-                                  .sort_by { |heading, _entries| heading_order(heading, person_works, groups) }
+                                  .group_by { |c| citation_heading(c, person_works, groups) }
+                                  .sort_by { |heading, _entries| heading_order(heading) }
                                   .to_h
 
     # sort all citations inside heading groups by seqno
@@ -344,28 +348,27 @@ module LexiconHelper
 
   private
 
-  # Builds the CitationHeading a group token stands for. A token naming a group that has since been
-  # deleted cannot occur -- the association nullifies its citations' lex_citation_group_id -- but a
-  # stale in-memory citation could still carry one, so fall back to the general heading.
-  def citation_heading(token, person_works, groups)
-    if token.nil?
-      CitationHeading.new(:general, nil, nil)
-    elsif token.start_with?(LexCitation::HEADING_TOKEN_PREFIX)
-      group = groups[token.delete_prefix(LexCitation::HEADING_TOKEN_PREFIX).to_i]
-      group.nil? ? CitationHeading.new(:general, nil, nil) : CitationHeading.new(:heading, token, group.title)
-    else
-      CitationHeading.new(person_works.key?(token) ? :work : :subject, token, token)
-    end
+  # Builds the CitationHeading a citation is displayed under.
+  #
+  # Whether a citation is under a sub-heading is read from its foreign key, not from the shape of
+  # its group token: a work title and a legacy subject are group tokens in their own right, so a
+  # title reading 'heading:5' would otherwise be taken for the sub-heading of that id -- and one
+  # reading 'heading:foo', its id parsing to 0, quietly emptied into the general bucket.
+  def citation_heading(citation, person_works, groups)
+    group = groups[citation.lex_citation_group_id]
+    return CitationHeading.new(:heading, citation.group_token, group.title, group.seqno) if group.present?
+
+    title = citation.subject_title
+    return CitationHeading.new(:general, nil, nil, 0) if title.nil?
+
+    work = person_works[title]
+    CitationHeading.new(work ? :work : :subject, title, title, work&.seqno || 0)
   end
 
   # General citations first (ungrouped, then the sub-headings in the editor's order), then the
   # citations about works in work order, then headings still carrying an unresolved legacy subject.
-  def heading_order(heading, person_works, groups)
-    case heading.kind
-    when :general then [0, 0, '']
-    when :heading then [1, groups[heading.token.delete_prefix(LexCitation::HEADING_TOKEN_PREFIX).to_i].seqno, '']
-    when :work then [2, person_works[heading.title].seqno, '']
-    else [3, 0, heading.title]
-    end
+  # Each heading carries its own position, so nothing has to be looked up a second time here.
+  def heading_order(heading)
+    [HEADING_KIND_ORDER.fetch(heading.kind), heading.position, heading.title.to_s]
   end
 end

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -158,6 +158,31 @@ module LexiconHelper
     end
   end
 
+  # One heading of a person's citation list, as produced by #grouped_and_ordered_citations.
+  #
+  # +kind+ tells apart the three things a heading can be, which are worded differently: :general
+  # (the citations about the person carrying no sub-heading), :heading (a general sub-heading such
+  # as ספרים -- a category, shown verbatim), and :subject (a work the citations are about, shown
+  # as 'על ״...״'). +token+ is LexCitation#group_token, the key the citations were grouped by.
+  CitationHeading = Struct.new(:kind, :token, :title) do
+    def general?
+      kind == :general
+    end
+
+    # Whether an editor may rename, delete and reorder this heading (see LexCitationGroup).
+    def editable?
+      kind == :heading
+    end
+  end
+
+  # The wording of a heading. A general sub-heading names a category of writing about the person,
+  # not a work, so it is shown as it stands rather than run through the 'על ״...״' template.
+  def citations_heading_text(heading)
+    return heading.title if heading.editable?
+
+    citations_subject_header(heading.title)
+  end
+
   EXTERNAL_IDENTIFIER_URLS = {
     'lc' => ->(id) { "https://id.loc.gov/authorities/#{id}" },
     'viaf' => ->(id) { "https://viaf.org/viaf/#{id}" },
@@ -292,36 +317,55 @@ module LexiconHelper
     safe_join(lines, tag.br)
   end
 
+  # A person's citations grouped under their headings, in display order.
+  #
+  # @return [Hash{CitationHeading => Array<LexCitation>}] each group's citations sorted by seqno.
+  #   The general citations come first -- the ungrouped ones, then each general sub-heading in the
+  #   editor's order -- followed by the citations about the person's works in work order, and
+  #   finally any heading still carrying an unresolved legacy subject.
   def grouped_and_ordered_citations(lex_person)
     person_works = lex_person.works.index_by(&:title)
+    groups = lex_person.citation_groups.index_by(&:id)
     # we preload data required for citations rendering, down to the entry's lex_file:
     # an author with no name of its own derives its display name from the entry (see
     # LexEntry#surname_first_title), which consults the file of a not-yet-ingested entry
     grouped_citations = lex_person.citations.preload(authors: { entry: :lex_file })
-                                  .group_by(&:subject_title).sort_by do |subject_title, _entries|
-      work = person_works[subject_title] if subject_title.present?
-      # sort General (empty subject) first, then titles associated with Person Works, then custom titles
-      ord = if subject_title.nil?
-              0 # general citations without subject first
-            elsif work.present?
-              1 # then citations associated with existing works
-            else
-              2 # then citations with manually entered subject
-            end
-      [
-        ord,
-        work&.seqno || 1_000_000,
-        subject_title || '' # if we use custom subject-title not linked to work, sort them by subject_title
-      ]
-    end
+                                  .group_by { |c| citation_heading(c.group_token, person_works, groups) }
+                                  .sort_by { |heading, _entries| heading_order(heading, person_works, groups) }
+                                  .to_h
 
-    grouped_citations = grouped_citations.to_h
-
-    # sort all citations inside subject_title groups by seqno
+    # sort all citations inside heading groups by seqno
     grouped_citations.each_value do |entries|
       entries.sort_by! { |citation| [citation.seqno, citation.id] }
     end
 
     grouped_citations
+  end
+
+  private
+
+  # Builds the CitationHeading a group token stands for. A token naming a group that has since been
+  # deleted cannot occur -- the association nullifies its citations' lex_citation_group_id -- but a
+  # stale in-memory citation could still carry one, so fall back to the general heading.
+  def citation_heading(token, person_works, groups)
+    if token.nil?
+      CitationHeading.new(:general, nil, nil)
+    elsif token.start_with?(LexCitation::HEADING_TOKEN_PREFIX)
+      group = groups[token.delete_prefix(LexCitation::HEADING_TOKEN_PREFIX).to_i]
+      group.nil? ? CitationHeading.new(:general, nil, nil) : CitationHeading.new(:heading, token, group.title)
+    else
+      CitationHeading.new(person_works.key?(token) ? :work : :subject, token, token)
+    end
+  end
+
+  # General citations first (ungrouped, then the sub-headings in the editor's order), then the
+  # citations about works in work order, then headings still carrying an unresolved legacy subject.
+  def heading_order(heading, person_works, groups)
+    case heading.kind
+    when :general then [0, 0, '']
+    when :heading then [1, groups[heading.token.delete_prefix(LexCitation::HEADING_TOKEN_PREFIX).to_i].seqno, '']
+    when :work then [2, person_works[heading.title].seqno, '']
+    else [3, 0, heading.title]
+    end
   end
 end

--- a/app/models/lex_citation.rb
+++ b/app/models/lex_citation.rb
@@ -54,6 +54,16 @@ class LexCitation < ApplicationRecord
   # Prefix marking a group token as naming a LexCitationGroup rather than a subject title.
   HEADING_TOKEN_PREFIX = 'heading:'
 
+  # The full shape of such a token. Matching the prefix alone would not do: a work title or a
+  # legacy subject heading is a group token in its own right, and one reading 'heading:whatever'
+  # would be taken for a sub-heading it is not.
+  HEADING_TOKEN_RE = /\A#{HEADING_TOKEN_PREFIX}(\d+)\z/
+
+  # The id of the LexCitationGroup a group token names, or nil when it names anything else.
+  def self.heading_token_group_id(group_token)
+    group_token.to_s[HEADING_TOKEN_RE, 1]&.to_i
+  end
+
   # Stable identifier of the heading this citation is displayed under: the key the citation lists
   # are grouped by, and the name a group goes by in the reordering endpoint.
   #

--- a/app/models/lex_citation.rb
+++ b/app/models/lex_citation.rb
@@ -16,6 +16,13 @@ class LexCitation < ApplicationRecord
              class_name: 'LexPersonWork', inverse_of: :citations_about,
              foreign_key: :lex_person_work_id, optional: true
 
+  # optional sub-heading this citation sits under within the general (about-the-person) citations,
+  # e.g. ספרים or מאמרים. Mutually exclusive with person_work: a citation about a work is already
+  # grouped by that work.
+  belongs_to :citation_group,
+             class_name: 'LexCitationGroup', inverse_of: :citations,
+             foreign_key: :lex_citation_group_id, optional: true
+
   belongs_to :manifestation, optional: true # manifestation representing this citation (if present in BYP)
 
   has_many :authors, class_name: 'LexCitationAuthor', inverse_of: :citation, dependent: :destroy
@@ -25,6 +32,8 @@ class LexCitation < ApplicationRecord
   validates :title, presence: true
 
   validate :person_work_belongs_to_same_person
+  validate :citation_group_belongs_to_same_person
+  validate :citation_group_only_on_general_citation
 
   # Subject is a string title of the work this citation is about (if any) and filled during parsing of legacy PHP files.
   # We should replace all subjects with person_work references where possible, and then clear the subject field.
@@ -40,6 +49,23 @@ class LexCitation < ApplicationRecord
 
   def subject_title
     return person_work&.title || subject
+  end
+
+  # Prefix marking a group token as naming a LexCitationGroup rather than a subject title.
+  HEADING_TOKEN_PREFIX = 'heading:'
+
+  # Stable identifier of the heading this citation is displayed under: the key the citation lists
+  # are grouped by, and the name a group goes by in the reordering endpoint.
+  #
+  # A general sub-heading is identified by id rather than by its title, because a person may well
+  # have a work titled 'מאמרים' too, and keying both on the bare title would silently merge the
+  # two groups. Work citations and citations still carrying a legacy subject heading do keep
+  # sharing a key when their titles agree -- that is what lets a half-resolved bibliography show
+  # one heading rather than two identical ones.
+  def group_token
+    return "#{HEADING_TOKEN_PREFIX}#{lex_citation_group_id}" if lex_citation_group_id.present?
+
+    subject_title
   end
 
   # The displayed prose that text_links pairs are matched against (see
@@ -70,5 +96,20 @@ class LexCitation < ApplicationRecord
     return if person_work.lex_person_id == lex_person_id
 
     errors.add(:person_work, :belongs_to_different_person)
+  end
+
+  def citation_group_belongs_to_same_person
+    return if citation_group.nil?
+    return if citation_group.lex_person_id == lex_person_id
+
+    errors.add(:citation_group, :belongs_to_different_person)
+  end
+
+  # A general sub-heading buckets citations about the person. A citation about one of the person's
+  # works belongs under that work instead, so the two groupings can never both apply.
+  def citation_group_only_on_general_citation
+    return if citation_group.nil? || person_work.nil?
+
+    errors.add(:citation_group, :not_on_work_citation)
   end
 end

--- a/app/models/lex_citation_group.rb
+++ b/app/models/lex_citation_group.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# A sub-heading of the general citations about a lexicon person: ספרים, מאמרים, ספרי יובל,
+# ביבליוגרפיה and the like. The legacy PHP bibliographies carry these as bare <font> headers above
+# each <ul>, and the distinction between them is editorial information worth keeping, so each one
+# becomes a named, ordered bucket a general citation can belong to.
+#
+# Only general citations are grouped: a citation about one of the person's works is already grouped
+# by that work. Deleting a group returns its citations to the ungrouped general list rather than
+# destroying them -- an editor removing a heading means "these are just general", never "throw these
+# away".
+class LexCitationGroup < ApplicationRecord
+  belongs_to :person, class_name: 'LexPerson', inverse_of: :citation_groups, foreign_key: :lex_person_id
+
+  has_many :citations, class_name: 'LexCitation', inverse_of: :citation_group, dependent: :nullify
+
+  validates :title, presence: true, uniqueness: { scope: :lex_person_id }
+
+  scope :ordered, -> { order(:seqno, :id) }
+
+  before_validation do
+    self.title = title&.strip.presence
+    # Read through the association rather than with a MAX query: during ingest the person is still
+    # unsaved and its groups exist only in memory.
+    siblings = person.nil? ? [] : person.citation_groups
+    self.seqno ||= (siblings.filter_map(&:seqno).max || 0) + 1
+  end
+end

--- a/app/models/lex_person.rb
+++ b/app/models/lex_person.rb
@@ -8,6 +8,9 @@ class LexPerson < ApplicationRecord
   enum :gender, { male: 0, female: 1, other: 2, unknown: 3 }
 
   has_many :citations, inverse_of: :person, class_name: 'LexCitation', dependent: :destroy
+  # Sub-headings of the general citations (ספרים, מאמרים, ...) -- see LexCitationGroup
+  has_many :citation_groups, -> { ordered }, inverse_of: :person, class_name: 'LexCitationGroup',
+                                             dependent: :destroy
   has_many :works, inverse_of: :person, class_name: 'LexPersonWork', dependent: :destroy
 
   belongs_to :authority, optional: true # link to an Authority record representing this person in BYP
@@ -51,14 +54,15 @@ class LexPerson < ApplicationRecord
     works_by_type(work_type).map(&:seqno).max || 0
   end
 
-  # TODO: after finishing Lexicon migration and removal of Lex_Citations.subject column
-  #   we should pass lex_person_work_id here and rename method appropriately
-  def citations_by_subject_title(subject_title)
-    citations.select { |c| c.subject_title == subject_title }
+  # Citations displayed under one heading, identified by LexCitation#group_token: a general
+  # sub-heading ('heading:<id>'), a work or legacy subject title, or nil for the citations that
+  # are general and carry no sub-heading.
+  def citations_by_group_token(group_token)
+    citations.select { |c| c.group_token == group_token }
   end
 
-  def max_citation_seqno_by_subject_title(subject_title, exclude_citation_id: nil)
-    cits = citations_by_subject_title(subject_title)
+  def max_citation_seqno_by_group_token(group_token, exclude_citation_id: nil)
+    cits = citations_by_group_token(group_token)
     cits = cits.reject { |c| c.id == exclude_citation_id } if exclude_citation_id.present?
     cits.map(&:seqno).compact.max || 0
   end
@@ -79,6 +83,20 @@ class LexPerson < ApplicationRecord
   def link_citations_with_subject!(subject, work)
     resolved = citations.where(subject: subject).to_a
     resolved.each { |citation| citation.update!(person_work: work, subject: nil) }
+    resolved.size
+  end
+
+  # Resolves one legacy citation subject heading the other way: as a sub-heading of the general
+  # citations rather than the title of a work (see LexCitationGroup). Every citation still carrying
+  # the heading moves under a group of that name, which is created if this is the first one.
+  #
+  # @param subject [String] the heading as stored on the citations
+  # @param title [String] the name to give the group, defaulting to the heading itself
+  # @return [Integer] how many citations were resolved
+  def group_citations_with_subject!(subject, title = subject)
+    group = citation_groups.find_or_create_by!(title: title.strip)
+    resolved = citations.where(subject: subject).to_a
+    resolved.each { |citation| citation.update!(citation_group: group, subject: nil) }
     resolved.size
   end
 end

--- a/app/services/lexicon/extract_citations.rb
+++ b/app/services/lexicon/extract_citations.rb
@@ -11,8 +11,18 @@ module Lexicon
     CITATIONS_START_TAGS = %w(font ul li).freeze
 
     def call(html_doc)
+      html = section_html(html_doc)
+      return [] if html.nil?
+
+      Lexicon::ParseCitations.call(html)
+    end
+
+    # The raw HTML of the bibliography section, or nil when the file has none. Split out of #call so
+    # that the section can be re-read without paying for an LLM parse -- see
+    # Lexicon::RecoverCitationHeadings, which needs the sub-headings the parse throws away.
+    def section_html(html_doc)
       header = header_element(html_doc)
-      return [] if header.nil?
+      return nil if header.nil?
 
       # The next element should open the citations section. Sometimes there could be one or more
       # blank paragraphs before it, so we skip blank elements that cannot open the section. Section
@@ -22,7 +32,7 @@ module Lexicon
         citations_node = citations_node.next_element
       end
 
-      return [] if citations_node.nil? || !citations_start?(citations_node)
+      return nil if citations_node.nil? || !citations_start?(citations_node)
 
       html_nodes = [citations_node]
 
@@ -63,7 +73,7 @@ module Lexicon
       # sections (e.g. Links block, so we cannot simply remove it)
       # header.remove
       # citations_node.remove
-      Lexicon::ParseCitations.call(html)
+      html
     end
 
     private

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -109,13 +109,14 @@ module Lexicon
       copy.to_html
     end
 
-    # Links the citation subject headings whose work is beyond doubt. Everything else -- a heading
-    # naming no work, naming one only approximately, or fitting two works equally well -- is left
-    # for an editor to resolve in the verification workbench's citation-headings section.
+    # Resolves the citation subject headings that are beyond doubt: those naming exactly one work,
+    # and the recognized general categories (ספרים, מאמרים, ...), which become general sub-headings
+    # keeping their name. Everything else -- a heading naming no work, naming one only
+    # approximately, or fitting two works equally well -- is left for an editor to resolve in the
+    # verification workbench's citation-headings section.
     def link_citations_to_works(lex_person)
-      MatchCitationSubjects.call(lex_person).select(&:certain?).each do |proposal|
-        lex_person.link_citations_with_subject!(proposal.subject, proposal.work)
-      end
+      MatchCitationSubjects.call(lex_person).select(&:certain?).sort_by(&:source_position)
+                           .each { |proposal| proposal.apply!(lex_person) }
     end
 
     def attach_backup_files(lex_person)

--- a/app/services/lexicon/match_citation_subjects.rb
+++ b/app/services/lexicon/match_citation_subjects.rb
@@ -8,15 +8,29 @@ module Lexicon
   # migration stored each heading verbatim on every citation below it (LexCitation#subject).
   # A citation still carrying a subject is invisible to the public citations cards, which are
   # driven by LexPersonWork#citations_about — so every heading has to end up either linked to a
-  # work or cleared as a general heading about the person.
+  # work or kept as a general sub-heading about the person (LexCitationGroup).
   #
-  # Nothing here writes: it returns proposals, which the ingest auto-links when they are certain
-  # and an editor confirms in the verification workbench when they are not. Use
-  # LexPerson#link_citations_with_subject! to apply one.
+  # The matching itself writes nothing: it returns proposals, which the ingest applies when they
+  # are certain and an editor confirms in the verification workbench when they are not. Apply one
+  # with Proposal#apply!.
   class MatchCitationSubjects < ApplicationService
-    # Headings that bucket citations about the person rather than about one particular work.
-    # These are cleared without a work, leaving their citations as general citations.
-    GENERIC_SUBJECTS = ['מאמרים', 'ספרים', 'על הספר'].freeze
+    # Headings that bucket citations about the person by kind of writing rather than naming one
+    # particular work. These become general sub-headings (LexCitationGroup) keeping their name,
+    # instead of being linked to a work.
+    #
+    # Drawn from a frequency survey of the a[name="Bib."] section of all 4,051 legacy person files:
+    # these are every heading that recurs across entries, which is what tells a category apart from
+    # a work title (of the ~9,200 distinct headings, the rest are 'על "..."' naming one work each).
+    GENERIC_SUBJECTS = [
+      'מאמרים', 'ספרים', 'על הספר', 'ביבליוגרפיה', 'ביבליוגרפיות', 'ספרי יובל', 'ספר יובל',
+      'ספרי יובל וזכרון', 'מונוגרפיות', 'מאמרים ורשימות', 'מבחר מאמרים מקוונים', 'מבחר שירים מקוונים'
+    ].freeze
+
+    # Legacy headings are written with a trailing colon about half the time ('ספרים:' as often as
+    # 'ספרים'), which is punctuation of the source layout rather than part of the name.
+    def self.normalize_subject(subject)
+      subject.to_s.strip.delete_suffix(':').strip
+    end
 
     # Headings read "about X" where the work itself is titled "X" — ParseCitations is supposed to
     # strip this, but the LLM leaves it in often enough that the matcher has to cope with it.
@@ -35,14 +49,36 @@ module Lexicon
 
     Proposal = Struct.new(:subject, :citations, :work, :similarity, :generic, :ambiguous,
                           keyword_init: true) do
-      # Good enough to apply without an editor looking at it: one work, identical once normalized.
+      # Good enough to apply without an editor looking at it: a heading naming exactly one work,
+      # identical once normalized, or one of the recognized general categories.
       def certain?
-        work.present? && similarity == 100
+        generic || (work.present? && similarity == 100)
       end
 
       # Whether there is anything for an editor to confirm, as opposed to pick by hand.
       def proposed?
         generic || work.present?
+      end
+
+      # The name the heading takes as a general sub-heading, i.e. without the layout punctuation.
+      def heading_title
+        MatchCitationSubjects.normalize_subject(subject)
+      end
+
+      # Where the heading stood in the source bibliography. Citations are inserted in source order,
+      # so their ids say what their seqno cannot: seqno restarts at 1 under every heading.
+      # Applying proposals in this order gives the sub-headings the order they had in the source.
+      def source_position
+        citations.filter_map(&:id).min || 0
+      end
+
+      # Resolves the heading: a general category becomes a sub-heading of the person's general
+      # citations, keeping its name; anything else points its citations at the work it names.
+      # @return [Integer] how many citations were resolved
+      def apply!(person)
+        return person.group_citations_with_subject!(subject, heading_title) if generic
+
+        person.link_citations_with_subject!(subject, work)
       end
     end
 
@@ -59,7 +95,7 @@ module Lexicon
     private
 
     def build_proposal(subject, citations, works)
-      if GENERIC_SUBJECTS.include?(subject.strip)
+      if GENERIC_SUBJECTS.include?(self.class.normalize_subject(subject))
         return Proposal.new(subject: subject, citations: citations, generic: true)
       end
 

--- a/app/services/lexicon/recover_citation_headings.rb
+++ b/app/services/lexicon/recover_citation_headings.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Lexicon
+  # Recovers the general sub-headings (ספרים, מאמרים, ספרי יובל, ...) of an already-migrated
+  # person's bibliography from their legacy PHP file.
+  #
+  # Until LexCitationGroup existed the migration threw those headings away: a heading recognized as
+  # a general category had its citations cleared (LexPerson#link_citations_with_subject! with no
+  # work), conflating every group into one flat general list. This re-reads the source, works out
+  # which heading each general citation sat under, and puts it back.
+  #
+  # Only the citations that are general *and* ungrouped are touched, so it is safe to re-run and
+  # never disturbs an editor's decisions: a citation linked to a work, already under a sub-heading,
+  # or still carrying an unresolved subject is left exactly as it is.
+  class RecoverCitationHeadings < ApplicationService
+    # Why a person was passed over, for the caller's report.
+    Result = Struct.new(:person_id, :skipped, :groups, :grouped_count, :unmatched_count,
+                        keyword_init: true) do
+      def skipped?
+        skipped.present?
+      end
+    end
+
+    # Shorter than this a title matches too much of the source text to be trusted; the same floor
+    # ParseCitations uses when it joins parsed citations back to the <li> they came from.
+    MIN_MATCHABLE_TITLE = 8
+
+    # @param person [LexPerson]
+    # @return [Result]
+    def call(person)
+      @person = person
+      path = person.entry&.lex_file&.full_path
+      return Result.new(person_id: person.id, skipped: :no_legacy_file) if path.blank? || !File.exist?(path)
+
+      items = source_items(path)
+      return Result.new(person_id: person.id, skipped: :no_headings_in_source) if items.empty?
+
+      assign(items)
+    end
+
+    private
+
+    # The <li> elements of the legacy bibliography that sit under a recoverable general
+    # sub-heading, in source order, each with the heading it belongs to.
+    def source_items(path)
+      html = Lexicon::ExtractCitations.new.section_html(HtmlUtils.parse_file(path))
+      return [] if html.blank?
+
+      heading = nil
+      Nokogiri::HTML::DocumentFragment.parse(html).css('*').filter_map do |node|
+        next if node.ancestors('li').any? # content of a citation, never a heading of its own
+
+        if node.name == 'li'
+          next if heading.nil?
+
+          { heading: heading, text: normalize(own_text(node)) }
+        elsif %w(font b p).include?(node.name) && node.css('ul, li').empty?
+          heading = general_heading(node.text)
+          nil
+        end
+      end
+    end
+
+    # The general sub-heading a source header stands for, or nil for anything else.
+    #
+    # Only the recognized general categories are recovered, deliberately. Legacy markup is broken
+    # enough that walking it turns up plenty of headers that are not general sub-headings at all --
+    # work titles both bare and quoted ('אבני גדר', 'On "Exile from exile"'), the links section's
+    # own 'קישורים' header bleeding in through an unclosed tag, and outright debris ('V–XXIV').
+    # Inventing a sub-heading out of any of those would be worse than the flat list we have, and an
+    # editor can always add one by hand in the citations tab.
+    def general_heading(text)
+      title = Lexicon::MatchCitationSubjects.normalize_subject(text.squish)
+      Lexicon::MatchCitationSubjects::GENERIC_SUBJECTS.include?(title) ? title : nil
+    end
+
+    # Matches each source <li> to the general citation it was migrated into, and files that citation
+    # under the <li>'s heading. Matching is by title containment, longest title first and each
+    # citation claimed at most once -- the same join ParseCitations falls back to.
+    def assign(items)
+      ungrouped = @person.citations.where(lex_person_work_id: nil, lex_citation_group_id: nil, subject: nil)
+                         .order(:seqno, :id).to_a
+      candidates = ungrouped.select { |c| normalize(c.title).length >= MIN_MATCHABLE_TITLE }
+      claimed = {}
+
+      items.each do |item|
+        citation = candidates.reject { |c| claimed.key?(c.id) }
+                             .select { |c| item[:text].include?(normalize(c.title)) }
+                             .max_by { |c| normalize(c.title).length }
+        claimed[citation.id] = item[:heading] if citation
+      end
+
+      persist(ungrouped, claimed)
+    end
+
+    # Writes the recovered grouping, renumbering the seqno of every list it touches -- a citation's
+    # seqno is its position within its own heading, so moving citations out of the general list
+    # would otherwise leave both lists numbered from a sequence they no longer follow.
+    def persist(ungrouped, claimed)
+      groups = {}
+      ActiveRecord::Base.transaction do
+        claimed.values.uniq.each do |title|
+          groups[title] = @person.citation_groups.find_or_create_by!(title: title)
+        end
+
+        ungrouped.group_by { |citation| claimed[citation.id] }.each do |title, citations|
+          citations.each_with_index do |citation, index|
+            citation.update!(citation_group: groups[title], seqno: index + 1)
+          end
+        end
+      end
+
+      Result.new(person_id: @person.id, groups: groups.keys, grouped_count: claimed.size,
+                 unmatched_count: ungrouped.size - claimed.size)
+    end
+
+    # Text of an <li> without the text of any citation nested inside it, so that a nested
+    # citation's title cannot be matched against its containing one.
+    def own_text(list_item)
+      copy = list_item.dup
+      copy.css('li').each(&:remove)
+      copy.text
+    end
+
+    # [[:space:]] rather than \s: legacy markup is littered with &nbsp;, and Ruby's \s does not
+    # match U+00A0, so a title would fail to be found inside the very <li> it was parsed from.
+    def normalize(text)
+      text.to_s.gsub(/[[:punct:]]/, ' ').gsub(/[[:space:]]+/, ' ').strip
+    end
+  end
+end

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -64,9 +64,9 @@
       - if lexicon_sections[:about]
         #lexicon-about
           = render layout: 'lexicon/block', locals: { title: t('activerecord.attributes.lex_person.about', gender_suffix: lex_person.female? ? 'ת' : '', gender_letter: lex_person.gender_letter) } do
-            - grouped_and_ordered_citations(lex_person).each do |subject, list|
-              - if subject.present?
-                %h4= citations_subject_header(subject)
+            - grouped_and_ordered_citations(lex_person).each do |heading, list|
+              - unless heading.general?
+                %h4= citations_heading_text(heading)
               %ul
                 - list.each do |c|
                   - cit_text = render_citation(c)

--- a/app/views/lexicon/citations/_citation_list.html.haml
+++ b/app/views/lexicon/citations/_citation_list.html.haml
@@ -1,0 +1,13 @@
+-# One heading's citations. group_token identifies the heading to the reorder endpoint (nil for
+  the ungrouped general citations); general says whether citations may be dragged in from
+  elsewhere.
+%ul.citations-group{ class: css_class, data: { group_token: group_token, general: general } }
+  - citations.each do |c|
+    %li{ data: { citation_id: c.id } }
+      %span.drag-handle{ title: t('lexicon.citations.index.drag_to_reorder'), style: 'cursor: move;' }
+        %span.handle ☰
+      = raw render_citation(c)
+      = link_to t(:edit), nil, class: 'edit-citation', data: { id: c.id }
+      = link_to t(:delete),
+                lexicon_citation_path(c),
+                remote: true, data: { confirm: t(:are_you_sure) }, method: :delete, class: 'delete-citation'

--- a/app/views/lexicon/citations/_form.html.haml
+++ b/app/views/lexicon/citations/_form.html.haml
@@ -7,6 +7,15 @@
                   label_method: :title,
                   selected: @citation.person_work&.id,
                   include_blank: true
+  -# Only offered when the person has sub-headings to choose from; they are created from the
+     citations list. A citation about a work is grouped by that work instead, hence the hint.
+  - if @person.citation_groups.any?
+    = f.association :citation_group,
+                    collection: @person.citation_groups,
+                    label_method: :title,
+                    selected: @citation.citation_group&.id,
+                    include_blank: true,
+                    hint: t('.citation_group_hint')
   = f.input :title
   = f.input :from_publication
   = f.input :pages

--- a/app/views/lexicon/citations/_scripts.html.haml
+++ b/app/views/lexicon/citations/_scripts.html.haml
@@ -1,0 +1,92 @@
+-# Behaviour of the citations tab: the citation modals, and adding, renaming, removing, reordering
+  and filling the general sub-headings (see LexCitationGroup).
+:javascript
+  $('.edit-citation').click(function(e) {
+    e.preventDefault();
+    const citationId = $(this).data('id');
+    openModal(`/lex/citations/${citationId}/edit`);
+  });
+  $('a.add-citation').click(function() {
+    openModal('/lex/people/#{@person.id}/citations/new');
+  });
+
+  const citationsPane = $('#citations');
+
+  const headingActionFailed = '#{j t('lexicon.citations.index.heading_action_failed')}';
+
+  function citationGroupRequest(url, method, data) {
+    return $.ajax({
+      url: url,
+      method: method,
+      headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+      data: data,
+      error: function(xhr) {
+        alert(headingActionFailed + '\n' + (xhr.responseText || ('Status ' + xhr.status)));
+        reloadContent(citationsPane);
+      }
+    }).done(function() { reloadContent(citationsPane); });
+  }
+
+  $('a.add-citation-group').click(function(e) {
+    e.preventDefault();
+    const title = prompt('#{j t('lexicon.citations.index.heading_name_prompt')}');
+    if (!title) { return; }
+    citationGroupRequest('/lex/people/#{@person.id}/citation_groups', 'POST',
+                         { lex_citation_group: { title: title } });
+  });
+
+  $('.rename-citation-group').click(function(e) {
+    e.preventDefault();
+    const title = prompt('#{j t('lexicon.citations.index.heading_name_prompt')}', $(this).data('title'));
+    if (!title) { return; }
+    citationGroupRequest(`/lex/citation_groups/${$(this).data('id')}`, 'PATCH',
+                         { lex_citation_group: { title: title } });
+  });
+
+  $('.delete-citation-group').click(function(e) {
+    e.preventDefault();
+    if (!confirm('#{j t('lexicon.citations.index.delete_heading_confirm')}')) { return; }
+    citationGroupRequest(`/lex/citation_groups/${$(this).data('id')}`, 'DELETE', {});
+  });
+
+  // Citations: reorder within a heading, and drag between the general buckets.
+  document.querySelectorAll('ul.citations-group').forEach(function(list) {
+    Sortable.create(list, {
+      handle: '.drag-handle',
+      animation: 150,
+      // Only the general buckets accept citations from elsewhere; every other list is closed.
+      group: list.dataset.general === 'true' ? 'general-citations' : ('work-' + list.dataset.groupToken),
+      onEnd: function(evt) {
+        const fromToken = evt.from.dataset.groupToken || '';
+        const toToken = evt.to.dataset.groupToken || '';
+        const moved = fromToken !== toToken;
+        if (evt.newIndex === evt.oldIndex && !moved) { return; }
+        $.post({
+          url: `/lex/citations/${evt.item.dataset.citationId}/reorder`,
+          data: {
+            new_index: evt.newIndex,
+            old_index: evt.oldIndex,
+            group_token: fromToken,
+            to_group_token: toToken
+          },
+          error: function(xhr, _status, _error) {
+            const errorMsg = xhr.status == 400 ? xhr.responseText : 'Status ' + xhr.status;
+            alert('#{j t('lexicon.citations.index.reordering_failed')}\n' + errorMsg);
+            reloadContent(citationsPane);
+          }
+        }).done(function() { if (moved) { reloadContent(citationsPane); } });
+      }
+    });
+  });
+
+  // Headings: reorder the general sub-headings among themselves.
+  Sortable.create(document.getElementById('citation-headings'), {
+    handle: '.heading-drag-handle',
+    draggable: '.citation-heading-block',
+    animation: 150,
+    onEnd: function(evt) {
+      if (evt.newIndex === evt.oldIndex) { return; }
+      citationGroupRequest(`/lex/citation_groups/${evt.item.dataset.groupId}/reorder`, 'POST',
+                           { new_index: evt.newIndex });
+    }
+  });

--- a/app/views/lexicon/citations/index.html.haml
+++ b/app/views/lexicon/citations/index.html.haml
@@ -1,54 +1,37 @@
+- groups = grouped_and_ordered_citations(@person)
+-# Keyed by token so an empty sub-heading -- one an editor has just added, or emptied by
+  dragging -- still gets rendered: the grouped hash only has a key where there is a citation
+  to put under it.
+- by_token = groups.transform_keys(&:token)
+- work_headings = groups.reject { |heading, _| heading.general? || heading.editable? }
 %a.btn.btn-primary.add-citation= t('.add_citation')
-- grouped_and_ordered_citations(@person).each do |subject_title, entries|
-  %h4= citations_subject_header(subject_title)
-  %ul.citations-group{ data: { subject_title: subject_title } }
-    - entries.each do |c|
-      %li{ data: { citation_id: c.id } }
-        %span.drag-handle{ title: t('.drag_to_reorder'), style: 'cursor: move;' }
-          %span.handle ☰
-        = raw render_citation(c)
-        = link_to t(:edit), nil, class: 'edit-citation', data: { id: c.id }
-        = link_to t(:delete),
-                  lexicon_citation_path(c),
-                  remote: true, data: { confirm: t(:are_you_sure) }, method: :delete, class: 'delete-citation'
+%a.btn.btn-outline-primary.ms-2.add-citation-group= t('.add_heading')
 
-:javascript
-  $('.edit-citation').click(function(e) {
-    e.preventDefault();
-    const citationId = $(this).data('id');
-    openModal(`/lex/citations/${citationId}/edit`);
-  });
-  $('a.add-citation').click(function() {
-    openModal('/lex/people/#{@person.id}/citations/new');
-  });
+-# The general buckets -- the ungrouped citations and every general sub-heading -- share one
+  Sortable group, so a citation can be dragged from any of them into any other. The ungrouped
+  bucket is rendered even when empty, so that a citation can always be dragged back out of a
+  sub-heading. Work headings stay closed: moving a citation under a work changes what it is
+  about, and that belongs in the citation's own edit form.
+%h4= t('lexicon.citations.header.general')
+= render partial: 'citation_list',
+         locals: { citations: by_token[nil] || [], group_token: nil, general: true, css_class: 'ungrouped-citations' }
 
-  // Initialize Sortable for each subject_title table
-  document.querySelectorAll('ul.citations-group').forEach(function(list) {
-    const subjectTitle = list.dataset.subjectTitle;
-    Sortable.create(
-      list,
-      {
-        handle: '.drag-handle',
-        animation: 150,
-        onEnd: function(evt) {
-          const oldIndex = evt.oldIndex; // zero-based
-          const newIndex = evt.newIndex; // zero-based
-          if (newIndex !== oldIndex) {
-            $.post({
-              url: `/lex/citations/${evt.item.dataset.citationId}/reorder`,
-              data: {
-                new_index: newIndex,
-                old_index: oldIndex,
-                subject_title: subjectTitle
-              },
-              error: function(xhr, _status, _error) {
-                const errorMsg = xhr.status == 400 ? xhr.responseText : 'Status ' + xhr.status;
-                alert('#{t('.reordering_failed')}\n' + errorMsg);
-                reloadContent($('#citations'));
-              }
-            });
-          }
-        }
-      }
-    );
-  });
+#citation-headings
+  - @person.citation_groups.each do |group|
+    - token = "#{LexCitation::HEADING_TOKEN_PREFIX}#{group.id}"
+    .citation-heading-block{ data: { group_id: group.id } }
+      %h4
+        %span.heading-drag-handle{ title: t('.drag_heading_to_reorder'), style: 'cursor: move;' } ☰
+        %span.heading-title= group.title
+        = link_to t(:edit), nil, class: 'rename-citation-group ms-2 small',
+                                 data: { id: group.id, title: group.title }
+        = link_to t(:delete), nil, class: 'delete-citation-group ms-2 small', data: { id: group.id }
+      = render partial: 'citation_list',
+               locals: { citations: by_token[token] || [], group_token: token, general: true, css_class: nil }
+
+- work_headings.each do |heading, entries|
+  %h4= citations_heading_text(heading)
+  = render partial: 'citation_list',
+           locals: { citations: entries, group_token: heading.token, general: false, css_class: nil }
+
+= render 'scripts'

--- a/app/views/lexicon/entries/_show_person.html.haml
+++ b/app/views/lexicon/entries/_show_person.html.haml
@@ -45,9 +45,9 @@
         - if sections[:about]
           #lexicon-about
             = render layout: 'lexicon/block', locals: { title: t('activerecord.attributes.lex_person.about', gender_suffix: lex_person.female? ? 'ת' : '', gender_letter: lex_person.gender_letter) } do
-              - grouped_and_ordered_citations(lex_person).each do |subject, list|
-                - if subject.present?
-                  %h4= citations_subject_header(subject)
+              - grouped_and_ordered_citations(lex_person).each do |heading, list|
+                - unless heading.general?
+                  %h4= citations_heading_text(heading)
                 %ul
                   - list.each do |c|
                     - cit_text = render_citation(c)

--- a/app/views/lexicon/verification/_edit_citation_subjects.html.haml
+++ b/app/views/lexicon/verification/_edit_citation_subjects.html.haml
@@ -2,8 +2,10 @@
 - confirm_url = lexicon_confirm_citation_subject_verification_path(@entry)
 - works = @item.works.sort_by(&:title)
 -# Headings are Hebrew, so they cannot serve as DOM ids; number them instead.
-- row_ids = @citation_subject_proposals.each_with_index.to_h { |proposal, index| [proposal.subject, "subject-row-#{index}"] }
-- proposed, unmatched = @citation_subject_proposals.partition(&:proposed?)
+:ruby
+  row_ids = @citation_subject_proposals.each_with_index.to_h { |proposal, index| [proposal.subject, "subject-row-#{index}"] }
+  proposed, unmatched = @citation_subject_proposals.partition(&:proposed?)
+  keep_heading_label = t('lexicon.verification.sections.citation_subject_keep_heading')
 .auto-match-citation-subjects-modal
   %h4= t('lexicon.verification.sections.auto_match_citation_subjects_heading')
 
@@ -19,13 +21,16 @@
             %span.badge.bg-light.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_count', count: proposal.citations.size)
             %span.mx-2 →
             - if proposal.generic
-              %em= t('lexicon.verification.sections.citation_subject_general')
+              %em= t('lexicon.verification.sections.citation_subject_heading', title: proposal.heading_title)
             - else
               = proposal.work.title
               %span.badge.bg-secondary.ms-2
                 #{proposal.similarity}%
+          -# A recognized general category keeps its name as a sub-heading of the general citations
+             (LexCitationGroup); anything else points its citations at the work it names.
+          - work_id = proposal.generic ? Lexicon::VerificationController::GENERAL_HEADING_WORK_ID : proposal.work&.id
           .match-actions.ms-3
-            %button.btn.btn-sm.btn-success.confirm-citation-subject{ type: 'button', data: { subject: proposal.subject, 'work-id': proposal.work&.id, 'confirm-url': confirm_url } }
+            %button.btn.btn-sm.btn-success.confirm-citation-subject{ type: 'button', data: { subject: proposal.subject, 'work-id': work_id, 'confirm-url': confirm_url } }
               = t('lexicon.verification.edit.confirm_match')
 
     -# Headings no work fits well enough, or that two works fit equally well: the editor picks.
@@ -41,8 +46,11 @@
             - if proposal.ambiguous
               %span.badge.bg-warning.text-dark.ms-1= t('lexicon.verification.sections.citation_subject_ambiguous')
           .match-actions.ms-3.d-flex.align-items-center
-            = select_tag 'work_id',
-                         options_from_collection_for_select(works, :id, :title),
+            -# Besides naming a work, a heading can be kept as a sub-heading of the general
+               citations, or dropped altogether (the blank option) leaving them plain general ones.
+            - options = options_for_select([[keep_heading_label, Lexicon::VerificationController::GENERAL_HEADING_WORK_ID]])
+            - options += options_from_collection_for_select(works, :id, :title)
+            = select_tag 'work_id', options,
                          include_blank: t('lexicon.verification.sections.citation_subject_general'),
                          class: 'form-control form-control-sm citation-subject-work-select me-2'
             %button.btn.btn-sm.btn-primary.confirm-citation-subject{ type: 'button', data: { subject: proposal.subject, 'confirm-url': confirm_url } }

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -236,7 +236,7 @@
       - total_count = checklist['citations']&.dig('items')&.size || 0
       = "#{verified_count}/#{total_count} " + t('lexicon.verification.migrated.verified')
   .section-content
-    - all_citations = item.citations.includes(:person_work, authors: { entry: :lex_file })
+    - all_citations = item.citations.includes(:person_work, :citation_group, authors: { entry: :lex_file })
     - cit_size = all_citations.size
     -# Resolved once for the whole section: which plaintext authors have an existing person entry
       to offer a match against (see LexCitationAuthor.matchable_names).
@@ -246,16 +246,20 @@
         = t('lexicon.verification.sections.count_mismatch', php_count: php_counts[:citations], migrated_count: cit_size)
         %button.btn-close{type: 'button', 'data-bs-dismiss': 'alert', 'aria-label': 'Close'}
     - if all_citations.any?
-      - all_citations.group_by(&:subject_title).each do |subject, citations|
+      - all_citations.group_by(&:group_token).each do |group_token, citations|
         .citation-group.mb-3
           -#
-            A group's heading is the work's title once it is linked, and the legacy string until then --
-            two states that look alike, so say which is which (see the citation-headings section above).
+            A group's heading is the work's title once it is linked, a general sub-heading's own
+            name once it is one, and the legacy string until it is either -- states that look alike,
+            so say which is which (see the citation-headings section above).
+          - group = citations.first.citation_group
           %h6.subject-header
-            = subject.presence || t('lexicon.citations.header.general')
+            = group&.title || group_token.presence || t('lexicon.citations.header.general')
             - if citations.first.person_work.present?
               %span.badge.bg-success.ms-1= t('lexicon.verification.sections.citation_group_linked')
-            - elsif subject.present?
+            - elsif group.present?
+              %span.badge.bg-success.ms-1= t('lexicon.verification.sections.citation_group_heading')
+            - elsif group_token.present?
               %span.badge.bg-warning.text-dark.ms-1= t('lexicon.verification.sections.citation_group_unlinked')
           - citations.each do |citation|
             .citation-card{ id: "citation-#{citation.id}", class: citation_card_css(citation, checklist) }

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -22,6 +22,7 @@ en:
       ingestible: Ingestible
       lex_citation: Citation of Lexicon Entry
       lex_citation_author: Citation Author
+      lex_citation_group: General citation sub-heading
       lex_entry: Lexicon Entry
       lex_linked_person: Associated Person
       lex_person: Lexicon Person
@@ -56,6 +57,9 @@ en:
               taken: Text is already in the anthology
         lex_citation:
           attributes:
+            citation_group:
+              belongs_to_different_person: must belong to the same Lexicon Person as the Citation itself
+              not_on_work_citation: cannot be set on a citation that is about one of the person's works
             person_work:
               belongs_to_different_person: must belong to the same Lexicon Person as the Citation itself
             subject:
@@ -137,10 +141,13 @@ en:
         authors: Authors
         backup_file: Backup File
         backup_url: Backup URL
+        citation_group: General sub-heading
         from_publication: From Publication
         notes: Context notes
         pages: Pages
         person_work: Work
+      lex_citation_group:
+        title: Sub-heading
       lex_file:
         error_message: Error message
         entrytype: Entry type

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -22,6 +22,7 @@ he:
       ingestible: ההעלאה
       lex_citation: מראה מקום על אדם או חיבור
       lex_citation_author: מחבר/ת מראה המקום
+      lex_citation_group: כותרת משנה של מראי מקום כלליים
       lex_entry: ערך בלקסיקון
       lex_linked_person: ישות מקושרת
       lex_person: אדם בלקסיקון
@@ -60,6 +61,9 @@ he:
               taken: היצירה הנוכחית כבר מופיעה במקראה הזאת.
         lex_citation:
           attributes:
+            citation_group:
+              belongs_to_different_person: חייב להשתייך לאותו יוצר כמו מראה המקום
+              not_on_work_citation: לא ניתן לשייך כותרת משנה כללית למראה מקום העוסק באחד מחיבורי היוצר
             person_work:
               belongs_to_different_person: חייב להשתייך לאותו יוצר כמו מראה המקום
             subject:
@@ -143,12 +147,15 @@ he:
         authors: מחברים
         backup_file: קובץ גיבוי
         backup_url: כתובת גיבוי
+        citation_group: כותרת משנה כללית
         from_publication: מתוך החיבור
         notes: הקשר והערות
         pages: עמודים
         person_work: חיבור
         subject: נושא
         link: קישורית
+      lex_citation_group:
+        title: כותרת משנה
       lex_file:
         error_message: הודעות שגיאה
         entrytype: סוג הערך

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -125,10 +125,16 @@ en:
         general: General
       index:
         add_citation: Add Citation
+        add_heading: Add sub-heading
         drag_to_reorder: Drag to reorder
+        drag_heading_to_reorder: Drag to reorder sub-headings
+        heading_name_prompt: 'Sub-heading name (e.g. ספרים, מאמרים, ספרי יובל):'
+        delete_heading_confirm: Remove this sub-heading? Its citations move back to the general list.
+        heading_action_failed: Sub-heading action failed
         reordering_failed: Reordering failed
       form:
         save_before_adding_authors: Please save the citation before adding authors
+        citation_group_hint: Only applies to general citations about the person, not to citations about a particular work
     linked_people:
       index:
         drag_to_reorder: Drag to reorder
@@ -327,7 +333,10 @@ en:
         unmatched_citation_subjects_heading: "Headings without a match"
         unmatched_citation_subjects_intro: "No work was matched to these headings. Pick a work, or leave the selection blank to mark the heading as a general one, not about a particular work."
         citation_subject_general: "General (not about a particular work)"
+        citation_subject_keep_heading: "Keep as a general sub-heading"
+        citation_subject_heading: "general sub-heading \"%{title}\""
         citation_group_linked: "Linked to a work"
+        citation_group_heading: "General sub-heading"
         citation_group_unlinked: "Heading not linked"
         citation_subject_assign: "Assign"
         citation_subject_ambiguous: "More than one work fits"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -126,10 +126,16 @@ he:
         general: כללי
       index:
         add_citation: הוספת מראה מקום
+        add_heading: הוספת כותרת משנה
         drag_to_reorder: גרור לשינוי סדר
+        drag_heading_to_reorder: גרור לשינוי סדר כותרות המשנה
+        heading_name_prompt: 'שם כותרת המשנה (למשל: ספרים, מאמרים, ספרי יובל):'
+        delete_heading_confirm: למחוק את כותרת המשנה? מראי המקום שתחתיה יעברו לרשימה הכללית.
+        heading_action_failed: הפעולה על כותרת המשנה נכשלה
         reordering_failed: שינוי הסדר נכשל
       form:
         save_before_adding_authors: נא לשמור את מראה המקום לפני הוספת מחברים
+        citation_group_hint: רלוונטי רק למראי מקום כלליים על היוצר/ת, שאינם עוסקים בחיבור מסוים
     linked_people:
       index:
         drag_to_reorder: גרור לשינוי סדר
@@ -328,7 +334,10 @@ he:
         unmatched_citation_subjects_heading: "כותרות ללא התאמה"
         unmatched_citation_subjects_intro: "לכותרות הבאות לא נמצאה יצירה מתאימה. בחרו יצירה, או השאירו ריק כדי לסמן שהכותרת כללית ואינה עוסקת ביצירה מסוימת."
         citation_subject_general: "כללי (לא על יצירה מסוימת)"
+        citation_subject_keep_heading: "שמירה ככותרת משנה כללית"
+        citation_subject_heading: "כותרת משנה כללית ״%{title}״"
         citation_group_linked: "מקושר ליצירה"
+        citation_group_heading: "כותרת משנה כללית"
         citation_group_unlinked: "כותרת לא מקושרת"
         citation_subject_assign: "שיוך"
         citation_subject_ambiguous: "יותר מיצירה אחת מתאימה"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,10 @@ Bybeconv::Application.routes.draw do
     match 'admin', to: 'entries#index', as: :lex_backend, via: %i(get post)
 
     resources :people, only: %i(edit update new create) do
+      # Sub-headings of the general citations (ספרים, מאמרים, ...) -- see LexCitationGroup
+      resources :citation_groups, shallow: true, only: %i(create update destroy) do
+        post :reorder, on: :member
+      end
       resources :citations, shallow: true, except: %i(show) do
         post :reorder, on: :member
         resources :authors, controller: 'citation_authors', only: %i(index create)

--- a/db/migrate/20260901090000_create_lex_citation_groups.rb
+++ b/db/migrate/20260901090000_create_lex_citation_groups.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# A legacy bibliography groups the citations that are about the person -- as opposed to about one
+# particular work of theirs -- under sub-headings of its own: ספרים, מאמרים, ספרי יובל,
+# ביבליוגרפיה. Until now the migration threw those away, conflating every group into one flat
+# "general" list. A LexCitationGroup is one such sub-heading: a named, ordered bucket of general
+# citations belonging to a person.
+#
+# Only general citations are grouped. A citation about a work is already grouped by that work
+# (LexPersonWork#citations_about), so lex_citation_group_id and lex_person_work_id are mutually
+# exclusive -- see LexCitation#citation_group_only_on_general_citation.
+class CreateLexCitationGroups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lex_citation_groups do |t|
+      t.references :lex_person, null: false, foreign_key: true
+      t.string :title, null: false
+      t.integer :seqno, null: false
+      t.timestamps
+    end
+
+    # One heading of a given name per person: renaming a heading onto an existing one would
+    # otherwise leave two indistinguishable groups an editor cannot tell apart.
+    add_index :lex_citation_groups, %i(lex_person_id title), unique: true,
+                                                             name: 'index_lex_citation_groups_on_person_and_title'
+
+    add_reference :lex_citations, :lex_citation_group, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20260901090001_recover_general_citation_headings.rb
+++ b/db/migrate/20260901090001_recover_general_citation_headings.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Restores the general sub-headings (ספרים, מאמרים, ספרי יובל, ...) that the migration used to
+# throw away, for the entries already migrated without them.
+#
+# Two sources of loss are undone:
+#
+# 1. Headings still stored as a legacy LexCitation#subject. The recognized-general list was short
+#    ('מאמרים', 'ספרים', 'על הספר') and did not allow for the trailing colon half the legacy files
+#    write, so 'ספרים:' and 'ביבליוגרפיה' were never recognized and sat unresolved. They now become
+#    LexCitationGroups keeping their name.
+# 2. Headings already cleared, whose citations are flat general ones with nothing left to say which
+#    group they came from. Those are re-read from the legacy PHP file --
+#    Lexicon::RecoverCitationHeadings matches each general citation back to the <li> it was parsed
+#    from and files it under that <li>'s heading.
+#
+# Both steps only ever touch citations that are general and ungrouped, so the migration is safe to
+# re-run and cannot overrule an editor. Entries are deliberately not sent back to verification:
+# recovery is conservative -- only headings on the recognized-general list are restored -- and adds
+# information rather than changing any editorial decision.
+#
+# Step 2 needs the legacy PHP corpus to be readable at LexFile#full_path. Where it is not, the
+# entry is counted as skipped and the migration carries on: a missing corpus must not fail a deploy,
+# and the step can simply be re-run once it is mounted.
+class RecoverGeneralCitationHeadings < ActiveRecord::Migration[8.0]
+  def up
+    group_recognized_subjects
+    recover_cleared_headings
+  end
+
+  def down
+    # Not reversible: the flat general list this restores structure to recorded nothing about which
+    # sub-heading each citation came from -- that is the very loss being repaired.
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def group_recognized_subjects
+    say 'Turning recognized general subject headings into sub-headings...'
+    headings = 0
+    citations = 0
+
+    LexPerson.where(id: LexCitation.where.not(subject: nil).select(:lex_person_id)).find_each do |person|
+      # Applied in source order, so the sub-headings come out in the order the legacy page had them
+      # (ספרים before מאמרים) rather than the alphabetical order the proposals arrive in.
+      Lexicon::MatchCitationSubjects.call(person).select(&:generic).sort_by(&:source_position).each do |proposal|
+        citations += proposal.apply!(person)
+        headings += 1
+      end
+    end
+
+    say "grouped #{citations} citations under #{headings} headings", true
+  end
+
+  def recover_cleared_headings
+    say 'Recovering cleared sub-headings from the legacy files...'
+    recovered = Hash.new(0)
+    skipped = Hash.new(0)
+
+    LexPerson.where(id: ungrouped_general_citations.select(:lex_person_id)).find_each do |person|
+      result = Lexicon::RecoverCitationHeadings.call(person)
+      if result.skipped?
+        skipped[result.skipped] += 1
+      else
+        recovered[:entries] += 1 if result.grouped_count.positive?
+        recovered[:citations] += result.grouped_count
+        recovered[:headings] += result.groups.size
+      end
+    rescue StandardError => e
+      skipped[:error] += 1
+      say "entry #{person.entry&.id}: #{e.class}: #{e.message}", true
+    end
+
+    say "recovered #{recovered[:headings]} headings over #{recovered[:citations]} citations " \
+        "in #{recovered[:entries]} entries", true
+    say "passed over: #{skipped.map { |reason, count| "#{reason}=#{count}" }.join(', ')}", true if skipped.any?
+  end
+
+  def ungrouped_general_citations
+    LexCitation.where(lex_person_work_id: nil, lex_citation_group_id: nil, subject: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_090001) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -654,10 +654,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_120001) do
     t.index ["lex_entry_id"], name: "index_lex_citation_authors_on_lex_entry_id"
   end
 
+  create_table "lex_citation_groups", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "lex_person_id", null: false
+    t.integer "seqno", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lex_person_id", "title"], name: "index_lex_citation_groups_on_person_and_title", unique: true
+    t.index ["lex_person_id"], name: "index_lex_citation_groups_on_lex_person_id"
+  end
+
   create_table "lex_citations", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "backup_url", limit: 1024
     t.datetime "created_at", precision: nil, null: false
     t.string "from_publication"
+    t.bigint "lex_citation_group_id"
     t.bigint "lex_person_id", null: false
     t.bigint "lex_person_work_id"
     t.string "link", limit: 1024
@@ -672,6 +683,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_120001) do
     t.json "text_links"
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["lex_citation_group_id"], name: "index_lex_citations_on_lex_citation_group_id"
     t.index ["lex_person_id"], name: "index_lex_citations_on_lex_person_id"
     t.index ["lex_person_work_id"], name: "index_lex_citations_on_lex_person_work_id"
     t.index ["manifestation_id"], name: "index_lex_citations_on_manifestation_id"
@@ -1251,6 +1263,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_120001) do
   add_foreign_key "involved_authorities", "authorities"
   add_foreign_key "lex_citation_authors", "lex_citations"
   add_foreign_key "lex_citation_authors", "lex_entries"
+  add_foreign_key "lex_citation_groups", "lex_people"
+  add_foreign_key "lex_citations", "lex_citation_groups"
   add_foreign_key "lex_citations", "lex_people"
   add_foreign_key "lex_citations", "lex_person_works"
   add_foreign_key "lex_citations", "manifestations"

--- a/spec/factories/lex_citation_groups.rb
+++ b/spec/factories/lex_citation_groups.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  sequence(:lex_citation_group_title) { |n| "כותרת משנה #{n}" }
+
+  factory :lex_citation_group do
+    person factory: :lex_person
+    title { generate(:lex_citation_group_title) }
+  end
+end

--- a/spec/fixtures/files/lexicon/general_citation_headings.php
+++ b/spec/fixtures/files/lexicon/general_citation_headings.php
@@ -1,0 +1,29 @@
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head>
+<body dir="rtl">
+<p><font size="4" color="#0000FF"><a name="Books">ספריה:</a></font></p>
+<ul style="margin-top:0in" type=circle>
+  <li>שיחות אינטימיות (תל אביב, 1995)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
+<font size="2">
+<font color="#FF0000">ספרים:</font>
+<ul style="margin-top:0in" type=circle>
+  <li><b>קרוזו, נעמי.</b>&nbsp; מונוגרפיה על&nbsp;המחברת (מונטריאול, 1991).</li>
+</ul>
+<font color="#FF0000">מאמרים:</font>
+<ul style="margin-top:0in" type=circle>
+  <li><b>כהן, דוד.</b> זרקור על דמות נעלמה. <u>קשר</u>, גל׳ 28 (2000), עמ׳ 21־27.</li>
+  <li><b>לוי, יוסף.</b> אנדרוגניות במצור. <u>מעריב</u>, 10 בפברואר 2021, עמ׳ 8.</li>
+</ul>
+<font color="#FF0000">על ״שיחות אינטימיות״</font>
+<ul style="margin-top:0in" type=circle>
+  <li><b>פלוני, ראובן.</b> ביקורת על הספר. <u>ידיעות אחרונות</u>, 5 במארס 2022, עמ׳ 3.</li>
+</ul>
+</font>
+<p><font size="4" color="#0000FF"><a name="links">קישורים:</a></font></p>
+<ul style="margin-top:0in" type=circle>
+  <li><a href="https://example.com">אתר חיצוני שאינו ציטוט</a></li>
+</ul>
+</body>
+</html>

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -333,6 +333,46 @@ RSpec.describe LexiconHelper, type: :helper do
     end
   end
 
+  describe '#grouped_and_ordered_citations' do
+    let(:person) { create(:lex_person) }
+    let!(:work) { create(:lex_person_work, person: person, title: 'שיחות אינטימיות', seqno: 1) }
+    let!(:books) { create(:lex_citation_group, person: person, title: 'ספרים', seqno: 1) }
+    let!(:articles) { create(:lex_citation_group, person: person, title: 'מאמרים', seqno: 2) }
+
+    let!(:plain) { create(:lex_citation, person: person, seqno: 1) }
+    let!(:book) { create(:lex_citation, person: person, citation_group: books, seqno: 1) }
+    let!(:article) { create(:lex_citation, person: person, citation_group: articles, seqno: 1) }
+    let!(:about_work) { create(:lex_citation, person: person, person_work: work, seqno: 1) }
+    let!(:unresolved) { create(:lex_citation, person: person, subject: 'על ״ספר אחר״', seqno: 1) }
+
+    let(:groups) { helper.grouped_and_ordered_citations(person) }
+
+    it 'orders the general citations first, then the works, then unresolved legacy headings' do
+      expect(groups.keys.map(&:kind)).to eq(%i(general heading heading work subject))
+      expect(groups.values).to eq([[plain], [book], [article], [about_work], [unresolved]])
+    end
+
+    it 'orders the general sub-headings by the editor\'s own order, not alphabetically' do
+      articles.update!(seqno: 0)
+      expect(helper.grouped_and_ordered_citations(person).keys.filter_map { |h| h.title if h.editable? })
+        .to eq(%w(מאמרים ספרים))
+    end
+
+    it 'shows a general sub-heading verbatim and a work heading in the "about" template' do
+      heading, work_heading = groups.keys.values_at(1, 3)
+      expect(helper.citations_heading_text(heading)).to eq('ספרים')
+      expect(helper.citations_heading_text(work_heading)).to eq('על ״שיחות אינטימיות״')
+    end
+
+    # A person may have both a work and a general sub-heading called 'מאמרים'; keying the groups on
+    # the bare title would silently merge their citations into one list.
+    it 'keeps a sub-heading and a same-titled work apart' do
+      work.update!(title: 'מאמרים')
+      keys = helper.grouped_and_ordered_citations(person).keys.select { |h| h.title == 'מאמרים' }
+      expect(keys.map(&:kind)).to contain_exactly(:heading, :work)
+    end
+  end
+
   describe '#render_citation with text_links' do
     let(:person) { create(:lex_person) }
     let!(:target_entry) { create(:lex_entry, :publication, title: 'שדות ומזוודות') }

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -371,6 +371,26 @@ RSpec.describe LexiconHelper, type: :helper do
       keys = helper.grouped_and_ordered_citations(person).keys.select { |h| h.title == 'מאמרים' }
       expect(keys.map(&:kind)).to contain_exactly(:heading, :work)
     end
+
+    # A work title is a group token in its own right, so one that happens to read like a
+    # sub-heading token must not be taken for one -- matching the 'heading:' prefix alone would
+    # have parsed an id of 0 and emptied the work's citations into the general bucket.
+    it 'does not mistake a work titled like a sub-heading token for a sub-heading' do
+      work.update!(title: 'heading:foo')
+
+      heading = groups.keys.find { |h| h.title == 'heading:foo' }
+      expect(heading.kind).to eq(:work)
+      expect(groups[heading]).to eq([about_work])
+    end
+
+    it 'does not mistake a legacy subject naming a real group id for that group' do
+      unresolved.update!(subject: "heading:#{books.id}")
+
+      heading = groups.keys.find { |h| h.title == "heading:#{books.id}" }
+      expect(heading.kind).to eq(:subject)
+      expect(groups[heading]).to eq([unresolved])
+      expect(groups.keys.count { |h| h.kind == :heading }).to eq(2)
+    end
   end
 
   describe '#render_citation with text_links' do

--- a/spec/models/lex_citation_group_spec.rb
+++ b/spec/models/lex_citation_group_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LexCitationGroup do
+  let(:person) { create(:lex_entry, :person).lex_item }
+
+  describe 'validations' do
+    it 'requires a title' do
+      group = build(:lex_citation_group, person: person, title: '  ')
+      expect(group).not_to be_valid
+      expect(group.errors[:title]).to be_present
+    end
+
+    it 'rejects a second heading of the same name for the same person' do
+      create(:lex_citation_group, person: person, title: 'ספרים')
+      expect(build(:lex_citation_group, person: person, title: 'ספרים')).not_to be_valid
+    end
+
+    it 'allows the same name for a different person' do
+      create(:lex_citation_group, person: person, title: 'ספרים')
+      other = create(:lex_entry, :person).lex_item
+      expect(build(:lex_citation_group, person: other, title: 'ספרים')).to be_valid
+    end
+  end
+
+  describe 'seqno' do
+    it 'appends each new heading after the person\'s existing ones' do
+      first = create(:lex_citation_group, person: person, title: 'ספרים')
+      second = create(:lex_citation_group, person: person, title: 'מאמרים')
+      expect([first.seqno, second.seqno]).to eq([1, 2])
+    end
+
+    it 'honours an explicitly given seqno' do
+      expect(create(:lex_citation_group, person: person, seqno: 7).seqno).to eq(7)
+    end
+
+    it 'orders the person\'s headings by seqno' do
+      second = create(:lex_citation_group, person: person, title: 'מאמרים', seqno: 2)
+      first = create(:lex_citation_group, person: person, title: 'ספרים', seqno: 1)
+      expect(person.reload.citation_groups.to_a).to eq([first, second])
+    end
+  end
+
+  # Removing a heading means "these citations are just general", never "throw these away".
+  describe 'destroying a heading' do
+    it 'returns its citations to the ungrouped general list' do
+      group = create(:lex_citation_group, person: person)
+      citation = create(:lex_citation, person: person, citation_group: group)
+
+      expect { group.destroy! }.not_to change(LexCitation, :count)
+      expect(citation.reload.citation_group).to be_nil
+    end
+  end
+end

--- a/spec/models/lex_citation_spec.rb
+++ b/spec/models/lex_citation_spec.rb
@@ -96,6 +96,19 @@ describe LexCitation do
     end
   end
 
+  describe '.heading_token_group_id' do
+    it 'reads the id out of a sub-heading token' do
+      expect(described_class.heading_token_group_id('heading:42')).to eq(42)
+    end
+
+    # A work title and a legacy subject are group tokens in their own right, so only the exact
+    # shape counts: a prefix test would parse an id of 0 out of these and take them for headings.
+    it 'is nil for anything that is not exactly heading:<id>' do
+      ['heading:foo', 'heading:', 'heading:12x', ' heading:12', 'על ״ספרים״', nil]
+        .each { |token| expect(described_class.heading_token_group_id(token)).to be_nil }
+    end
+  end
+
   # A Wayback Machine replacement for a dead anchored URL frequently repeats the anchor, which
   # makes the URL unparseable and so instantly "broken" again. See by-p6e.
   describe 'trimming a duplicated anchor from URL fields' do

--- a/spec/models/lex_citation_spec.rb
+++ b/spec/models/lex_citation_spec.rb
@@ -34,6 +34,66 @@ describe LexCitation do
         end
       end
     end
+
+    describe 'citation_group association validation' do
+      let(:person) { create(:lex_entry, :person).lex_item }
+      let(:group) { create(:lex_citation_group, person: person) }
+      let(:citation) { build(:lex_citation, person: person, citation_group: group, person_work: person_work) }
+      let(:person_work) { nil }
+
+      it { is_expected.to be_truthy }
+
+      context 'when the sub-heading belongs to a different person' do
+        let(:group) { create(:lex_citation_group, person: create(:lex_entry, :person).lex_item) }
+
+        it 'fails with a validation message' do
+          expect(result).to be false
+          expect(citation.errors[:citation_group]).to include(
+            I18n.t('activerecord.errors.models.lex_citation.attributes.citation_group.belongs_to_different_person')
+          )
+        end
+      end
+
+      context 'when the citation is also about one of the person\'s works' do
+        let(:person_work) { create(:lex_person_work, person: person) }
+
+        it 'fails: a citation about a work is grouped by that work, not by a general sub-heading' do
+          expect(result).to be false
+          expect(citation.errors[:citation_group]).to include(
+            I18n.t('activerecord.errors.models.lex_citation.attributes.citation_group.not_on_work_citation')
+          )
+        end
+      end
+    end
+  end
+
+  describe '#group_token' do
+    let(:person) { create(:lex_entry, :person).lex_item }
+
+    it 'is nil for a general citation under no heading' do
+      expect(build(:lex_citation, person: person).group_token).to be_nil
+    end
+
+    it 'is the work title for a citation about a work' do
+      work = create(:lex_person_work, person: person, title: 'מאמרים')
+      expect(build(:lex_citation, person: person, person_work: work).group_token).to eq('מאמרים')
+    end
+
+    it 'is the legacy subject for a citation still carrying one' do
+      expect(build(:lex_citation, person: person, subject: 'על "X"').group_token).to eq('על "X"')
+    end
+
+    # A person may well have a work titled 'מאמרים' as well as a general sub-heading of that name,
+    # so the sub-heading is identified by id: keying on the title alone would merge the two groups.
+    it 'is keyed by id for a general sub-heading, even one titled like a work' do
+      work = create(:lex_person_work, person: person, title: 'מאמרים')
+      group = create(:lex_citation_group, person: person, title: 'מאמרים')
+      grouped = create(:lex_citation, person: person, citation_group: group)
+      about_work = create(:lex_citation, person: person, person_work: work)
+
+      expect(grouped.group_token).to eq("heading:#{group.id}")
+      expect(grouped.group_token).not_to eq(about_work.group_token)
+    end
   end
 
   # A Wayback Machine replacement for a dead anchored URL frequently repeats the anchor, which

--- a/spec/models/lex_person_spec.rb
+++ b/spec/models/lex_person_spec.rb
@@ -71,43 +71,53 @@ describe LexPerson do
     end
   end
 
-  describe '.citations_by_subject_title' do
-    subject(:result) { person.citations_by_subject_title(subject_title) }
+  describe '.citations_by_group_token' do
+    subject(:result) { person.citations_by_group_token(group_token) }
 
     let(:person) { create(:lex_person) }
     let(:work_1) { create(:lex_person_work, person: person, title: 'Work A') }
     let(:work_2) { create(:lex_person_work, person: person, title: 'Work B') }
+    let(:group) { create(:lex_citation_group, person: person, title: 'Work B') }
     let!(:citation_1) { create(:lex_citation, person: person, person_work: work_1) }
     let!(:citation_2) { create(:lex_citation, person: person, person_work: work_2) }
     let!(:citation_3) { create(:lex_citation, person: person, subject: 'Work B', person_work: nil) }
     let!(:citation_general) { create(:lex_citation, person: person, subject: nil, person_work: nil) }
+    let!(:citation_grouped) { create(:lex_citation, person: person, citation_group: group) }
 
-    context 'when subject_title matches person_work title' do
-      let(:subject_title) { 'Work A' }
+    context 'when the token is a person_work title' do
+      let(:group_token) { 'Work A' }
 
       it 'returns citations with the given title from person_work' do
         expect(result).to eq([citation_1])
       end
     end
 
-    context 'when subject_title matches both person_work title and subject field' do
-      let(:subject_title) { 'Work B' }
+    context 'when the token matches both a person_work title and a legacy subject' do
+      let(:group_token) { 'Work B' }
 
-      it 'returns citations with the given subject_title from person_work and subject field' do
+      it 'returns the citations of both, which display under one heading' do
         expect(result).to contain_exactly(citation_2, citation_3)
       end
     end
 
-    context 'when subject_title is a nil' do
-      let(:subject_title) { nil }
+    context 'when the token is nil' do
+      let(:group_token) { nil }
 
-      it 'returns general citations not tied to specific work' do
+      it 'returns general citations tied neither to a work nor to a sub-heading' do
         expect(result).to eq([citation_general])
       end
     end
 
-    context 'when subject_title is not found in any citation' do
-      let(:subject_title) { 'Bambarbia Kirgudu' }
+    context 'when the token names a general sub-heading' do
+      let(:group_token) { "heading:#{group.id}" }
+
+      it 'returns only that sub-heading\'s citations, not the same-titled work\'s' do
+        expect(result).to eq([citation_grouped])
+      end
+    end
+
+    context 'when the token is not found in any citation' do
+      let(:group_token) { 'Bambarbia Kirgudu' }
 
       it 'returns empty array' do
         expect(result).to eq([])
@@ -132,9 +142,9 @@ describe LexPerson do
     end
   end
 
-  describe '.max_citation_seqno_by_subject_title' do
+  describe '.max_citation_seqno_by_group_token' do
     subject(:result) do
-      person.max_citation_seqno_by_subject_title(subject_title, exclude_citation_id: exclude_citation_id)
+      person.max_citation_seqno_by_group_token(group_token, exclude_citation_id: exclude_citation_id)
     end
 
     let(:person) { create(:lex_person) }
@@ -144,8 +154,8 @@ describe LexPerson do
     let!(:citation_a_2) { create(:lex_citation, person: person, subject: 'Work A', seqno: 2) }
     let!(:citation_a_3) { create(:lex_citation, person: person, subject: 'Work A', seqno: 4) }
 
-    context 'when there are citations with the given subject_title' do
-      let(:subject_title) { 'Work A' }
+    context 'when there are citations with the given token' do
+      let(:group_token) { 'Work A' }
 
       it 'returns the maximum seqno among those citations' do
         expect(result).to eq(4)
@@ -168,16 +178,16 @@ describe LexPerson do
       end
     end
 
-    context 'when given subject_title has no citations' do
-      let(:subject_title) { 'Work X' }
+    context 'when the given token has no citations' do
+      let(:group_token) { 'Work X' }
 
       it 'returns 0' do
         expect(result).to eq(0)
       end
     end
 
-    context 'when nil subject_title is passed' do
-      let(:subject_title) { nil }
+    context 'when a nil token is passed' do
+      let(:group_token) { nil }
 
       context 'when there are general citations' do
         let!(:general_citation_1) { create(:lex_citation, person: person, seqno: 1) }
@@ -192,6 +202,34 @@ describe LexPerson do
           expect(result).to eq(0)
         end
       end
+    end
+  end
+
+  describe '#group_citations_with_subject!' do
+    subject(:call) { person.group_citations_with_subject!('ספרים:', 'ספרים') }
+
+    let(:person) { create(:lex_person) }
+    let!(:citation_1) { create(:lex_citation, person: person, subject: 'ספרים:', seqno: 1) }
+    let!(:citation_2) { create(:lex_citation, person: person, subject: 'ספרים:', seqno: 2) }
+    let!(:other) { create(:lex_citation, person: person, subject: 'מאמרים', seqno: 1) }
+
+    it 'moves every citation under the heading into a sub-heading of that name' do
+      expect(call).to eq(2)
+      group = person.citation_groups.sole
+      expect(group.title).to eq('ספרים')
+      expect(group.citations).to contain_exactly(citation_1, citation_2)
+    end
+
+    it 'clears the legacy subject of the citations it groups, leaving the others alone' do
+      call
+      expect(citation_1.reload.subject).to be_nil
+      expect(other.reload.subject).to eq('מאמרים')
+    end
+
+    it 'reuses an existing sub-heading of the same name' do
+      group = create(:lex_citation_group, person: person, title: 'ספרים')
+      expect { call }.not_to change(LexCitationGroup, :count)
+      expect(citation_1.reload.citation_group).to eq(group)
     end
   end
 end

--- a/spec/requests/author_toc_lexicon_content_spec.rb
+++ b/spec/requests/author_toc_lexicon_content_spec.rb
@@ -228,5 +228,17 @@ RSpec.describe 'Authority TOC lexicon content', type: :request do
       expect(response.body).to include(I18n.t('lexicon.citations.header.subject_line', subject: 'נושא ידני'))
       expect(response.body).not_to include('<h4></h4>')
     end
+
+    # A general sub-heading names a kind of writing about the person, so it is shown as it stands
+    # rather than wrapped in the 'על ״...״' template a work title gets. See LexCitationGroup.
+    it 'headlines a general sub-heading verbatim, with its citations under it' do
+      group = create(:lex_citation_group, person: lex_person, title: 'ספרים')
+      create(:lex_citation, person: lex_person, citation_group: group, title: 'מונוגרפיה על היוצר')
+
+      call
+      expect(rendered).to have_css('#lexicon-about h4', text: 'ספרים')
+      expect(response.body).not_to include(I18n.t('lexicon.citations.header.subject_line', subject: 'ספרים'))
+      expect(rendered).to have_css('#lexicon-about li', text: 'מונוגרפיה על היוצר')
+    end
   end
 end

--- a/spec/requests/lexicon/citation_groups_controller_spec.rb
+++ b/spec/requests/lexicon/citation_groups_controller_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lexicon::CitationGroupsController, type: :request do
+  before do
+    login_as_lexicon_editor
+  end
+
+  let(:person) { create(:lex_entry, :person).lex_item }
+
+  describe 'POST /lex/people/:person_id/citation_groups' do
+    subject(:call) do
+      post "/lex/people/#{person.id}/citation_groups", params: { lex_citation_group: { title: title } }, xhr: true
+    end
+
+    let(:title) { '  ספרים  ' }
+
+    it 'creates the sub-heading, trimmed' do
+      expect { call }.to change(LexCitationGroup, :count).by(1)
+      expect(response).to have_http_status(:created)
+      expect(person.citation_groups.sole).to have_attributes(title: 'ספרים', seqno: 1)
+    end
+
+    context 'when a heading of that name already exists' do
+      before { create(:lex_citation_group, person: person, title: 'ספרים') }
+
+      it 'is rejected with the validation message' do
+        expect { call }.not_to change(LexCitationGroup, :count)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to be_present
+      end
+    end
+  end
+
+  describe 'PATCH /lex/citation_groups/:id' do
+    subject(:call) do
+      patch "/lex/citation_groups/#{group.id}", params: { lex_citation_group: { title: 'ספרי יובל' } }, xhr: true
+    end
+
+    let(:group) { create(:lex_citation_group, person: person, title: 'ספרים') }
+
+    it 'renames the heading for every citation under it at once' do
+      citation = create(:lex_citation, person: person, citation_group: group)
+      expect(call).to eq(200)
+      expect(group.reload.title).to eq('ספרי יובל')
+      expect(citation.reload.citation_group.title).to eq('ספרי יובל')
+    end
+  end
+
+  describe 'DELETE /lex/citation_groups/:id' do
+    subject(:call) { delete "/lex/citation_groups/#{group.id}", xhr: true }
+
+    let(:group) { create(:lex_citation_group, person: person) }
+    let!(:citation) { create(:lex_citation, person: person, citation_group: group) }
+
+    it 'removes the heading and returns its citations to the general list' do
+      expect { call }.to change(LexCitationGroup, :count).by(-1)
+      expect(response).to have_http_status(:ok)
+      expect(citation.reload.citation_group).to be_nil
+      expect(citation.group_token).to be_nil
+    end
+  end
+
+  describe 'POST /lex/citation_groups/:id/reorder' do
+    subject(:call) { post "/lex/citation_groups/#{books.id}/reorder", params: { new_index: new_index }, xhr: true }
+
+    let!(:books) { create(:lex_citation_group, person: person, title: 'ספרים') }
+    let!(:articles) { create(:lex_citation_group, person: person, title: 'מאמרים') }
+    let!(:festschrift) { create(:lex_citation_group, person: person, title: 'ספרי יובל') }
+
+    let(:new_index) { 2 }
+
+    it 'moves the heading and renumbers the rest' do
+      expect(call).to eq(200)
+      expect(person.reload.citation_groups.to_a).to eq([articles, festschrift, books])
+      expect(person.citation_groups.map(&:seqno)).to eq([1, 2, 3])
+    end
+
+    context 'when the position is out of range' do
+      let(:new_index) { 5 }
+
+      it 'fails with bad request and changes nothing' do
+        expect(call).to eq(400)
+        expect(person.reload.citation_groups.to_a).to eq([books, articles, festschrift])
+      end
+    end
+  end
+end

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -471,12 +471,13 @@ describe '/lexicon/citations' do
   describe 'POST /lex/citations/:id/reorder' do
     subject(:call) do
       post "/lex/citations/#{citation_to_move.id}/reorder",
-           params: { new_index: new_index, old_index: old_index, subject_title: subject_title },
+           params: { new_index: new_index, old_index: old_index, group_token: group_token }.merge(extra_params),
            xhr: true
     end
 
     let(:work) { create(:lex_person_work, person: person, title: 'Test Work') }
-    let(:subject_title) { work.title }
+    let(:group_token) { work.title }
+    let(:extra_params) { {} }
 
     let!(:citation_1) { create(:lex_citation, person: person, person_work: work, seqno: 2) }
     let!(:citation_2) { create(:lex_citation, person: person, person_work: work, seqno: 3) }
@@ -524,23 +525,23 @@ describe '/lexicon/citations' do
       end
     end
 
-    context 'when subject_title does not match' do
+    context 'when group_token does not match' do
       let(:citation_to_move) { other_citation }
       let(:old_index) { 0 }
       let(:new_index) { 1 }
 
       it 'fails with bad request' do
         expect(call).to eq(400)
-        expect(response.body).to eq("subject_title mismatch, actual: '#{other_work.title}', got: '#{work.title}'")
+        expect(response.body).to eq("group_token mismatch, actual: '#{other_work.title}', got: '#{work.title}'")
       end
     end
 
     context 'when using subject string instead of person_work' do
-      let(:subject_title) { 'Subject String' }
+      let(:group_token) { 'Subject String' }
 
-      let!(:citation_1) { create(:lex_citation, person: person, subject: subject_title, seqno: 1) }
-      let!(:citation_2) { create(:lex_citation, person: person, subject: subject_title, seqno: 2) }
-      let!(:citation_3) { create(:lex_citation, person: person, subject: subject_title, seqno: 3) }
+      let!(:citation_1) { create(:lex_citation, person: person, subject: group_token, seqno: 1) }
+      let!(:citation_2) { create(:lex_citation, person: person, subject: group_token, seqno: 2) }
+      let!(:citation_3) { create(:lex_citation, person: person, subject: group_token, seqno: 3) }
 
       let(:citation_to_move) { citation_1 }
       let(:old_index) { 0 }
@@ -549,9 +550,85 @@ describe '/lexicon/citations' do
       it 'reorders citations correctly' do
         expect(call).to eq(200)
 
-        reordered = person.reload.citations.select { |c| c.subject == subject_title }.sort_by(&:seqno)
+        reordered = person.reload.citations.select { |c| c.subject == group_token }.sort_by(&:seqno)
         expect(reordered.map(&:id)).to eq([citation_2.id, citation_3.id, citation_1.id])
         expect(reordered.map(&:seqno)).to eq((1..3).to_a)
+      end
+    end
+
+    # Dragging a citation from one general bucket into another (see LexCitationGroup).
+    context 'when moving a citation to another general bucket' do
+      let(:group) { create(:lex_citation_group, person: person, title: 'ספרים') }
+      let!(:general_1) { create(:lex_citation, person: person, seqno: 1) }
+      let!(:general_2) { create(:lex_citation, person: person, seqno: 2) }
+      let!(:grouped) { create_list(:lex_citation, 2, person: person, citation_group: group) }
+
+      let(:citation_to_move) { general_2 }
+      let(:group_token) { '' }
+      let(:extra_params) { { to_group_token: "heading:#{group.id}" } }
+      let(:old_index) { 1 }
+      let(:new_index) { 1 }
+
+      it 'files it under the target sub-heading at the requested position' do
+        expect(call).to eq(200)
+
+        expect(general_2.reload.citation_group).to eq(group)
+        expect(group.citations.order(:seqno).map(&:id)).to eq([grouped.first.id, general_2.id, grouped.last.id])
+        expect(group.citations.order(:seqno).map(&:seqno)).to eq((1..3).to_a)
+      end
+
+      it 'renumbers the bucket the citation left, leaving no gap where it was' do
+        call
+        remaining = person.reload.citations_by_group_token(nil).sort_by(&:seqno)
+        expect(remaining).not_to include(general_2)
+        expect(remaining.map(&:seqno)).to eq((1..remaining.size).to_a)
+      end
+
+      it 'moves a citation back out of a sub-heading into the ungrouped general list' do
+        post "/lex/citations/#{grouped.first.id}/reorder",
+             params: { new_index: 0, old_index: 0, group_token: "heading:#{group.id}", to_group_token: '' },
+             xhr: true
+
+        expect(response).to have_http_status(:ok)
+        expect(grouped.first.reload.citation_group).to be_nil
+        general = person.reload.citations_by_group_token(nil).sort_by(&:seqno)
+        expect(general.first).to eq(grouped.first)
+        expect(general.map(&:seqno)).to eq((1..general.size).to_a)
+      end
+
+      # A drag can only rearrange the general buckets; what a citation is about is set on its form.
+      it 'refuses to move a citation under a work' do
+        post "/lex/citations/#{general_2.id}/reorder",
+             params: { new_index: 0, old_index: 1, group_token: '', to_group_token: work.title },
+             xhr: true
+
+        expect(response).to have_http_status(:bad_request)
+        expect(general_2.reload.person_work).to be_nil
+      end
+
+      # Dragging out of a work's list would leave the citation both about a work and under a
+      # general sub-heading, which LexCitation forbids -- and renumber saves without validating.
+      it 'refuses to move a citation out of a work\'s list' do
+        about_work = create(:lex_citation, person: person, person_work: work, seqno: 1)
+        post "/lex/citations/#{about_work.id}/reorder",
+             params: { new_index: 0, old_index: 0, group_token: work.title,
+                       to_group_token: "heading:#{group.id}" },
+             xhr: true
+
+        expect(response).to have_http_status(:bad_request)
+        expect(about_work.reload.citation_group).to be_nil
+        expect(about_work.person_work).to eq(work)
+      end
+
+      it 'refuses a sub-heading belonging to another person' do
+        other_group = create(:lex_citation_group, person: create(:lex_entry, :person).lex_item)
+        post "/lex/citations/#{general_2.id}/reorder",
+             params: { new_index: 0, old_index: 1, group_token: '',
+                       to_group_token: "heading:#{other_group.id}" },
+             xhr: true
+
+        expect(response).to have_http_status(:bad_request)
+        expect(general_2.reload.citation_group).to be_nil
       end
     end
   end

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -620,6 +620,21 @@ describe '/lexicon/citations' do
         expect(about_work.person_work).to eq(work)
       end
 
+      # 'heading:<id>' is only a sub-heading token in that exact shape. Matching the prefix alone
+      # would let a work titled 'heading:foo' pass the general-bucket guard.
+      it 'refuses to move a citation out of a work titled like a sub-heading token' do
+        odd_work = create(:lex_person_work, person: person, title: 'heading:foo')
+        about_work = create(:lex_citation, person: person, person_work: odd_work, seqno: 1)
+
+        post "/lex/citations/#{about_work.id}/reorder",
+             params: { new_index: 0, old_index: 0, group_token: 'heading:foo', to_group_token: '' },
+             xhr: true
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to eq("'heading:foo' is not a general citation heading")
+        expect(about_work.reload.person_work).to eq(odd_work)
+      end
+
       it 'refuses a sub-heading belonging to another person' do
         other_group = create(:lex_citation_group, person: create(:lex_entry, :person).lex_item)
         post "/lex/citations/#{general_2.id}/reorder",

--- a/spec/requests/lexicon/entries_spec.rb
+++ b/spec/requests/lexicon/entries_spec.rb
@@ -196,6 +196,20 @@ describe '/lexicon/entries' do
           expect(response.body).to include('data-scroll-target="#lexicon-about"')
           expect(response.body).to include('data-scroll-target="#lexicon-links"')
         end
+
+        # The general citations come first, ungrouped ones then each sub-heading, and only then the
+        # citations about a work. See LexCitationGroup and LexiconHelper#grouped_and_ordered_citations.
+        it 'headlines a general sub-heading verbatim, above the work headings' do
+          person = entry.lex_item
+          group = create(:lex_citation_group, person: person, title: 'ספרים')
+          create(:lex_citation, person: person, citation_group: group, title: 'מונוגרפיה על היוצר')
+          work = create(:lex_person_work, person: person, title: 'ספר הזכרונות')
+          create(:lex_citation, person: person, person_work: work, title: 'מאמר על הספר')
+
+          call
+          headings = rendered.all('#lexicon-about h4').map(&:text)
+          expect(headings).to eq(['ספרים', I18n.t('lexicon.citations.header.subject_line', subject: 'ספר הזכרונות')])
+        end
       end
 
       context 'when a Person entry has no biography' do

--- a/spec/requests/lexicon/verification_citation_subjects_spec.rb
+++ b/spec/requests/lexicon/verification_citation_subjects_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Lexicon::Verification citation subject headings', type: :request
 
   describe 'PATCH /lex/verification/:id/confirm_citation_subject' do
     let!(:citations) { create_list(:lex_citation, 2, person: person, subject: 'על "אור פרא"') }
+    let!(:books) { create_list(:lex_citation, 2, person: person, subject: 'ספרים:') }
 
     it 'links every citation under the heading to the work and clears the heading' do
       patch "/lex/verification/#{entry.id}/confirm_citation_subject",
@@ -51,6 +52,19 @@ RSpec.describe 'Lexicon::Verification citation subject headings', type: :request
       expect(response).to have_http_status(:success)
       expect(citations.map { |c| c.reload.person_work }).to all(be_nil)
       expect(citations.map { |c| c.reload.subject }).to all(be_nil)
+    end
+
+    # The third resolution: neither a work nor discarded, but kept as a named sub-heading of the
+    # general citations. See LexCitationGroup.
+    it 'keeps a heading confirmed as a general sub-heading, under its own name' do
+      patch "/lex/verification/#{entry.id}/confirm_citation_subject",
+            params: { subject: 'ספרים:', work_id: Lexicon::VerificationController::GENERAL_HEADING_WORK_ID }
+
+      expect(response).to have_http_status(:success)
+      group = person.citation_groups.sole
+      expect(group.title).to eq 'ספרים'
+      expect(group.citations).to match_array(books)
+      expect(books.map { |c| c.reload.subject }).to all(be_nil)
     end
 
     it 'leaves the citations alone when the work belongs to someone else' do

--- a/spec/services/lexicon/match_citation_subjects_spec.rb
+++ b/spec/services/lexicon/match_citation_subjects_spec.rb
@@ -105,9 +105,40 @@ describe Lexicon::MatchCitationSubjects do
       add_citation('מאמרים')
     end
 
-    it 'proposes clearing it without a work' do
-      expect(proposal_for('מאמרים')).to have_attributes(generic: true, work: nil, certain?: false,
-                                                        proposed?: true)
+    it 'proposes keeping it as a general sub-heading, with certainty' do
+      expect(proposal_for('מאמרים')).to have_attributes(generic: true, work: nil, certain?: true,
+                                                        proposed?: true, heading_title: 'מאמרים')
+    end
+
+    it 'applies as a sub-heading of the general citations' do
+      proposal_for('מאמרים').apply!(person)
+      group = person.citation_groups.sole
+      expect(group.title).to eq('מאמרים')
+      expect(group.citations.count).to eq(1)
+    end
+  end
+
+  # About half the legacy files write the heading with a trailing colon; it is layout punctuation,
+  # not part of the name, and used to keep the heading from being recognized as generic at all.
+  describe 'a generic bucket heading written with a trailing colon' do
+    before do
+      add_citation('ספרים:')
+    end
+
+    it 'is recognized, and drops the colon from the sub-heading name' do
+      expect(proposal_for('ספרים:')).to have_attributes(generic: true, certain?: true, heading_title: 'ספרים')
+    end
+  end
+
+  describe 'the general categories beyond ספרים and מאמרים' do
+    before do
+      add_citation('ספרי יובל')
+      add_citation('ביבליוגרפיה:')
+    end
+
+    it 'recognizes them too' do
+      expect(proposal_for('ספרי יובל')).to have_attributes(generic: true, heading_title: 'ספרי יובל')
+      expect(proposal_for('ביבליוגרפיה:')).to have_attributes(generic: true, heading_title: 'ביבליוגרפיה')
     end
   end
 

--- a/spec/services/lexicon/recover_citation_headings_spec.rb
+++ b/spec/services/lexicon/recover_citation_headings_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lexicon::RecoverCitationHeadings do
+  subject(:call) { described_class.call(person) }
+
+  let(:lex_file) do
+    create(:lex_file, :person, status: :ingested, fname: 'general_citation_headings.php',
+                               full_path: Rails.root.join('spec/fixtures/files/lexicon/general_citation_headings.php'))
+  end
+  let(:person) { lex_file.lex_entry.lex_item }
+
+  let!(:monograph) { add_general_citation('מונוגרפיה על המחברת', 1) }
+  let!(:article_1) { add_general_citation('זרקור על דמות נעלמה', 2) }
+  let!(:article_2) { add_general_citation('אנדרוגניות במצור', 3) }
+
+  # Titles as an LLM parse of the fixture would have stored them, i.e. what the flat general list
+  # looks like today for an entry migrated before LexCitationGroup existed.
+  def add_general_citation(title, seqno)
+    create(:lex_citation, person: person, title: title, seqno: seqno, subject: nil, person_work: nil)
+  end
+
+  it 'files each general citation under the sub-heading it sat under in the legacy file' do
+    expect(call).to have_attributes(grouped_count: 3, unmatched_count: 0, groups: %w(ספרים מאמרים))
+
+    expect(monograph.reload.citation_group.title).to eq('ספרים')
+    expect(article_1.reload.citation_group.title).to eq('מאמרים')
+    expect(article_2.reload.citation_group.title).to eq('מאמרים')
+  end
+
+  it 'gives the sub-headings the order the legacy page had them in' do
+    call
+    expect(person.reload.citation_groups.map(&:title)).to eq(%w(ספרים מאמרים))
+  end
+
+  it 'numbers each sub-heading\'s citations from one' do
+    call
+    expect(person.reload.citation_groups.map { |g| g.citations.order(:seqno).map(&:seqno) }).to eq([[1], [1, 2]])
+  end
+
+  # The heading naming a work ('על ״שיחות אינטימיות״') is not a general sub-heading: its citations
+  # belong under the work, and inventing a group for it would be worse than leaving them flat.
+  it 'ignores headings that are not recognized general categories' do
+    review = add_general_citation('ביקורת על הספר', 4)
+    call
+    expect(review.reload.citation_group).to be_nil
+  end
+
+  it 'leaves a citation that matches no source item in the ungrouped general list' do
+    stray = add_general_citation('מאמר שאינו מופיע במקור כלל', 5)
+    expect(call).to have_attributes(grouped_count: 3, unmatched_count: 1)
+    expect(stray.reload.citation_group).to be_nil
+  end
+
+  describe 'what it refuses to touch' do
+    it 'leaves citations already under a sub-heading alone' do
+      group = create(:lex_citation_group, person: person, title: 'ביבליוגרפיה')
+      monograph.update!(citation_group: group)
+
+      call
+      expect(monograph.reload.citation_group).to eq(group)
+    end
+
+    it 'leaves citations about a work alone' do
+      work = create(:lex_person_work, person: person, title: 'שיחות אינטימיות')
+      article_1.update!(person_work: work)
+
+      call
+      expect(article_1.reload.citation_group).to be_nil
+      expect(article_1.person_work).to eq(work)
+    end
+
+    it 'leaves citations still carrying an unresolved legacy subject alone' do
+      article_1.update!(subject: 'על משהו אחר')
+
+      call
+      expect(article_1.reload.citation_group).to be_nil
+      expect(article_1.subject).to eq('על משהו אחר')
+    end
+  end
+
+  it 'is safe to run twice' do
+    call
+    expect { described_class.call(person.reload) }.not_to change(LexCitationGroup, :count)
+  end
+
+  context 'when the legacy file is not readable' do
+    before { lex_file.update!(full_path: '/nonexistent/00000.php') }
+
+    it 'reports the entry as skipped and changes nothing' do
+      expect(call).to have_attributes(skipped: :no_legacy_file, skipped?: true)
+      expect(monograph.reload.citation_group).to be_nil
+    end
+  end
+
+  context 'when the legacy file has no recognized general sub-heading' do
+    before do
+      lex_file.update!(full_path: Rails.root.join('spec/fixtures/files/lexicon/ul_directly_after_citations_header.php'))
+    end
+
+    it 'reports the entry as skipped' do
+      expect(call).to have_attributes(skipped: :no_headings_in_source)
+    end
+  end
+end

--- a/spec/system/lexicon/citation_sub_headings_spec.rb
+++ b/spec/system/lexicon/citation_sub_headings_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Managing the general citation sub-headings (ספרים, מאמרים, ...) from the entry editor's
+# citations tab. See LexCitationGroup.
+RSpec.describe 'General citation sub-headings', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:person) { create(:lex_person, gender: :female) }
+  let!(:entry) { create(:lex_entry, title: 'חוה שפירא', lex_item: person, status: :draft) }
+  let!(:general) do
+    create(:lex_citation, person: person, authors_count: 0, title: 'זרקור על דמות נעלמה', link: nil, seqno: 1)
+  end
+
+  def open_citations_tab
+    visit "/lex/entries/#{entry.id}/edit"
+    click_link_or_button I18n.t('lexicon.entries.edit.citations')
+    expect(page).to have_css('#citations ul.citations-group', wait: 5)
+  end
+
+  def heading_titles
+    all('#citation-headings .citation-heading-block .heading-title').map(&:text)
+  end
+
+  it 'adds a sub-heading from the citations tab' do
+    open_citations_tab
+    accept_prompt(with: 'ספרים') { find('a.add-citation-group').click }
+
+    expect(page).to have_css('#citation-headings .citation-heading-block', text: 'ספרים', wait: 5)
+    expect(person.citation_groups.reload.map(&:title)).to eq(['ספרים'])
+  end
+
+  context 'with an existing sub-heading' do
+    let!(:group) { create(:lex_citation_group, person: person, title: 'ספרים') }
+    let!(:grouped) do
+      create(:lex_citation, person: person, citation_group: group, authors_count: 0,
+                            title: 'מונוגרפיה על המחברת', link: nil, seqno: 1)
+    end
+
+    it 'shows the sub-heading verbatim, with its citation under it' do
+      open_citations_tab
+
+      within '#citation-headings .citation-heading-block' do
+        expect(page).to have_css('h4', text: 'ספרים')
+        expect(page).to have_css('ul.citations-group li', text: 'מונוגרפיה על המחברת')
+      end
+    end
+
+    it 'renames the sub-heading' do
+      open_citations_tab
+      accept_prompt(with: 'ספרי יובל') do
+        find('#citation-headings .rename-citation-group').click
+      end
+
+      expect(page).to have_css('#citation-headings h4', text: 'ספרי יובל', wait: 5)
+      expect(group.reload.title).to eq('ספרי יובל')
+    end
+
+    it 'removes the sub-heading, keeping its citations in the general list' do
+      open_citations_tab
+      accept_confirm do
+        find('#citation-headings .delete-citation-group').click
+      end
+
+      expect(page).to have_no_css('#citation-headings .citation-heading-block', wait: 5)
+      expect(page).to have_css('ul.citations-group li', text: 'מונוגרפיה על המחברת')
+      expect(grouped.reload.citation_group).to be_nil
+    end
+
+    it 'moves a citation into the sub-heading from its edit form' do
+      open_citations_tab
+      within('ul.citations-group.ungrouped-citations') do
+        click_link_or_button I18n.t(:edit)
+      end
+      expect(page).to have_css('#generalDlg.show', wait: 5)
+
+      within '#generalDlg' do
+        select 'ספרים', from: 'lex_citation[lex_citation_group_id]'
+        click_link_or_button I18n.t(:save)
+      end
+
+      expect(page).to have_css("ul.citations-group[data-group-token='heading:#{group.id}'] li",
+                               text: 'זרקור על דמות נעלמה', wait: 5)
+      expect(general.reload.citation_group).to eq(group)
+    end
+
+    context 'with a second sub-heading' do
+      let!(:articles) { create(:lex_citation_group, person: person, title: 'מאמרים', seqno: 2) }
+
+      # The drag itself is SortableJS, which Selenium cannot drive; what it posts is covered by
+      # spec/requests/lexicon/citation_groups_controller_spec.rb. What matters here is that the tab lists the
+      # headings in the editor's own order, and offers a handle to change it.
+      it 'lists the sub-headings in their stored order, each with a drag handle' do
+        open_citations_tab
+        expect(heading_titles).to eq(%w(ספרים מאמרים))
+        expect(page).to have_css('#citation-headings .heading-drag-handle', count: 2)
+
+        articles.update!(seqno: 0)
+        open_citations_tab
+        expect(heading_titles).to eq(%w(מאמרים ספרים))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Legacy lexicon bibliographies group the citations that are **about the person** — as opposed to about one particular work — under sub-headings of their own: ספרים, מאמרים, ספרי יובל, ביבליוגרפיה. The migration threw those away, conflating every group into one flat "general" list.

Example — `00095.php` (חוה שפירא):

```html
<p><font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
  <font color="#FF0000">ספרים:</font>   <ul>…</ul>
  <font color="#FF0000">מאמרים:</font>  <ul>…</ul>
```

`MatchCitationSubjects::GENERIC_SUBJECTS` recognized exactly three headings (`'מאמרים'`, `'ספרים'`, `'על הספר'`) and resolved each by **clearing** it. Everything else — including the `':'`-suffixed spellings about half the files use — was not recognized at all and sat unresolved in the verification workbench.

## The model

`LexCitationGroup`: a named, ordered bucket of general citations belonging to a person.

```
lex_citation_groups   id | lex_person_id | title | seqno   (unique on person+title)
lex_citations         + lex_citation_group_id (nullable)
```

Only general citations are grouped — a citation about a work is already grouped by that work — so `lex_citation_group_id` and `lex_person_work_id` are mutually exclusive. Deleting a sub-heading returns its citations to the ungrouped general list (`dependent: :nullify`); an editor removing a heading means "these are just general", never "throw these away".

**Grouping key.** Citation lists are now keyed by `LexCitation#group_token` instead of the heading's text. A person may well have both a work and a general sub-heading titled `מאמרים`, and keying on the bare title would silently merge them; a sub-heading is therefore keyed `heading:<id>`. A work title and a legacy subject that agree *do* still share a key — that is what keeps a half-resolved bibliography showing one heading rather than two identical ones.

## Editing (entry editor, not the verification view)

The citations tab now renders the ungrouped general bucket, then each sub-heading, then the work headings. Editors can:

- **add** a sub-heading, **rename** it (one `UPDATE`, not N), **remove** it, and **drag-reorder** the sub-headings;
- **move citations between** the general buckets by dragging, or from the citation's own edit form (a new `citation_group` select).

Work lists stay closed to drags: moving a citation under a work changes what it is *about*, which belongs in the edit form. The reorder endpoint enforces this on both ends — `renumber` saves without validating, so a crafted request could otherwise write a citation that is both about a work and under a general sub-heading.

## Recognizing a general heading

`GENERIC_SUBJECTS` is expanded to every heading that *recurs across entries* in the `a[name="Bib."]` section of all 4,051 legacy person files — which is what tells a category apart from a work title. Of ~9,200 distinct headings, the rest are `על "..."` naming one work each:

| heading | files |
| --- | --- |
| ספרים / ספרים: | 230 |
| מאמרים / מאמרים: | 218 |
| ביבליוגרפיה(:) / ביבליוגרפיות | 41 |
| ספרי יובל / ספר יובל | 8 |
| מונוגרפיות, מאמרים ורשימות, מבחר מאמרים מקוונים, מבחר שירים מקוונים | 14 |

The trailing colon is normalized away (layout punctuation, not part of the name). A generic heading is now `certain?`, so ingest applies it without an editor; the workbench offers **"keep as a general sub-heading"** as a third resolution beside naming a work and dropping the heading.

## Recovering the ~300 already-migrated entries

Two data migrations, both of which only ever touch citations that are general *and* ungrouped — safe to re-run, and they cannot overrule an editor:

1. **Headings still stored as a legacy `subject`** become sub-headings (the newly recognized ones: `ספרים:`, `ביבליוגרפיה`, …).
2. **Headings already cleared** are re-read from the legacy PHP file. `Lexicon::RecoverCitationHeadings` matches each general citation back to the `<li>` it was parsed from (title containment, longest first, each claimed once) and files it under that `<li>`'s heading.

Sub-headings come out in **source order** (ספרים before מאמרים), not alphabetically, via `Proposal#source_position`.

Recovery is deliberately restricted to the recognized-general list. A probe over the corpus with a looser rule ("any heading not phrased as a work title") turned up bare work titles (`אבני גדר`), the English form (`On "Exile from exile"`), the links section's own `קישורים` header bleeding in through an unclosed tag, and outright debris (`V–XXIV`). Inventing a sub-heading out of any of those would be worse than the flat list. With the allowlist: **281 files, 11 distinct headings, all genuine.**

Run against the dev database, this recovered 21 sub-headings — e.g. `דוד אבידן: ספרים (19), מאמרים (49)`; `שולמית הראבן: ספרים (1), מאמרים (35)`, matching the source tally exactly.

> ⚠️ Step 2 needs the legacy PHP corpus readable at `LexFile#full_path`. Where it is not, the entry is counted as skipped and the migration carries on — a missing corpus must not fail a deploy, and the step can simply be re-run once it is mounted. Entries are **not** sent back to verification: recovery adds information rather than changing an editorial decision.

## Test plan

Ran (all green):

```
spec/models/lex_citation_spec.rb spec/models/lex_citation_group_spec.rb
spec/models/lex_person_spec.rb spec/helpers/lexicon_helper_spec.rb
spec/services/lexicon/ spec/requests/lexicon/
spec/requests/author_toc_lexicon_content_spec.rb          → 879 examples, 0 failures
spec/system/lexicon/citation_sub_headings_spec.rb
spec/system/lexicon/citation_text_links_spec.rb           →   9 examples, 0 failures
```

New coverage: `LexCitationGroup` validations / seqno / nullify-on-destroy; `LexCitation#group_token` including the work-vs-sub-heading name collision; `LexPerson#group_citations_with_subject!`; `grouped_and_ordered_citations` ordering and heading wording; the `citation_groups` controller (create/rename/delete/reorder); cross-bucket drags and the two refusals; `RecoverCitationHeadings` against a new fixture (11 examples, incl. what it refuses to touch and re-runnability); the workbench's third resolution; and public rendering on both the entry page and the author TOC.

`bundle exec rubocop` and `bundle exec haml-lint` are clean on every changed file (remaining offenses in the reports are pre-existing and unrelated).

**The full suite was not run** — it takes 40+ minutes and needs your approval.

## Two things to flag

- `LexPerson#general_citations` is dead code (no callers anywhere) and its name is now ambiguous, since grouped citations are also general. Left untouched — say the word and I'll remove it.
- The heading-reorder **drag** is SortableJS, which Selenium cannot drive, so the system spec asserts the rendered order and the presence of handles instead; what the drag posts is covered by the request spec.
