### PR TITLE
Clear redirect-URL cache when lexicon attachments change

### DIFF
--- a/app/controllers/lexicon/attachments_controller.rb
+++ b/app/controllers/lexicon/attachments_controller.rb
@@ -31,6 +31,7 @@ module Lexicon
         @error = t('.file_exists', filename: filename)
       else
         @lex_entry.attachments.attach(file)
+        @lex_entry.clear_redirect_urls_cache
       end
 
       respond_to do |format|
@@ -44,6 +45,7 @@ module Lexicon
 
     def destroy
       @lex_entry.attachments.find_by(blob_id: params[:id]).purge
+      @lex_entry.clear_redirect_urls_cache
     end
 
     private

--- a/app/services/lexicon/migrate_attachment.rb
+++ b/app/services/lexicon/migrate_attachment.rb
@@ -53,6 +53,7 @@ module Lexicon
         file_entry.attachments.reload
 
         file_entry.attachments.attach(io: uri.open, filename: filename)
+        file_entry.clear_redirect_urls_cache
         new_path = file_entry.download_path(filename)
         link = file_entry.legacy_links.create!(old_path: src, new_path: new_path)
       end

--- a/spec/requests/lexicon/attachments_spec.rb
+++ b/spec/requests/lexicon/attachments_spec.rb
@@ -70,6 +70,18 @@ describe '/lexicon/entries/<ENTRY_ID>/attachments' do
       expect(attached_filenames).to eq(%w(image.png lorem.pdf lorem_ipsum.png))
     end
 
+    # Regression: FilesController caches the entry's filename->URL map for 2h, including the
+    # case of zero attachments, so a stale cache made newly attached files 404 until the TTL
+    # expired.
+    it 'clears the cached redirect URLs so newly attached files are immediately reachable' do
+      cache_key = DownloadLink.redirect_urls_cache_key(LexEntry, lex_entry.id)
+      Rails.cache.write(cache_key, { 'stale.png' => 'http://stale-url' })
+
+      call
+
+      expect(Rails.cache.read(cache_key)).to be_nil
+    end
+
     context 'when file with the same name already exists' do
       let!(:image) do
         lex_entry.attachments.attach(
@@ -130,6 +142,15 @@ describe '/lexicon/entries/<ENTRY_ID>/attachments' do
       expect(call).to eq(200)
 
       expect(attached_filenames).to eq(%w(image.png))
+    end
+
+    it 'clears the cached redirect URLs so the removed file stops being served' do
+      cache_key = DownloadLink.redirect_urls_cache_key(LexEntry, lex_entry.id)
+      Rails.cache.write(cache_key, { 'lorem.pdf' => 'http://stale-url' })
+
+      call
+
+      expect(Rails.cache.read(cache_key)).to be_nil
     end
   end
 end

--- a/spec/services/lexicon/migrate_attachment_spec.rb
+++ b/spec/services/lexicon/migrate_attachment_spec.rb
@@ -46,6 +46,17 @@ describe Lexicon::MigrateAttachment do
         expect(link.new_path).to eq("/files/lex/#{lex_entry.id}/image002.jpg")
         expect(call).to eq link.new_path
       end
+
+      # Regression: FilesController caches the entry's filename->URL map for 2h, so a stale
+      # cache made the newly migrated attachment 404 until the TTL expired.
+      it 'clears the cached redirect URLs so the migrated file is immediately reachable' do
+        cache_key = DownloadLink.redirect_urls_cache_key(LexEntry, lex_entry.id)
+        Rails.cache.write(cache_key, { 'stale.png' => 'http://stale-url' })
+
+        call
+
+        expect(Rails.cache.read(cache_key)).to be_nil
+      end
     end
 
     context 'when LegacyLink for the same path already exists' do


### PR DESCRIPTION
## Summary
- `Lexicon::AttachmentsController#create`/`#destroy` and `Lexicon::MigrateAttachment` attach/purge `LexEntry` attachments without invalidating `FilesController`'s cached filename→URL map (unlike `ManifestationController`, which already calls `clear_redirect_urls_cache`).
- `FilesController` caches that map for 2 hours, even when empty, so a newly attached image would 404 from `/files/lex/:id/:filename` until the TTL expired.
- Fixes by-69d: added `clear_redirect_urls_cache` calls after attach/purge in all three code paths, plus regression request/service specs asserting the cache is actually cleared.

## Test plan
- [x] `bundle exec rspec spec/requests/lexicon/attachments_spec.rb spec/services/lexicon/migrate_attachment_spec.rb` — all pass
- [ ] Full suite not run (per project policy, requires explicit approval — ran targeted specs only)