### PR TITLE
Hide the punctuation of empty publication detail fields on lexicon works

### DIFF
--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -58,10 +58,12 @@ module LexiconHelper
   end
 
   def render_person_work(work)
-    parts = [
-      render_person_work_title(work),
-      "(#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
-    ]
+    parts = [render_person_work_title(work)]
+
+    # Works whose bibliographic details are part of the title leave these fields empty; showing
+    # the bare punctuation of an empty parenthetical would be noise.
+    details = format_publication_details(work)
+    parts << "(#{details})" if details.present?
 
     parts += work.linked_people
                  .sort_by(&:sort_value)
@@ -132,14 +134,11 @@ module LexiconHelper
     end
   end
 
+  # "place : publisher, date", with any blank field — and the punctuation that would introduce it —
+  # left out entirely. Returns nil when all three are blank.
   def format_publication_details(work)
-    place = work.publication_place.presence
-    rest = [work.publisher, work.publication_date].compact_blank.join(', ')
-    if place
-      rest.present? ? "#{place}: #{rest}" : place
-    else
-      rest.presence
-    end
+    place_and_publisher = [work.publication_place, work.publisher].compact_blank.join(' : ')
+    [place_and_publisher, work.publication_date].compact_blank.join(', ').presence
   end
 
   # Many legacy subjects are already phrased as 'על "שם היצירה"', so wrapping them in the

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -228,6 +228,25 @@ RSpec.describe LexiconHelper, type: :helper do
         .to eq('ספר הזכרונות (תל אביב : עם עובד, 1975) <כולל אחרית דבר> <ובו תצלומים>')
     end
 
+    # Works whose bibliographic details are embedded in the title leave these fields empty; the
+    # parenthetical must then disappear altogether rather than render as "( : , )". See issue #1700.
+    it 'omits the parenthetical entirely when no publication details are present' do
+      work.update!(publication_place: nil, publisher: nil, publication_date: nil)
+
+      expect(rendered_text(work.reload)).to eq('ספר הזכרונות')
+    end
+
+    it 'omits the punctuation of the blank fields when only some details are present' do
+      work.update!(publication_place: nil, publisher: nil)
+      expect(rendered_text(work.reload)).to eq('ספר הזכרונות (1975)')
+
+      work.update!(publisher: 'עם עובד', publication_date: nil)
+      expect(rendered_text(work.reload)).to eq('ספר הזכרונות (עם עובד)')
+
+      work.update!(publication_place: 'תל אביב', publisher: nil, publication_date: '1975')
+      expect(rendered_text(work.reload)).to eq('ספר הזכרונות (תל אביב, 1975)')
+    end
+
     it 'keeps the brackets outside a link that spans the whole comment' do
       target = create(:lex_entry, :person, title: 'יגאל שוורץ')
       work.update!(comment: 'יגאל שוורץ', comment_links: [{ 'text' => 'יגאל שוורץ', 'entry_id' => target.id }])


### PR DESCRIPTION
Fixes #1700

## Problem

`render_person_work` built the bibliographic parenthetical unconditionally:

```ruby
"(#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
```

When a work's details are embedded in its title and the fields are deliberately left blank — as on [Kishon's entry](https://benyehuda.org/lex/entries/105) — the line rendered as:

> שחור על גבי לבן - תיאטרון הבימה - 1955 ( : , )

## Fix

The blank-aware `format_publication_details` helper already existed and was used by the verification page, so the public view now goes through it, and the parentheses are dropped entirely when it returns nothing. That helper was also simplified from an 8-line branch to a 2-line join of the present fields.

| place | publisher | date | rendered |
| --- | --- | --- | --- |
| ✓ | ✓ | ✓ | `(תל אביב : עם עובד, 1975)` |
| — | — | ✓ | `(1975)` |
| — | ✓ | — | `(עם עובד)` |
| ✓ | — | ✓ | `(תל אביב, 1975)` |
| — | — | — | *(nothing at all)* |

## Also changed (please review)

Reusing the helper means two cosmetic changes on the **verification** page, both of which look like corrections rather than regressions:

- the place/publisher separator becomes `" : "`, matching the public page (was `": "`)
- a work with a place and a date but no publisher now renders `place, date` rather than `place: date`

## Testing

- Three new examples in `spec/helpers/lexicon_helper_spec.rb` covering the all-blank case and the partial cases; the existing example asserting the full `(תל אביב : עם עובד, 1975)` form still passes unchanged.
- `bundle exec rspec spec/helpers/ spec/requests/lexicon/` — 591 examples, 0 failures
- `bundle exec rspec spec/system/lexicon/` — 215 examples, 1 failure: `verification_citation_subjects_spec.rb:83`, which **fails identically on master** (verified by stashing the change) and is unrelated to publication details.
- The full suite was not run; it takes 40+ minutes and needs approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
