### PR TITLE
Centre the shekel glyph in the top-bar donation button and stop its label wrapping

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1495,6 +1495,24 @@ p.by-genre-name-v02.headline-2-v02 {
   white-space: nowrap;
 }
 
+/* The same 18px-glyph-in-a-26px-CLS-box problem as the author page card and the
+   reading-mode buttons above: the shekel glyph sat against the top of the
+   button's white background instead of on its centre line, ~4px above the
+   label beside it. Centre the glyph in its box. */
+.donation-btn-v02 .by-icon-v02 {
+  line-height: 26px;
+}
+
+/* The top-bar button had only ~5px of slack around its label at 122px. Alef is
+   loaded from Google Fonts in weight 400 only, so the bold label is synthesised
+   by the browser, and macOS emboldens wider than Linux/Windows does -- enough
+   to eat that slack and, on a stylesheet predating the nowrap rule above, wrap
+   the label. Give the label room to spare here; the narrower mobile donation
+   buttons keep the 122px above. */
+#donev_top_bar .donation-btn-v02 {
+  min-width: 132px;
+}
+
 /* Tag-proposal popup: the mode toggle (suggest / pick from full list) and the
    tag-suggestion heuristic strip. Both are Bootstrap tab navs, and Bootstrap's
    .nav / .nav-link class names collide with the side-menu rules in

--- a/spec/system/donation_button_nowrap_spec.rb
+++ b/spec/system/donation_button_nowrap_spec.rb
@@ -6,6 +6,37 @@ require 'rails_helper'
 # button -- sized by a fixed min-width -- wrapped there while looking fine
 # elsewhere. The label is now pinned to a single line regardless of metrics.
 RSpec.describe 'Top-bar donation button', :js, type: :system do
+  # Measures the button against its own contents: the label's own width comes
+  # from a Range over the text node, since it is an anonymous flex item with no
+  # element of its own to measure.
+  let(:measure_button_js) do
+    <<~JS
+      (function () {
+        var btn = document.querySelector('.donation-area-v02 .donation-btn-v02');
+        var cs = getComputedStyle(btn);
+        var icon = btn.querySelector('.by-icon-v02');
+        var labelWidth = 0;
+        btn.childNodes.forEach(function (node) {
+          if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) return;
+          var range = document.createRange();
+          range.selectNodeContents(node);
+          labelWidth += range.getBoundingClientRect().width;
+        });
+        var contentWidth = btn.clientWidth -
+          parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+        return {
+          whiteSpace: cs.whiteSpace,
+          lineHeight: parseFloat(cs.lineHeight),
+          height: btn.getBoundingClientRect().height,
+          scrollWidth: btn.scrollWidth,
+          clientWidth: btn.clientWidth,
+          slack: contentWidth - labelWidth -
+            icon.getBoundingClientRect().width - parseFloat(cs.columnGap || 0)
+        };
+      })()
+    JS
+  end
+
   before do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
   end
@@ -15,24 +46,16 @@ RSpec.describe 'Top-bar donation button', :js, type: :system do
 
     expect(page).to have_css('.donation-area-v02 .donation-btn-v02', visible: :visible)
 
-    metrics = page.evaluate_script(<<~JS)
-      (function () {
-        var btn = document.querySelector('.donation-area-v02 .donation-btn-v02');
-        var cs = getComputedStyle(btn);
-        return {
-          whiteSpace: cs.whiteSpace,
-          lineHeight: parseFloat(cs.lineHeight),
-          height: btn.getBoundingClientRect().height,
-          scrollWidth: btn.scrollWidth,
-          clientWidth: btn.clientWidth
-        };
-      })()
-    JS
+    metrics = page.evaluate_script(measure_button_js)
 
     # The guarantee: the label cannot break onto a second line.
     expect(metrics['whiteSpace']).to eq('nowrap')
     # And as rendered here it is one line, with the text not clipped.
     expect(metrics['height']).to be < (metrics['lineHeight'] * 2)
     expect(metrics['scrollWidth']).to be <= metrics['clientWidth'] + 1
+    # The button is also wide enough to absorb a browser that measures the bold
+    # label a few percent wider: Alef is served in weight 400 only, so the bold
+    # label is synthesised, and macOS emboldens more than Linux/Windows.
+    expect(metrics['slack']).to be >= 8
   end
 end

--- a/spec/system/donation_button_nowrap_spec.rb
+++ b/spec/system/donation_button_nowrap_spec.rb
@@ -6,22 +6,27 @@ require 'rails_helper'
 # button -- sized by a fixed min-width -- wrapped there while looking fine
 # elsewhere. The label is now pinned to a single line regardless of metrics.
 RSpec.describe 'Top-bar donation button', :js, type: :system do
-  # Measures the button against its own contents: the label's own width comes
-  # from a Range over the text node, since it is an anonymous flex item with no
+  # Measures the button against its own contents. "Slack" is how much of the
+  # button's content box the icon and label do not occupy, taken as the span
+  # from the leftmost to the rightmost of their client rects -- which already
+  # accounts for the flex gap between them, so nothing here has to parse
+  # `column-gap` (it computes to the keyword `normal` when no gap applies).
+  # The label needs a Range because it is an anonymous flex item, with no
   # element of its own to measure.
   let(:measure_button_js) do
     <<~JS
       (function () {
         var btn = document.querySelector('.donation-area-v02 .donation-btn-v02');
         var cs = getComputedStyle(btn);
-        var icon = btn.querySelector('.by-icon-v02');
-        var labelWidth = 0;
+        var rects = [btn.querySelector('.by-icon-v02').getBoundingClientRect()];
         btn.childNodes.forEach(function (node) {
           if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) return;
           var range = document.createRange();
           range.selectNodeContents(node);
-          labelWidth += range.getBoundingClientRect().width;
+          rects.push(range.getBoundingClientRect());
         });
+        var occupied = Math.max.apply(null, rects.map(function (r) { return r.right; })) -
+          Math.min.apply(null, rects.map(function (r) { return r.left; }));
         var contentWidth = btn.clientWidth -
           parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
         return {
@@ -30,8 +35,7 @@ RSpec.describe 'Top-bar donation button', :js, type: :system do
           height: btn.getBoundingClientRect().height,
           scrollWidth: btn.scrollWidth,
           clientWidth: btn.clientWidth,
-          slack: contentWidth - labelWidth -
-            icon.getBoundingClientRect().width - parseFloat(cs.columnGap || 0)
+          slack: contentWidth - occupied
         };
       })()
     JS


### PR DESCRIPTION
## What

Two visual issues on the `#donev_top_bar` donation button.

### 1. The shekel glyph was not vertically centred on the button

`.by-icon-v02` has a 26px CLS box but an 18px `line-height`, so the glyph
renders against the top of that box while the flex row centres the box itself —
the glyph ended up ~4px above the button's centre line, visually touching the
top border. This is the same problem already fixed for the author page top card
and the reading-mode buttons; the fix is the same `line-height: 26px`.

Before / after (production page, 6× device scale):

| before | after |
| --- | --- |
| glyph flush with the top border | glyph on the centre line |

### 2. The label wrapped on Chrome/macOS

`white-space: nowrap` has been on `.donation-btn-v02` since #1578, and with it
the button grows to fit a wider label (verified in headless Chrome: widening the
label grows the button from 122px to 158px rather than wrapping). What is thin
is the margin: at `min-width: 122px` the content box left only **~4.5px of
slack** around the icon + gap + label.

Alef is loaded from Google Fonts with the legacy `css?family=Alef` URL, which
serves weight 400 only, so the button's bold label is **synthesised** by the
browser — and macOS emboldens more than Linux/Windows does, which is enough to
eat that slack. The top-bar button is now `132px`, ~19% headroom on the label.
The narrower mobile donation buttons keep the shared 122px.

## Test plan

- `spec/system/donation_button_nowrap_spec.rb` (existing) now also asserts the
  button keeps ≥8px of slack around its contents, so the width cannot silently
  be squeezed back to where a wider font stack overflows. **Verified it fails at
  122px and passes at 132px.**
- Per the reviewer's request, no permanent spec was added for the glyph
  centring; it was verified by screenshotting the button with the candidate CSS
  injected.
- Ran: `bundle exec rspec spec/system/donation_button_nowrap_spec.rb
  spec/system/donation_banner_spacing_spec.rb
  spec/system/donation_popup_stacking_spec.rb` → 6 examples, 0 failures.
- `bundle exec rubocop spec/system/donation_button_nowrap_spec.rb` → clean.
- The full suite was **not** run (40+ min; needs approval).

## Note for follow-up (not in this PR)

The root cause behind the platform-dependent label width is the synthesised
bold. Loading `css?family=Alef:400,700` would give browsers a real bold face and
make the metrics consistent across platforms — but that changes typography
site-wide, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
