### PR TITLE
Fix stale/orphaned ES docs for lexicon entries on edit/delete

### DIFF
--- a/app/controllers/lexicon/entries_controller.rb
+++ b/app/controllers/lexicon/entries_controller.rb
@@ -128,15 +128,24 @@ scope = LexEntry.where.not(lex_item: nil).includes(:lex_item)
     end
 
     def update
-      if @lex_entry.update(lex_entry_params)
-        render json: { success: true, status: @lex_entry.status }
-      else
-        render json: { success: false, errors: @lex_entry.errors.full_messages }, status: :unprocessable_entity
+      # Chewy's root strategy is :bypass (see config/initializers/chewy.rb), so without this
+      # the lex_entries / lex_entries_autocomplete docs never pick up the new title.
+      Chewy.strategy(:atomic) do
+        if @lex_entry.update(lex_entry_params)
+          render json: { success: true, status: @lex_entry.status }
+        else
+          render json: { success: false, errors: @lex_entry.errors.full_messages }, status: :unprocessable_entity
+        end
       end
     end
 
     def destroy
-      @lex_entry.destroy
+      # Chewy's root strategy is :bypass (see config/initializers/chewy.rb), so without this
+      # the lex_entries / lex_entries_autocomplete docs are never removed, leaving stale
+      # autocomplete suggestions for entries that no longer exist. See by-0ys.
+      Chewy.strategy(:atomic) do
+        @lex_entry.destroy
+      end
       redirect_to lexicon_entries_url, alert: t('.success')
     end
 

--- a/spec/requests/lexicon/entries_spec.rb
+++ b/spec/requests/lexicon/entries_spec.rb
@@ -289,5 +289,57 @@ describe '/lexicon/entries' do
         expect(flash.alert).to eq(I18n.t('lexicon.entries.destroy.success'))
       end
     end
+
+    # Chewy's root strategy is :bypass (see config/initializers/chewy.rb), so a plain
+    # `@lex_entry.destroy` outside an explicit strategy leaves the ES doc behind, and the
+    # deleted entry keeps showing up in autocomplete suggestions. See by-0ys.
+    context 'with a synced ES autocomplete index' do
+      let!(:entry) { create(:lex_entry, :person) }
+
+      before do
+        Chewy.massacre
+        import_and_await(LexEntriesAutocompleteIndex, LexEntry.all)
+      end
+
+      after { Chewy.massacre }
+
+      it 'removes the doc for the destroyed entry' do
+        expect(LexEntriesAutocompleteIndex.filter(term: { id: entry.id }).first).to be_present
+        call
+        expect(LexEntriesAutocompleteIndex.filter(term: { id: entry.id }).first).to be_nil
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    subject(:call) { patch "/lex/entries/#{entry.id}", params: { lex_entry: { title: 'New Title' } } }
+
+    before do
+      login_as_lexicon_editor
+    end
+
+    let!(:entry) { create(:lex_entry, :person, title: 'Old Title') }
+
+    it 'updates the title' do
+      call
+      expect(entry.reload.title).to eq('New Title')
+    end
+
+    # Chewy's root strategy is :bypass (see config/initializers/chewy.rb), so a plain
+    # `@lex_entry.update` outside an explicit strategy leaves the ES doc with the stale
+    # title, and autocomplete keeps suggesting the entry under its old name. See by-0ys.
+    context 'with a synced ES autocomplete index' do
+      before do
+        Chewy.massacre
+        import_and_await(LexEntriesAutocompleteIndex, LexEntry.all)
+      end
+
+      after { Chewy.massacre }
+
+      it 'refreshes the doc with the new title' do
+        call
+        expect(LexEntriesAutocompleteIndex.filter(term: { id: entry.id }).first.title).to eq('New Title')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `Chewy.root_strategy` is `:bypass` (`config/initializers/chewy.rb`), meaning `update_index` callbacks are a no-op unless the write is explicitly wrapped in a `Chewy.strategy(:atomic)` block — the pattern already used by `AuthorsController` and `ManifestationController`.
- `Lexicon::EntriesController#update` and `#destroy` saved/destroyed `LexEntry` records with no such wrapper, so the `lex_entries` and `lex_entries_autocomplete` ES indexes never got the deletion or the new title. In practice: deleting an entry left its autocomplete doc behind (the same name then shows up twice in suggestions), and editing an entry's title left the old title searchable.
- Wraps both actions in `Chewy.strategy(:atomic)`.

Root cause investigation and fix for by-0ys ("lex_entries_autocomplete index holds stale docs for deleted entries").

## Test plan
- [x] Added `spec/requests/lexicon/entries_spec.rb` coverage: destroying an entry now removes its `LexEntriesAutocompleteIndex` doc, and updating an entry's title now refreshes it — confirmed both fail without the fix and pass with it.
- [x] `bundle exec rspec spec/requests/lexicon/entries_spec.rb` (26 examples, 0 failures)
- [x] `bundle exec rspec spec/requests/lexicon/` (416 examples, 0 failures) — no regressions
- [ ] Full suite not run (needs user approval per project rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)