### PR TITLE
Fix sitenotice_update crashing on validation failure

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -962,16 +962,15 @@ class AdminController < ApplicationController
     @sn.status = (sn_params[:status] == '1' ? :enabled : :disabled)
     @sn.fromdate = Date.new(params[:fromdate][:year].to_i, params[:fromdate][:month].to_i, params[:fromdate][:day].to_i)
     @sn.todate = Date.new(params[:todate][:year].to_i, params[:todate][:month].to_i, params[:todate][:day].to_i)
-    if @sn.nil?
-      flash[:error] = I18n.t(:no_such_item)
-      redirect_to url_for(action: :index)
-    elsif @sn.save
-      Sitenotice.clear_cache
-      flash[:notice] = I18n.t(:updated_successfully)
-      redirect_to action: :sitenotice_show, id: @sn.id
-    else
-      format.html { render action: 'sitenotice_edit' }
-      format.json { render json: @sn.errors, status: :unprocessable_content }
+    respond_to do |format|
+      if @sn.save
+        Sitenotice.clear_cache
+        format.html { redirect_to url_for(action: :sitenotice_show, id: @sn.id), notice: t(:updated_successfully) }
+        format.json { render json: @sn, status: :ok, location: @sn }
+      else
+        format.html { render action: 'sitenotice_edit' }
+        format.json { render json: @sn.errors, status: :unprocessable_content }
+      end
     end
   end
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1472,4 +1472,36 @@ describe AdminController do
       end
     end
   end
+
+  describe '#sitenotice_update' do
+    subject(:call) do
+      patch :sitenotice_update, params: {
+        id: sitenotice.id,
+        sitenotice: { body: body, status: '1' },
+        fromdate: { year: '2026', month: '1', day: '1' },
+        todate: { year: '2026', month: '2', day: '1' }
+      }
+    end
+
+    include_context 'when editor logged in'
+
+    let(:sitenotice) { create(:sitenotice) }
+
+    context 'with valid params' do
+      let(:body) { 'updated notice body' }
+
+      it 'saves and redirects to sitenotice_show' do
+        expect(call).to redirect_to(action: :sitenotice_show, id: sitenotice.id)
+        expect(sitenotice.reload.body).to eq('updated notice body')
+      end
+    end
+
+    context 'with invalid params (blank body)' do
+      let(:body) { '' }
+
+      it 're-renders the edit form instead of raising' do
+        expect(call).to render_template(:sitenotice_edit)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `sitenotice_update`'s failure branch called `format.html`/`format.json` without a `respond_to` wrapper, unlike its sibling `sitenotice_create`. A failed save (e.g. blank body) raised `NameError: undefined local variable or method 'format'` instead of re-rendering the edit form.
- Wrapped the branches in `respond_to`, matching `sitenotice_create`'s pattern.
- Dropped the dead `@sn.nil?` branch: `Sitenotice.find` raises `ActiveRecord::RecordNotFound` rather than returning `nil`, so that branch could never execute.

Fixes by-ov2 (flagged by Copilot review on PR #1573).

## Test plan
- [x] Added a controller spec covering both a valid update (redirects to `sitenotice_show`) and an invalid update with blank body (re-renders `sitenotice_edit` instead of raising)
- [x] `bundle exec rspec spec/controllers/admin_controller_spec.rb -e sitenotice_update` passes
- [ ] Full suite not run (needs approval per project rules); ran only the targeted spec above

🤖 Generated with [Claude Code](https://claude.com/claude-code)