### PR TITLE
Fix lexicon ingestion crash when there is no heading table

### DIFF
--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -40,10 +40,13 @@ module Lexicon
 
       lex_person.authority = Lexicon::ExtractAuthority.call(html_doc)
 
+      # A handful of files (e.g. dead "No Access" stubs) carry no heading table at all: the
+      # entry is left with no name/dates, but ingestion still produces a draft an editor can
+      # review rather than crashing and losing the file entirely.
       heading_table = html_doc.at_css('table[width="100%"]')
-      heading_table_html = heading_table.to_html
       # Match both patterns: (YYYY) and (YYYY-YYYY); handles maqaf, en-dash, hyphen
-      if (match = heading_table_html.match(%r{<font size="4"[^>]*>\s*\((\d{4})(?:[-–־](\d{4}))?\)\s*</font>}))
+      if heading_table.present? &&
+         (match = heading_table.to_html.match(%r{<font size="4"[^>]*>\s*\((\d{4})(?:[-–־](\d{4}))?\)\s*</font>}))
         lex_person.birthdate = match[1]
         lex_person.deathdate = match[2]
       end

--- a/spec/fixtures/files/lexicon/no_heading_table.php
+++ b/spec/fixtures/files/lexicon/no_heading_table.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>No Access</title>
+</head>
+<body>
+<p align="center"><font size="7" color="#FF0000">Lexicon of Modern Hebrew Literature</font></p>
+<p align="center"><font color="#0000FF"><b><font size="7">No Access</font></b></font></p>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -418,6 +418,29 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when the entry has no heading table at all (by-0x4)' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Test Person',
+          fname: 'no_heading_table.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/no_heading_table.php')
+        }
+      )
+    end
+
+    it 'ingests a blank-dated entry instead of raising on nil.to_html' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      expect(file.reload).to be_status_ingested
+      person = file.lex_entry.lex_item
+      expect(person).to have_attributes(birthdate: nil, deathdate: nil)
+    end
+  end
+
   context 'when both birthdate and deathdate provided', vcr: { cassette_name: 'lexicon/ingest_person/00024' } do
     let(:file) do
       create(


### PR DESCRIPTION
## Summary
- `Lexicon::IngestPerson#create_lex_item` did `heading_table = html_doc.at_css('table[width="100%"]')` then `heading_table.to_html` with no nil guard. A handful of legacy files have no such table at all — e.g. `01928.php`, which is a dead "No Access" stub page, not a real person entry — so ingestion died with `NoMethodError: undefined method 'to_html' for nil`, losing the whole entry.
- Skip the birthdate/deathdate regex match when there's no heading table. Everything downstream (`bio_elements`, `ExtractAuthority`, `ExtractCitations`, works parsing) already tolerates a nil/missing heading table, so the file now ingests as a blank-dated draft an editor can review instead of crashing.

Fixes by-0x4 (found while fixing by-w5m, #1607).

## Test plan
- [x] Added `spec/fixtures/files/lexicon/no_heading_table.php` (modeled on 01928.php's structure) and a regression spec
- [x] Verified against the real corpus file `01928.php` directly (outside the repo) — now ingests without raising
- [x] `bundle exec rspec spec/services/lexicon/ingest_person_spec.rb` — 41 examples, 0 failures
- [ ] Full suite not run (needs approval per project rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)