### PR TITLE
Count all publicly reachable lexicon entries in the Authors menu

### DIFF
--- a/app/controllers/lexicon/entries_controller.rb
+++ b/app/controllers/lexicon/entries_controller.rb
@@ -67,10 +67,9 @@ scope = LexEntry.where.not(lex_item: nil).includes(:lex_item)
       @person_filters_active = @genders.any? || @birth_year_from.present? || @birth_year_to.present? ||
                                @death_year_from.present? || @death_year_to.present?
 
-      # Start with base scope
-      # We render all not-completed migrations (they will be redirected to old site) plus published entries.
-      # Only main entries are listed; secondary entries are reachable via internal links only.
-      @lex_entries = LexEntry.main.includes(:lex_item).where(status: LexEntry::MIGRATION_STATUSES + %w(published))
+      # Start with base scope: published entries plus not-completed migrations (which get
+      # redirected to the old site); see LexEntry.publicly_listed.
+      @lex_entries = LexEntry.publicly_listed.includes(:lex_item)
 
       # Calculate gender facets (before applying gender filter)
       @gender_facet = calculate_gender_facets

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -53,6 +53,11 @@ class LexEntry < ApplicationRecord
   # reachable via internal links from another entry.
   scope :main, -> { where(main: true) }
 
+  # The entries the public lexicon index lists, and the ones a visitor can actually reach:
+  # published entries, plus entries whose migration has not completed -- those are still served,
+  # by redirecting to their legacy PHP file. Draft and deprecated entries are editor-only.
+  scope :publicly_listed, -> { main.where(status: MIGRATION_STATUSES + %w(published)) }
+
   # SQL counterpart of `#entry_type == :person`: entries backed by a LexPerson item, plus entries
   # still awaiting ingestion -- no lex_item yet -- whose legacy file is a person file. The
   # lex_item_type IS NULL half matters: #entry_type only consults the file when the column is
@@ -184,9 +189,11 @@ class LexEntry < ApplicationRecord
     end
   end
 
-  def self.cached_published_count
-    Rails.cache.fetch('lex_entry_published_count', expires_in: 24.hours) do
-      LexEntry.where(status: :published).count
+  # Number shown in the site menu next to the lexicon link. Counts every entry a visitor can
+  # reach, not just the migrated ones -- unmigrated entries are served from the legacy PHP files.
+  def self.cached_public_count
+    Rails.cache.fetch('lex_entry_public_count', expires_in: 24.hours) do
+      publicly_listed.count
     end
   end
 

--- a/app/views/shared/_tabs.html.haml
+++ b/app/views/shared/_tabs.html.haml
@@ -2,7 +2,7 @@
   .header-nav-area
     %nav#nav
       %ul#menu
-        - authors_total = t(:x_authors_in_the_project_and_y_in_the_lexicon, x: Authority.cached_count, y: LexEntry.cached_published_count)
+        - authors_total = t(:x_authors_in_the_project_and_y_in_the_lexicon, x: Authority.cached_count, y: LexEntry.cached_public_count)
         %li.topMenuItem-v02
           .by-dropdown-v02.dropdown#ddauthors
             %a.by-nav-item-v02#nav-authors{'data-toggle' =>'dropdown', 'data-boundary' => 'viewport', tabindex: '1'}= t(:authors)
@@ -22,7 +22,7 @@
               %a{href: lexicon_root_path}
                 -# ICON TBD # %span.by-icon-v02 L
                 = t(:lexicon_name)
-                %span{style:'color:black'}= " - #{LexEntry.cached_published_count} #{t(:authors)}"
+                %span{style:'color:black'}= " - #{LexEntry.cached_public_count} #{t(:authors)}"
         - works_total = "#{t(:x_volumes_and, x: Collection.cached_volume_and_issue_count)}#{Manifestation.cached_count} #{t(:works_in_the_project)}"
         %li.topMenuItem-v02
           .by-dropdown-v02.dropdown#ddworks

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -66,6 +66,37 @@ RSpec.describe LexEntry, type: :model do
     end
   end
 
+  describe '.publicly_listed' do
+    # Unmigrated entries are reachable too -- /lex/entries/:id redirects them to their legacy PHP
+    # file -- so they belong in the public listing (and in the menu count derived from it) exactly
+    # like published ones. Only editor-facing entries are left out.
+    let!(:published) { create(:lex_entry, status: :published) }
+    let!(:unmigrated) { create(:lex_file, :person, entry_status: :raw).lex_entry }
+    let!(:verifying) { create(:lex_entry, status: :verifying) }
+
+    it 'includes published entries and entries whose migration has not completed' do
+      expect(described_class.publicly_listed).to contain_exactly(published, unmigrated, verifying)
+    end
+
+    it 'excludes draft, deprecated and secondary entries' do
+      create(:lex_entry, status: :draft)
+      create(:lex_entry, status: :deprecated)
+      create(:lex_entry, status: :published, main: false)
+
+      expect(described_class.publicly_listed).to contain_exactly(published, unmigrated, verifying)
+    end
+  end
+
+  describe '.cached_public_count' do
+    it 'counts unmigrated entries alongside published ones' do
+      create(:lex_entry, status: :published)
+      create(:lex_file, :person, entry_status: :raw)
+      create(:lex_entry, status: :draft)
+
+      expect(described_class.cached_public_count).to eq 2
+    end
+  end
+
   describe '#surname_first_title' do
     subject(:surname_first_title) { entry.surname_first_title }
 

--- a/spec/requests/lexicon_menu_count_spec.rb
+++ b/spec/requests/lexicon_menu_count_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Authors menu used to advertise only the migrated (published) lexicon entries, which
+# undercounts the lexicon: unmigrated entries are served just as well, by redirecting to their
+# legacy PHP file. The menu now reports every publicly reachable entry.
+RSpec.describe 'Lexicon count in the Authors menu', type: :request do
+  around do |example|
+    I18n.with_locale(:he) { example.run }
+  end
+
+  before { clean_tables }
+
+  def authors_menu_text
+    menu = Nokogiri::HTML(response.body).at_css('#menu-authors')
+    expect(menu).not_to be_nil, 'the Authors dropdown (#menu-authors) is missing from the page'
+    menu.text
+  end
+
+  it 'counts unmigrated entries as well as published ones' do
+    create(:lex_entry, status: :published)
+    create(:lex_file, :person, entry_status: :raw)
+
+    get root_path
+
+    expect(response).to have_http_status(:ok)
+    expect(LexEntry.cached_public_count).to eq 2
+    expect(authors_menu_text).to include(
+      I18n.t(:x_authors_in_the_project_and_y_in_the_lexicon, x: Authority.cached_count, y: 2)
+    )
+    expect(authors_menu_text).to include("2 #{I18n.t(:authors)}")
+  end
+end


### PR DESCRIPTION
## Problem

The "Authors" menu reported `LexEntry.cached_published_count` — only entries whose migration off
the legacy PHP files has completed. That undercounts the lexicon: unmigrated entries are equally
accessible to visitors, because `/lex/entries/:id` redirects them to their legacy PHP file.

## Change

- New `LexEntry.publicly_listed` scope: `main` entries whose status is in `MIGRATION_STATUSES`
  or `published` — exactly the set `Lexicon::EntriesController#index` already listed. Draft and
  deprecated entries stay out (editor-only), as do secondary (`main: false`) entries, which are
  reachable only via internal links and are not listed at /lex.
- `LexEntry.cached_published_count` → `LexEntry.cached_public_count`, counting that scope. New
  cache key (`lex_entry_public_count`), so no stale value survives the deploy.
- Both menu call sites in `app/views/shared/_tabs.html.haml` updated; the entries index now uses
  the scope instead of restating it inline.

## Test plan

New specs, all passing:

- `spec/models/lex_entry_spec.rb` — `.publicly_listed` includes published and unmigrated entries,
  excludes draft/deprecated/secondary; `.cached_public_count` counts unmigrated alongside published.
- `spec/requests/lexicon_menu_count_spec.rb` — the rendered Authors dropdown reports both the
  published and the unmigrated entry (fails on the old behaviour, which reported 1 of 2).

Ran: `spec/models/lex_entry_spec.rb`, `spec/controllers/lexicon/entries_controller_spec.rb`,
`spec/requests/lexicon/entries_spec.rb`, `spec/requests/lexicon/entries_php_badge_spec.rb`,
`spec/requests/lexicon/entries_ux_improvements_spec.rb`, `spec/requests/mobile_menu_totals_spec.rb`,
`spec/requests/lexicon_menu_count_spec.rb` (173 + 1 examples, 0 failures) and
`spec/system/lexicon/entries_filtering_spec.rb`, `spec/system/lexicon/entries_list_filtering_spec.rb`
(21 examples, 0 failures). The full suite was **not** run — it takes 40+ minutes and needs approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
