### PR TITLE
Pre-fill matched entry id in lexicon citation-author match modal

### DIFF
--- a/app/controllers/lexicon/citation_authors_controller.rb
+++ b/app/controllers/lexicon/citation_authors_controller.rb
@@ -40,8 +40,12 @@ module Lexicon
     end
 
     # Modal offering to link a plaintext author imported from a legacy PHP file to an existing
-    # person entry, pre-filled with the name the match was found by (see LexCitationAuthor.normalize_name).
-    def match; end
+    # person entry, pre-filled with the name the match was found by (see LexCitationAuthor.normalize_name)
+    # and the entry id it resolves to, so confirming immediately submits a valid match instead of
+    # requiring the editor to reselect it from the autocomplete dropdown themselves.
+    def match
+      @matching_entry = @author.matching_entry
+    end
 
     # Links the author to the chosen person entry. The imported name is deliberately left untouched,
     # so the citation keeps displaying it as "lastname, firstname" exactly as the legacy file had it.

--- a/app/models/lex_citation_author.rb
+++ b/app/models/lex_citation_author.rb
@@ -48,6 +48,16 @@ class LexCitationAuthor < ApplicationRecord
     LexEntry.person_type.where(title: names).pluck(:title).to_set(&:downcase)
   end
 
+  # The person-type entry whose title matches this author's normalized name (see
+  # .matchable_names), so the match modal can resolve an id to pre-select rather than just a
+  # display string. Comparison is case-insensitive to match .matchable_names, since lex_entries.title
+  # uses a case-sensitive (utf8mb4_bin) collation.
+  def matching_entry
+    return nil if normalized_name.blank?
+
+    LexEntry.person_type.where('LOWER(title) = ?', normalized_name.downcase).first
+  end
+
   private
 
   def entry_must_be_person

--- a/app/views/lexicon/citation_authors/match.html.haml
+++ b/app/views/lexicon/citation_authors/match.html.haml
@@ -3,7 +3,7 @@
   = t('.imported_name')
   %strong{ dir: text_dir(@author.name.to_s) }= @author.name
 = simple_form_for @author, url: lexicon_citation_author_path(@author), method: :patch, remote: true do |f|
-  = f.hidden_field :lex_entry_id
+  = f.hidden_field :lex_entry_id, value: @matching_entry&.id
   = f.input :name,
             label: t('.entry_label'),
             id_element: '#lex_citation_author_lex_entry_id',

--- a/spec/models/lex_citation_author_spec.rb
+++ b/spec/models/lex_citation_author_spec.rb
@@ -234,4 +234,37 @@ describe LexCitationAuthor do
       end
     end
   end
+
+  describe '#matching_entry' do
+    subject(:matching_entry) { author.matching_entry }
+
+    let(:lex_person) { create(:lex_entry, :person).lex_item }
+    let(:citation) { create(:lex_citation, person: lex_person, authors_count: 0) }
+    let(:author) { create(:lex_citation_author, citation: citation, name: 'איזיקוביץ, גילי', link: nil) }
+
+    context 'when a person entry is titled exactly like the normalized name' do
+      let!(:entry) { create(:lex_entry, :person, title: 'גילי איזיקוביץ') }
+
+      it { is_expected.to eq(entry) }
+    end
+
+    context 'when the entry title differs only by case' do
+      let!(:entry) { create(:lex_entry, :person, title: 'Gili Izikovich') }
+      let(:author) { create(:lex_citation_author, citation: citation, name: 'izikovich, gili', link: nil) }
+
+      it 'matches case-insensitively' do
+        expect(matching_entry).to eq(entry)
+      end
+    end
+
+    context 'when the only entry with that title is a publication' do
+      before { create(:lex_entry, :publication, title: 'גילי איזיקוביץ') }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when no entry carries that title' do
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/requests/lexicon/citation_authors_spec.rb
+++ b/spec/requests/lexicon/citation_authors_spec.rb
@@ -108,6 +108,26 @@ describe '/lex/citation_authors' do
       expect(call).to eq(200)
       expect(response.body).to include('גילי איזיקוביץ')
     end
+
+    def hidden_lex_entry_id_value(body)
+      Nokogiri::HTML(body).at_css('#lex_citation_author_lex_entry_id')['value']
+    end
+
+    context 'when a person entry is titled exactly like the normalized name' do
+      let!(:matching_entry) { create(:lex_entry, :person, title: 'גילי איזיקוביץ') }
+
+      it 'pre-fills the hidden entry id, so confirming without touching the dropdown still submits it' do
+        expect(call).to eq(200)
+        expect(hidden_lex_entry_id_value(response.body)).to eq(matching_entry.id.to_s)
+      end
+    end
+
+    context 'when no entry matches the normalized name' do
+      it 'leaves the hidden entry id blank' do
+        expect(call).to eq(200)
+        expect(hidden_lex_entry_id_value(response.body)).to be_blank
+      end
+    end
   end
 
   describe 'PATCH /lex/citation_authors/:id' do

--- a/spec/system/lexicon/verification_citation_author_match_spec.rb
+++ b/spec/system/lexicon/verification_citation_author_match_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe 'Matching an imported citation author to an existing entry', :js,
       expect(author.name).to eq('איזיקוביץ, גילי')
     end
 
+    it 'links the author when confirming immediately, without reselecting from the dropdown' do
+      visit lexicon_verification_path(entry)
+
+      within("#citation-#{citation.id}") { click_button match_button_label }
+      expect(page).to have_css('#generalDlg', visible: :visible)
+
+      # The dropdown already shows the right name; click confirm straight away
+      expect(page).to have_field('lex_citation_author_name', with: 'גילי איזיקוביץ')
+      click_button I18n.t('lexicon.citation_authors.match.confirm')
+
+      within("#citation-#{citation.id}") do
+        expect(page).to have_link('איזיקוביץ, גילי', href: lexicon_entry_path(matching_entry), wait: 8)
+        expect(page).to have_no_button(match_button_label)
+      end
+
+      expect(author.reload.entry).to eq(matching_entry)
+    end
+
     it 'leaves the author alone when the modal is closed without confirming' do
       visit lexicon_verification_path(entry)
 


### PR DESCRIPTION
## Summary
- Fixes by-3gs: in the lexicon migration verification workbench, the "match author to entry" modal pre-fills the autocomplete text field with the resolved name, but the hidden `lex_entry_id` field was left blank — jQuery-UI autocomplete only writes that field from its own `select`/`change` callbacks, which never fire just because matching text is already showing.
- Clicking אישור ההתאמה without first reselecting the suggestion from the dropdown therefore submitted a blank id, and the request silently failed validation (`entry_not_found`), forcing the editor to notice the error and manually reselect.
- Added `LexCitationAuthor#matching_entry`, which resolves the same person-type entry that made `.matchable_names` show the match button in the first place, and the `CitationAuthorsController#match` action now passes it to the view so the hidden field starts pre-filled with the correct id.

## Test plan
- [x] `bundle exec rspec spec/models/lex_citation_author_spec.rb spec/requests/lexicon/citation_authors_spec.rb` — new `#matching_entry` model spec + hidden-field-prefill request specs, all pass
- [x] `bundle exec rspec spec/system/lexicon/verification_citation_author_match_spec.rb` — added a regression test that confirms without reselecting from the autocomplete dropdown; all 5 examples pass
- [x] `bundle exec rubocop` / `bundle exec haml-lint` on all changed files — clean (pre-existing unrelated offenses in the request spec left untouched)
- [ ] Full suite not run (needs explicit approval per project rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)