### PR TITLE
Fix HTML-escaped to_json breaking lexicon link/citation toasts

### DIFF
--- a/app/views/lexicon/citations/update.js.erb
+++ b/app/views/lexicon/citations/update.js.erb
@@ -1,21 +1,23 @@
+<%# raw(): .js.erb templates are HTML-escaped like any other ERB template, which would turn
+    to_json's quotes into &quot; and make this a JS syntax error. %>
 if ($('#citations').length) {
   // Entry-edit view: lazy-reload just the citations section
   reloadContent($('#citations'));
   <% if @link_check_performed %>
-  showToast(<%= @link_toast_message.to_json %>, '<%= @link_toast_type %>');
+  showToast(<%= raw(@link_toast_message.to_json) %>, '<%= @link_toast_type %>');
   <% end %>
   <% if @monday_report_failed %>
-  showToast(<%= @monday_toast_message.to_json %>, 'error');
+  showToast(<%= raw(@monday_toast_message.to_json) %>, 'error');
   <% end %>
 } else {
   // Verification view: store toast data in sessionStorage so it survives the page reload.
   // flash.now (set by the controller) only lives for the current JS response, not the reload.
 <% if @link_check_performed %>
-  sessionStorage.setItem('link-check-toast-type', <%= @link_toast_type.to_json %>);
-  sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
+  sessionStorage.setItem('link-check-toast-type', <%= raw(@link_toast_type.to_json) %>);
+  sessionStorage.setItem('link-check-toast-message', <%= raw(@link_toast_message.to_json) %>);
 <% end %>
 <% if @monday_report_failed %>
-  sessionStorage.setItem('monday-report-toast-message', <%= @monday_toast_message.to_json %>);
+  sessionStorage.setItem('monday-report-toast-message', <%= raw(@monday_toast_message.to_json) %>);
 <% end %>
   // Reload is triggered by the openModal onSuccess callback; setTimeout is a safety fallback.
   setTimeout(function() { reloadPage(); }, 300);

--- a/app/views/lexicon/links/update.js.erb
+++ b/app/views/lexicon/links/update.js.erb
@@ -1,21 +1,23 @@
+<%# raw(): .js.erb templates are HTML-escaped like any other ERB template, which would turn
+    to_json's quotes into &quot; and make this a JS syntax error. %>
 if ($('#links').length) {
   // Entry-edit view: lazy-reload just the links section
   reloadContent($('#links'));
   <% if @link_check_performed %>
-  showToast(<%= @link_toast_message.to_json %>, '<%= @link_toast_type %>');
+  showToast(<%= raw(@link_toast_message.to_json) %>, '<%= @link_toast_type %>');
   <% end %>
   <% if @monday_report_failed %>
-  showToast(<%= @monday_toast_message.to_json %>, 'error');
+  showToast(<%= raw(@monday_toast_message.to_json) %>, 'error');
   <% end %>
 } else {
   // Verification view: store toast data in sessionStorage so it survives the page reload.
   // flash (set by the controller) is also embedded into the reloaded page as a fallback if sessionStorage isn't available.
 <% if @link_check_performed %>
-  sessionStorage.setItem('link-check-toast-type', <%= @link_toast_type.to_json %>);
-  sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
+  sessionStorage.setItem('link-check-toast-type', <%= raw(@link_toast_type.to_json) %>);
+  sessionStorage.setItem('link-check-toast-message', <%= raw(@link_toast_message.to_json) %>);
 <% end %>
 <% if @monday_report_failed %>
-  sessionStorage.setItem('monday-report-toast-message', <%= @monday_toast_message.to_json %>);
+  sessionStorage.setItem('monday-report-toast-message', <%= raw(@monday_toast_message.to_json) %>);
 <% end %>
   // Reload is triggered by the edit-button onSuccess callback; setTimeout is a safety fallback.
   setTimeout(function() { reloadPage(); }, 300);

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -159,6 +159,14 @@ describe '/lexicon/citations' do
           expect(response.body).to include('showToast')
           expect(response.body).to include('success')
         end
+
+        # .js.erb is HTML-escaped like any other ERB template, so an unwrapped to_json call
+        # turns its quotes into `&quot;` and makes the whole response script a JS syntax
+        # error -- the toast (and the sessionStorage fallback) then silently never appear.
+        it 'does not HTML-escape the JSON passed to showToast' do
+          call
+          expect(response.body).not_to include('&quot;')
+        end
       end
 
       context 'when the new link is still broken' do

--- a/spec/requests/lexicon/links_spec.rb
+++ b/spec/requests/lexicon/links_spec.rb
@@ -113,6 +113,14 @@ describe '/lexicon/links' do
           expect(response.body).to include('showToast')
           expect(response.body).to include('success')
         end
+
+        # .js.erb is HTML-escaped like any other ERB template, so an unwrapped to_json call
+        # turns its quotes into `&quot;` and makes the whole response script a JS syntax
+        # error -- the toast (and the sessionStorage fallback) then silently never appear.
+        it 'does not HTML-escape the JSON passed to showToast' do
+          call
+          expect(response.body).not_to include('&quot;')
+        end
       end
 
       context 'when the new link is still broken' do


### PR DESCRIPTION
## Summary
- `.js.erb` templates are HTML-escaped like any other ERB template, so the unwrapped `to_json` calls in `lexicon/links/update.js.erb` and `lexicon/citations/update.js.erb` turned quotes into `&quot;`, producing a JS syntax error that silently swallowed the link-check and Monday-report toasts (and the sessionStorage fallback in the verification branch).
- Wraps every `.to_json` call in `raw()`, matching the existing fix already applied to `lexicon/external_identifiers/update.js.erb`.

Closes by-ygx.

## Test plan
- [x] Added request-spec assertions (`does not HTML-escape the JSON passed to showToast`) to `spec/requests/lexicon/links_spec.rb` and `spec/requests/lexicon/citations_spec.rb` — confirmed these fail without the fix and pass with it.
- [x] `bundle exec rspec spec/requests/lexicon/links_spec.rb spec/requests/lexicon/citations_spec.rb` (83 examples, 0 failures)
- [ ] Full suite not run (needs user approval per project rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)