### PR TITLE
Fix order-sensitive comparison in translated_from_multiple_languages spec

### DIFF
--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -364,7 +364,11 @@ describe AdminController do
       expect(authors.length).to eq 1
       expect(authors[0][0]).to eq author
       expect(authors[0][1]).to match_array %w(he ru de)
-      expect(authors[0][2]).to eq({ 'he' => hebrew_works, 'ru' => russian_works, 'de' => german_works })
+      manifestations_by_lang = authors[0][2]
+      expect(manifestations_by_lang.keys).to match_array %w(he ru de)
+      expect(manifestations_by_lang['he']).to match_array hebrew_works
+      expect(manifestations_by_lang['ru']).to match_array russian_works
+      expect(manifestations_by_lang['de']).to match_array german_works
     end
   end
 


### PR DESCRIPTION
## Summary
- `AdminController#translated_from_multiple_languages` groups manifestations per author-language and sorts each group by `sort_title` — that's the intentional display order, but it doesn't match factory creation order once titles differ non-numerically (`"Manifestation 10"` sorts before `"Manifestation 9"` lexicographically).
- The spec compared the whole per-language hash with `eq()`, which is order-sensitive, so it flaked whenever the sequence crossed into double digits within a language bucket. Reproduced locally (confirmed failing on master before this fix).
- Fixes by-byi: switched the assertion to compare each language's bucket with `match_array`, since the test only cares about membership, not display order.

## Test plan
- [x] `bundle exec rspec spec/controllers/admin_controller_spec.rb -e translated_from_multiple_languages` — passes
- [ ] Full suite not run (per project policy, requires explicit approval — ran targeted spec only)